### PR TITLE
LayoutData revisions

### DIFF
--- a/coretrace/raytrace.cpp
+++ b/coretrace/raytrace.cpp
@@ -412,7 +412,7 @@ bool Trace(TSystem *System, unsigned int seed,
             }
 
             //set up the layout data object that provides configuration details for the hash tree
-            LayoutData sun_ld;
+            KDLayoutData sun_ld;
             sun_ld.xlim[0] = System->Sun.MinXSun;
             sun_ld.xlim[1] = System->Sun.MaxXSun;
             sun_ld.ylim[0] = System->Sun.MinYSun;
@@ -420,7 +420,7 @@ bool Trace(TSystem *System, unsigned int seed,
             sun_ld.min_unit_dx = d_elm_max;
             sun_ld.min_unit_dy = d_elm_max;
 
-            sun_hash.create_mesh( &sun_ld );
+            sun_hash.create_mesh( sun_ld );
             time("Adding solar mesh elements:\t", &fout);
             
            //load stage 0 elements into the mesh
@@ -437,7 +437,7 @@ bool Trace(TSystem *System, unsigned int seed,
             if(AsPowerTower)
             {
                 //Set things up for the polar coordinate tree
-                LayoutData rec_ld;
+                KDLayoutData rec_ld;
                 rec_ld.xlim[0] = -M_PI;
                 rec_ld.xlim[1] = M_PI;
                 rec_ld.ylim[0] = -M_PI/2.;
@@ -445,7 +445,7 @@ bool Trace(TSystem *System, unsigned int seed,
                 //use smallest element to set the minimum size
                 rec_ld.min_unit_dx = rec_ld.min_unit_dy = el_proj_dat.back().d_proj; //radians at equator
             
-                rec_hash.create_mesh( &rec_ld );
+                rec_hash.create_mesh( rec_ld );
                 time("Adding polar mesh elements:\t", &fout);
 
                 //load stage 0 elements into the receiver mesh in the order of largest projection to smallest

--- a/coretrace/treemesh.cpp
+++ b/coretrace/treemesh.cpp
@@ -352,7 +352,7 @@ st_hash_tree::st_hash_tree()
 	log2inv = 1./log(2.);
 }
 
-bool st_hash_tree::create_mesh(LayoutData *data){
+bool st_hash_tree::create_mesh(KDLayoutData &data){
 	/*
 	Create a mesh of the heliostat field according to the performance surface
 	provided by the 'integrals' class.
@@ -360,11 +360,11 @@ bool st_hash_tree::create_mesh(LayoutData *data){
 	Data = data;
         
 	//Calculate min and max recursion levels based on user zone size limitations
-	double dextx = (Data->xlim[1] - Data->xlim[0]);
-	nx_req = (int)floor( log(dextx/Data->min_unit_dx)*log2inv );
+	double dextx = (Data.xlim[1] - Data.xlim[0]);
+	nx_req = (int)floor( log(dextx/Data.min_unit_dx)*log2inv );
     nx_req = nx_req < 1 ? 1 : nx_req;
-	double dexty = (Data->ylim[1] - Data->ylim[0]);
-	ny_req = (int)floor( log(dexty/Data->min_unit_dy)*log2inv );
+	double dexty = (Data.ylim[1] - Data.ylim[0]);
+	ny_req = (int)floor( log(dexty/Data.min_unit_dy)*log2inv );
     ny_req = ny_req < 1 ? 1 : ny_req;
 
 	//estimate the maximum number of nodes and reserve memory
@@ -388,18 +388,22 @@ bool st_hash_tree::create_mesh(LayoutData *data){
 	}
 	
     //set up the head node's range. This doesn't actually create the tree yet.
-	head_node.set_range(Data->xlim[0], Data->xlim[1], Data->ylim[0], Data->ylim[1]);
+	head_node.set_range(Data.xlim[0], Data.xlim[1], Data.ylim[0], Data.ylim[1]);
     
     return true;
 }
 
 string st_hash_tree::pos_to_binary_base(double x, double y){
-    double res = fmin(Data->min_unit_dx, Data->min_unit_dy);
+    double res = fmin(Data.min_unit_dx, Data.min_unit_dy);
 	return pos_to_binary(x, y, res);
 }
 
 void st_hash_tree::reset(){
-	Data = 0;
+    Data.min_unit_dx = 
+        Data.min_unit_dy = 
+        Data.xlim[0] = Data.xlim[1] = Data.ylim[0] = Data.ylim[1] =
+            std::numeric_limits<double>::quiet_NaN();
+    
 	head_node = st_opt_element();
 	nodes.clear();
 	nx_req = -1;
@@ -762,10 +766,10 @@ string st_hash_tree::pos_to_binary(double x, double y, double res){
 	bool x_mode = true; //start with radius
         
 	double 
-		y0 = Data->ylim[0],
-		y1 = Data->ylim[1],
-		x0 = Data->xlim[0],
-		x1 = Data->xlim[1];
+		y0 = Data.ylim[0],
+		y1 = Data.ylim[1],
+		x0 = Data.xlim[0],
+		x1 = Data.xlim[1];
 	    
 	int nc = max(nx_req, ny_req)*2;
         
@@ -805,10 +809,10 @@ void st_hash_tree::binary_to_pos(const string &binary, double *x, double *y)
     bool x_mode = true; //start with radius
         
 	double 
-		y0 = Data->ylim[0],
-		y1 = Data->ylim[1],
-		x0 = Data->xlim[0],
-		x1 = Data->xlim[1];
+		y0 = Data.ylim[0],
+		y1 = Data.ylim[1],
+		x0 = Data.xlim[0],
+		x1 = Data.xlim[1];
 
     *x = (x0 + x1)/2.;
     *y = (y0 + y1)/2.;

--- a/coretrace/treemesh.h
+++ b/coretrace/treemesh.h
@@ -56,7 +56,7 @@
 using namespace std;
 
 
-struct LayoutData
+struct KDLayoutData
 {
     double xlim[2];     //[min, max]
     double ylim[2];     //[min, max]
@@ -118,7 +118,7 @@ public:
 class st_hash_tree
 {
 protected:
-	LayoutData *Data;
+	KDLayoutData Data;
 	vector<st_opt_element> nodes;
 	st_opt_element head_node;
 	int nx_req, ny_req; //The number of divisions required to achieve the desired resolution
@@ -128,7 +128,7 @@ protected:
 public:
 	st_hash_tree();
 	void reset();
-	bool create_mesh(LayoutData *Data);
+	bool create_mesh(KDLayoutData &Data);
 	
     virtual void add_object(void *object, double locx, double locy, double *objsize=0);
     virtual string pos_to_binary_base(double x, double y);


### PR DESCRIPTION
Renaming LayoutData to KDLayoutData, SolarPILOT namespace conflict; making LayoutData a non-pointer member of st_hash_tree. This keeps the object in memory when the method that originally creates the LayoutData object expires.

Resolves #8 

Affects usage in SolarPILOT.