### PR TITLE
Fix ZAperture calculation for parabolic surfaces.

### DIFF
--- a/coretrace/apertureplane.cpp
+++ b/coretrace/apertureplane.cpp
@@ -213,7 +213,10 @@ bool AperturePlane(
 // *************************************************************************
 	case 'p':
 	case 'P': //{Surface described by Parabola}
-			FocalLength = 1.0/(2.0*Element->VertexCurvX);
+	{
+			// Get greater of two parabola parameters to calc focal length
+			double c_max = std::max(Element->VertexCurvX, Element->VertexCurvY);
+			FocalLength = 1.0 / (2.0 * c_max);
 			switch (Element->ShapeIndex)
 			{
 			case 'c':
@@ -252,6 +255,7 @@ bool AperturePlane(
 			}
 			
 		break;
+	}
 // *************************************************************************                 
 	case 'f':
 	case 'F': //      {Surface described by flat plane}


### PR DESCRIPTION
Fix Issue [https://github.com/NREL/SolTrace/issues/68](url)

ZAperture calculation for parabolic surfaces was only using the first parabola parameter (Cx) to calculate the FocalLength and subsequently the ZAperture. This led to ZAperture's that were too small and did not encompass the entire geometry.

Modified to use the max of Cx and Cy to calculate FocalLength and ZAperture. Tested with rectangular and triangular apertures. 

jm-dev-branch already made this fix (https://github.com/NREL/SolTrace/blob/jm-dev-branch/coretrace/simulation_runner/native_runner/parabola_calculator.cpp)