### PR TITLE
Fix focal length check bug.

### DIFF
--- a/coretrace/simulation_runner/native_runner/parabola_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/parabola_calculator.cpp
@@ -36,9 +36,13 @@ namespace SolTrace::NativeRunner
         double fy = para->focal_length_y;
 
         // Validate focal lengths
-        if (std::isnan(fx) || std::isnan(fy) || std::isinf(fx) || std::isinf(fy))
+        if (std::isnan(fx) || std::isnan(fy))
         {
-            throw std::invalid_argument("ParabolaCalculator: Focal lengths cannot be NaN or infinite");
+            throw std::invalid_argument("ParabolaCalculator: Focal lengths cannot be NaN");
+        }
+        if (std::isinf(fx) && std::isinf(fy))
+        {
+            throw std::invalid_argument("ParabolaCalculator: Both focal lengths cannot be infinite");
         }
 
         this->cx = fabs(fx) < 1e-12 ? 0.0 : 0.5 / fx;


### PR DESCRIPTION
Change parabola calculator focal length check to allow one parameter (fx or fy) to be infinite. SolTrace allows cx and/or cy to be zero when defining parabolic surface (i.e. trough). 

Legacy soltrace actually allows both to be zero, resulting in a flat surface, not sure we want to allow that in the future though.