### PR TITLE
Trace settings and spline updates

### DIFF
--- a/app/src/intersections.cpp
+++ b/app/src/intersections.cpp
@@ -216,7 +216,7 @@ void IntersectionViewer::RebuildGeometry( ElementListBox *lb )
 		int ielem = abs(R.ElementMap[i])-1;
 		bool absorbed = ( R.ElementMap[i] < 0 );
 
-		bool selected = (lb && lb->IsSelected( istage, ielem ));
+		bool selected = (lb && lb->IsSelected( istage, ielem ) && (absorbed || !m_finalOnly));
 		
 		if ( R.Transform( m_prj, m_coordSys, i, Pos, Cos, Elm, Stg, Ray ) )
 		{

--- a/app/src/project.h
+++ b/app/src/project.h
@@ -192,6 +192,26 @@ public:
 	double RLocToRef[3][3];
 };
 
+
+class TraceSettings
+{
+public:
+	TraceSettings();
+
+	void ResetToDefaults();
+	bool Write(FILE* fp);
+	bool Read(FILE* fp);
+
+	int n_rays;
+	int n_rays_sun;
+	int n_cpu;
+	int seed;
+	bool is_include_sunshape;
+	bool is_include_errors;
+	bool is_point_focus;
+};
+
+
 class Project;
 
 class RayData
@@ -247,6 +267,7 @@ public:
 	SunShape Sun;
 	std::vector<Optical*> OpticsList;
 	std::vector<Stage*> StageList;
+	TraceSettings Trace_Settings;
 
 	RayData Results;
 
@@ -292,6 +313,5 @@ private:
 					size_t &RayCount);
 	Project &m_prj;
 };
-
 
 #endif

--- a/app/src/soltrace.cpp
+++ b/app/src/soltrace.cpp
@@ -56,9 +56,9 @@
 #include <wx/stdpaths.h>
 #include <wx/busyinfo.h>
 
-#ifdef __WXMSW__
-#include <wex/mswfatal.h>
-#endif
+//#ifdef __WXMSW__
+//#include <wex/mswfatal.h>
+//#endif
 
 #include <wex/easycurl.h>
 #include <wex/metro.h>
@@ -144,9 +144,9 @@ class MyApp : public wxApp
 public:
 	virtual void OnFatalException()
 	{
-#ifdef __WXMSW__
-		wxMSWHandleApplicationFatalException();
-#endif
+//#ifdef __WXMSW__
+//		wxMSWHandleApplicationFatalException();
+//#endif
 	}
 
 	virtual bool OnInit()
@@ -158,11 +158,11 @@ public:
 
 		bool is64 = (sizeof(void*) == 8);
 
-#ifdef __WXMSW__
-		wxMSWSetupExceptionHandler( "SolTrace", 
-			wxString::Format("%d.%d.%d (%d bit)", version_major, version_minor, version_micro, is64 ? 64 : 32 ), 
-			"soltrace.support@nrel.gov" );
-#endif
+//#ifdef __WXMSW__
+//		wxMSWSetupExceptionHandler( "SolTrace", 
+//			wxString::Format("%d.%d.%d (%d bit)", version_major, version_minor, version_micro, is64 ? 64 : 32 ), 
+//			"soltrace.support@nrel.gov" );
+//#endif
 		
 		wxEasyCurl::Initialize();
 
@@ -420,6 +420,7 @@ bool MainWindow::CloseProject( bool force )
 
 
 	m_project.Sun.ResetToDefaults();
+	m_project.Trace_Settings.ResetToDefaults();
 	m_project.ClearOptics();
 	m_project.ClearStages();	
 	m_project.Results.FreeMemory();
@@ -545,6 +546,7 @@ void MainWindow::UpdateAllInputForms()
 	m_sunShapeForm->UpdateFromData();
 	m_opticsForm->UpdateList( 0 );
 	m_geometryForm->UpdateForm();
+	m_traceForm->UpdateFromData();
 }
 
 void MainWindow::UpdateResults()

--- a/app/src/trace.h
+++ b/app/src/trace.h
@@ -71,6 +71,8 @@ class TraceForm : public wxPanel
 public:
 	TraceForm( wxWindow *parent, Project &m_prj );
 
+	void UpdateFromData();
+
 	void SetOptions( size_t nrays, size_t nmaxsunrays, int ncpu, int seed,
 		bool sunshape, bool opterr, bool aspowertower );
 	void GetOptions( size_t *nrays, size_t *nmaxsunrays, int *ncpu, int *seed,

--- a/coretrace/intersect.cpp
+++ b/coretrace/intersect.cpp
@@ -955,6 +955,19 @@ Label_10:
 		 
 	SJ1 = 0.0;
 
+	// JM 10/2023: Check upper and lower bounds for S (distance along ray path from (X1,Y1,Zstart)) to restrict step size for cubic spline
+	// This may slow down the solution - previously the iterations would find an intersection point for the spline, but it would be later disgarded because it is out of bounds, now the loop below will reach the iteration limit before failing is there is no intersection
+	double lower_bound = -1e10;
+	double upper_bound = 1e10;
+	if (Element->SurfaceType == 9)
+	{
+		double s_to_xmin = (Element->CubicSplineXData[0] - X1) / (CosKLM[0] + 0.00000000001);  // Distance along ray path from (X1,Y1,Zstart) to smallest x-coordinate on surface 
+		double s_to_xmax = (Element->CubicSplineXData[Element->CubicSplineXData.size() - 1] - X1) / (CosKLM[0] + 0.00000000001);  // Distance along ray path from (X1,Y1,Zstart) to largest x-coordinate on surface 
+		lower_bound = fmin(s_to_xmin, s_to_xmax);
+		upper_bound = fmax(s_to_xmin, s_to_xmax);
+	}
+
+
 	i = 0;
 //Begin the Newton-Raphson Iteration
 	while ( i++ < NumIterations)
@@ -976,6 +989,20 @@ Label_40:
 		if ( fabs(FXYZ) <= Epsilon*fabs(DFDXYZ) ) goto Label_100;
 		
 		SJ1 = SJ - FXYZ/DFDXYZ;
+
+		// JM 10/2023: Enforce bounds to restrict next guess for cubic spline
+		if (Element->SurfaceType == 9)
+		{
+			if ((FXYZ < 0 && CosKLM[2]>0) || (FXYZ > 0 && CosKLM[2] < 0)) // FXYZ < 0 if current point is below surface, FXYZ > 0 if current point is above surface
+				lower_bound = fmax(SJ, lower_bound);
+			else if ((FXYZ < 0 && CosKLM[2]<0) || (FXYZ > 0 && CosKLM[2] > 0))
+				upper_bound = fmin(SJ, upper_bound);
+			if (SJ1 < lower_bound || SJ1 > upper_bound)
+				SJ1 = 0.5 * (lower_bound + upper_bound);
+			if (upper_bound <= lower_bound)
+				break;
+		}
+
 	}
 	*ErrorFlag = 1;   //Failed to converge
 

--- a/coretrace/mathproc.cpp
+++ b/coretrace/mathproc.cpp
@@ -304,7 +304,7 @@ void spline( std::vector<double> &x,
 		y2[0] = -0.5;
 		u[0] = (3.0/(x[1]-x[0]))*((y[1]-y[0])/(x[1]-x[0])-yp1);
 	}
-	for (i=2;i<n-1;i++)
+	for (i=1;i<n-1;i++)
 	{
 		sig = (x[i]-x[i-1])/(x[i+1]-x[i-1]);
 		p = sig*y2[i-1]+2.0;


### PR DESCRIPTION
- Added the ability to save/read trace settings
- Fixed a minor problem in the definition of cubic splines
- Added bounds to the numerical procedure to find the intersection location for cubic splines. This helps to avoid occasions where the numerical solution fails to find an existing intersection location
- Minor change to data/plots on the Intersections page to update when the "Show final intersections only" box is checked