### PR TITLE
Convert parabola args to from cx to fx.

### DIFF
--- a/coretrace/simulation_data/surface.cpp
+++ b/coretrace/simulation_data/surface.cpp
@@ -22,8 +22,19 @@ surface_ptr make_surface_from_type(SurfaceType type, const std::vector<double> &
         retval = make_surface<Flat>();
         break;
     case PARABOLA:
-        retval = nargs < 2 ? nullptr : make_surface<Parabola>(args[0], args[1]);
+    {
+        if (nargs < 2)
+            retval = nullptr;
+        else
+        {
+            double cx = args[0];
+            double cy = args[1];
+            double fx = 1.0 / (2.0 * cx);
+            double fy = 1.0 / (2.0 * cy);
+            retval = make_surface<Parabola>(fx, fy);
+        }
         break;
+    } 
     case SPHERE:
         retval = nargs < 1 ? nullptr : make_surface<Sphere>(args[0]);
         break;

--- a/google-tests/regression-tests/native_runner_performance_test.cpp
+++ b/google-tests/regression-tests/native_runner_performance_test.cpp
@@ -236,7 +236,7 @@ TEST(NativeRunner, LargePerformanceTest)
     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
     std::chrono::duration<double, std::milli> dur = t1 - t0;
-    EXPECT_TRUE(dur.count() < 40000.0);
+    EXPECT_TRUE(dur.count() < 16000.0);
 
     const TSystem *sys = runner.get_system();
     // sys->RayData.Print();

--- a/google-tests/regression-tests/native_runner_performance_test.cpp
+++ b/google-tests/regression-tests/native_runner_performance_test.cpp
@@ -236,7 +236,7 @@ TEST(NativeRunner, LargePerformanceTest)
     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
     std::chrono::duration<double, std::milli> dur = t1 - t0;
-    EXPECT_TRUE(dur.count() < 16000.0);
+    EXPECT_TRUE(dur.count() < 40000.0);
 
     const TSystem *sys = runner.get_system();
     // sys->RayData.Print();

--- a/google-tests/unit-tests/simulation_data/surface_test.cpp
+++ b/google-tests/unit-tests/simulation_data/surface_test.cpp
@@ -84,8 +84,8 @@ TEST(Surface, MakeSurfaceFromType)
         
         auto parabola = std::dynamic_pointer_cast<SolTrace::Data::Parabola>(surface);
         ASSERT_NE(parabola, nullptr);
-        EXPECT_DOUBLE_EQ(parabola->focal_length_x, 1.5);
-        EXPECT_DOUBLE_EQ(parabola->focal_length_y, 2.0);
+        EXPECT_DOUBLE_EQ(parabola->focal_length_x, 0.33333333333333331);
+        EXPECT_DOUBLE_EQ(parabola->focal_length_y, 0.25);
     }
 
     // Test PARABOLA creation with insufficient arguments
@@ -159,8 +159,8 @@ TEST(Surface, MakeSurfaceFromType)
         ASSERT_NE(parabola, nullptr);
         EXPECT_EQ(parabola->get_type(), SolTrace::Data::PARABOLA);
         auto para_cast = std::dynamic_pointer_cast<SolTrace::Data::Parabola>(parabola);
-        EXPECT_DOUBLE_EQ(para_cast->focal_length_x, 5.0);
-        EXPECT_DOUBLE_EQ(para_cast->focal_length_y, 7.5);
+        EXPECT_DOUBLE_EQ(para_cast->focal_length_x, 0.1);
+        EXPECT_DOUBLE_EQ(para_cast->focal_length_y, 0.066666666666666666);
         
         // SPHERE only uses first argument
         auto sphere = SolTrace::Data::make_surface_from_type(SolTrace::Data::SPHERE, multi_args);


### PR DESCRIPTION
Legacy soltrace uses cx and cy for parabola arguments. The new structure uses focal lengths x and y. 
Modified conversion step. Modified test time for NativeRunner LargePerformanceTest.