### PR TITLE
New sun models

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,9 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop new_sun_models ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop new_sun_models ]
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,9 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ develop new_sun_models ]
+    branches: [ develop, new_sun_models ]
   pull_request:
-    branches: [ develop new_sun_models ]
+    branches: [ develop, new_sun_models ]
 
 jobs:
   build:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,9 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ develop, new_sun_models ]
+    branches: [ develop ]
   pull_request:
-    branches: [ develop, new_sun_models ]
+    branches: [ develop ]
 
 jobs:
   build:

--- a/coretrace/raytrace_refactored.cpp
+++ b/coretrace/raytrace_refactored.cpp
@@ -258,7 +258,7 @@ void ProcessInteraction(
 			if (optics->DistributionType == 'F' || optics->DistributionType == 'f')
 				CopyVec3(CosIn, LastDFXYZ);  // Apply diffuse errors relative to surface normal
 			else
-				CopyVec3(CosIn, CosRayOutElement); // Apply all other errors relative to the specularly-reflected direction
+				CopyVec3(CosIn, CosRayOutElement); // Apply all other errors relative to the secularly-reflected direction
 
 			Errors(myrng, CosIn, 2, &System->Sun,
 				Stage->ElementList[k], optics, CosOut, LastDFXYZ);  //optical errors

--- a/coretrace/raytrace_refactored.cpp
+++ b/coretrace/raytrace_refactored.cpp
@@ -258,7 +258,7 @@ void ProcessInteraction(
 			if (optics->DistributionType == 'F' || optics->DistributionType == 'f')
 				CopyVec3(CosIn, LastDFXYZ);  // Apply diffuse errors relative to surface normal
 			else
-				CopyVec3(CosIn, CosRayOutElement); // Apply all other errors relative to the secularly-reflected direction
+				CopyVec3(CosIn, CosRayOutElement); // Apply all other errors relative to the specularly-reflected direction
 
 			Errors(myrng, CosIn, 2, &System->Sun,
 				Stage->ElementList[k], optics, CosOut, LastDFXYZ);  //optical errors

--- a/coretrace/simulation_data/error_distributions.hpp
+++ b/coretrace/simulation_data/error_distributions.hpp
@@ -12,11 +12,12 @@
 
 namespace SolTrace::Data {
 
-enum DistributionType
+enum class DistributionType
 {
     GAUSSIAN,
     PILLBOX,
-    USER_DEFINED
+    DIFFUSE,
+    USER_DEFINED        // Not supported in legacy but should be added.
 };
 
 } // namespace SolTrace::Data

--- a/coretrace/simulation_data/optical_properties.hpp
+++ b/coretrace/simulation_data/optical_properties.hpp
@@ -32,7 +32,7 @@ struct OpticalProperties
     double refraction_index_back;
 
     OpticalProperties() : my_type(REFLECTION),
-                          error_distribution_type(GAUSSIAN),
+                          error_distribution_type(DistributionType::GAUSSIAN),
                           transmitivity(0.0),
                           reflectivity(0.0),
                           slope_error(0.0),

--- a/coretrace/simulation_data/ray_source.hpp
+++ b/coretrace/simulation_data/ray_source.hpp
@@ -41,7 +41,7 @@ public:
     virtual void set_position(double, double, double) = 0;
     virtual void set_position(const DateTime &, double lat, double long) = 0;
     virtual SunShape get_shape() const = 0;
-    virtual void set_shape(SunShape shape, double _sigma, double _half_width,
+    virtual void set_shape(SunShape shape, double _sigma, double _half_width, double _csr,
         std::vector<double> _user_angle = {}, std::vector<double> _user_intensity = {}) = 0;
 
     double get_sigma()
@@ -51,6 +51,10 @@ public:
     double get_half_width()
     {
         return this->half_width;
+    }
+    double get_circumsolar_ratio()
+    {
+        return this->circumsolar_ratio;
     }
     void get_user_data(std::vector<double> &angle, std::vector<double> &intensity)
     {
@@ -62,6 +66,7 @@ public:
 protected:
     double sigma = std::numeric_limits<double>::quiet_NaN();
     double half_width = std::numeric_limits<double>::quiet_NaN();
+    double circumsolar_ratio = std::numeric_limits<double>::quiet_NaN();
     std::vector<double> user_angle;
     std::vector<double> user_intensity;
 };

--- a/coretrace/simulation_data/ray_source.hpp
+++ b/coretrace/simulation_data/ray_source.hpp
@@ -62,6 +62,7 @@ public:
         intensity = this->user_intensity;
         return;
     }
+    virtual void calculate_buie_parameters(double& kappa, double& gamma) = 0;
 
 protected:
     double sigma = std::numeric_limits<double>::quiet_NaN();

--- a/coretrace/simulation_data/ray_source.hpp
+++ b/coretrace/simulation_data/ray_source.hpp
@@ -16,10 +16,18 @@
 
 #include "container.hpp"
 #include "datetime.hpp"
-#include "error_distributions.hpp"
 #include "vector3d.hpp"
 
 namespace SolTrace::Data {
+
+enum class SunShape
+{
+    GAUSSIAN,
+    PILLBOX,
+    LIMBDARKENED,
+    BUIE_CSR,
+    USER_DEFINED
+};
 
 class RaySource
 {
@@ -32,8 +40,8 @@ public:
     virtual void set_position(const Vector3d &) = 0;
     virtual void set_position(double, double, double) = 0;
     virtual void set_position(const DateTime &, double lat, double long) = 0;
-    virtual DistributionType get_shape() const = 0;
-    virtual void set_shape(DistributionType shape, double _sigma, double _half_width,
+    virtual SunShape get_shape() const = 0;
+    virtual void set_shape(SunShape shape, double _sigma, double _half_width,
         std::vector<double> _user_angle = {}, std::vector<double> _user_intensity = {}) = 0;
 
     double get_sigma()

--- a/coretrace/simulation_data/simdata_io.cpp
+++ b/coretrace/simulation_data/simdata_io.cpp
@@ -62,6 +62,10 @@ DistributionType char_to_distribution(const char dist_char)
     {
         return DistributionType::PILLBOX;
     }
+    case ('f'):
+    {
+        return DistributionType::DIFFUSE;
+    }
     case ('d'):
     {
         return DistributionType::USER_DEFINED;
@@ -69,6 +73,29 @@ DistributionType char_to_distribution(const char dist_char)
     default:
     {
         return DistributionType::GAUSSIAN;
+    }
+    }
+}
+
+SunShape char_to_sunshape(const char dist_char)
+{
+    switch (dist_char)
+    {
+    case ('g'):
+    {
+        return SunShape::GAUSSIAN;
+    }
+    case ('p'):
+    {
+        return SunShape::PILLBOX;
+    }
+    case ('d'):
+    {
+        return SunShape::USER_DEFINED;
+    }
+    default:
+    {
+        return SunShape::GAUSSIAN;
     }
     }
 }
@@ -266,7 +293,7 @@ bool process_sun(FILE *fp, SimulationData &sd)
     // }
 
     // Define sun shape
-    DistributionType sun_shape = char_to_distribution(cshape);
+    SunShape sun_shape = char_to_sunshape(cshape);
     sun->set_shape(sun_shape, Sigma, HalfWidth, angle_vec, intensity_vec);
 
     // TODO set point source

--- a/coretrace/simulation_data/simdata_io.cpp
+++ b/coretrace/simulation_data/simdata_io.cpp
@@ -294,9 +294,10 @@ bool process_sun(FILE *fp, SimulationData &sd)
 
     // Define sun shape
     SunShape sun_shape = char_to_sunshape(cshape);
-    sun->set_shape(sun_shape, Sigma, HalfWidth, angle_vec, intensity_vec);
+    sun->set_shape(sun_shape, Sigma, HalfWidth, 0.0, angle_vec, intensity_vec);
 
     // TODO set point source
+	// TOOD: Buie sun shape not implemented here
 
     // Attach sun to simulation data
     sd.add_ray_source(sun);

--- a/coretrace/simulation_data/simdata_io.cpp
+++ b/coretrace/simulation_data/simdata_io.cpp
@@ -295,9 +295,9 @@ bool process_sun(FILE *fp, SimulationData &sd)
     // Define sun shape
     SunShape sun_shape = char_to_sunshape(cshape);
     sun->set_shape(sun_shape, Sigma, HalfWidth, 0.0, angle_vec, intensity_vec);
+    // TOD: Buie sun shape not implemented here
 
     // TODO set point source
-	// TOOD: Buie sun shape not implemented here
 
     // Attach sun to simulation data
     sd.add_ray_source(sun);

--- a/coretrace/simulation_data/simulation_data_export.hpp
+++ b/coretrace/simulation_data/simulation_data_export.hpp
@@ -26,6 +26,7 @@ using SolTrace::Data::SimulationParameters;
 using SolTrace::Data::SingleElement;
 using SolTrace::Data::Sphere;
 using SolTrace::Data::StageElement;
+using SolTrace::Data::SunShape;
 using SolTrace::Data::Sun;
 using SolTrace::Data::Surface;
 using SolTrace::Data::SurfaceType;

--- a/coretrace/simulation_data/sun.cpp
+++ b/coretrace/simulation_data/sun.cpp
@@ -48,6 +48,25 @@ void Sun::set_buie_csr_distribution(double _csr)
     circumsolar_ratio = _csr;
 }
 
+void Sun::calculate_buie_parameters(double& kappa, double& gamma)
+{
+    // Calculate kappa and gamma parameters
+    // Creates the Buie (2003) sun shape based on CSR
+    // [1] Buie, D., Dey, C., & Bosi, S. (2003). The effective size of the solar cone for solar concentrating systems. Solar energy, 74(2003), 417-427.
+    // [2] Buie, D., Monger, A., & Dey, C. (2003). Sun shape distributions for terrestrial solar simulations. Solar Energy, 74(March 2003), 113-122.
+    double csr = this->get_circumsolar_ratio();
+    double chi;
+    if (csr > 0.145)
+        chi = -0.04419909985804843 + csr * (1.401323894233574 + csr * (-0.3639746714505299 + csr * (-0.9579768560161194 + 1.1550475450828657 * csr)));
+    else if (csr > 0.035)
+        chi = 0.022652077593662934 + csr * (0.5252380349996234 + (2.5484334534423887 - 0.8763755326550412 * csr) * csr);
+    else
+        chi = 0.004733749294807862 + csr * (4.716738065192151 + csr * (-463.506669149804 + csr * (24745.88727411664 + csr * (-606122.7511711778 + 5521693.445014727 * csr))));
+    
+    kappa = 0.9 * log(13.5 * chi) * pow(chi, -0.3);
+    gamma = 2.2 * log(0.52 * chi) * pow(chi, 0.43) - 0.1;
+}
+
 void Sun::set_user_defined_distribution(std::vector<double> _user_angle,
                                         std::vector<double> _user_intensity)
 {

--- a/coretrace/simulation_data/sun.cpp
+++ b/coretrace/simulation_data/sun.cpp
@@ -35,6 +35,19 @@ void Sun::set_pillbox_distribution(double _half_width)
     half_width = _half_width;
 }
 
+void Sun::set_buie_csr_distribution(double _csr)
+{
+    if (_csr < 0.0 || _csr > 0.8)
+    {
+        throw std::invalid_argument("Buie CSR must be in the range [0, 0.8]");
+    }
+    if (std::isnan(_csr) || std::isinf(_csr))
+    {
+        throw std::invalid_argument("Buie CSR must be finite");
+    }
+    circumsolar_ratio = _csr;
+}
+
 void Sun::set_user_defined_distribution(std::vector<double> _user_angle,
                                         std::vector<double> _user_intensity)
 {
@@ -90,6 +103,7 @@ void Sun::set_user_defined_distribution(std::vector<double> _user_angle,
 void Sun::set_shape(SunShape shape,
                     double _sigma,
                     double _half_width,
+                    double _csr,
                     std::vector<double> _user_angle,
                     std::vector<double> _user_intensity)
 {
@@ -98,6 +112,7 @@ void Sun::set_shape(SunShape shape,
     // Clear arguments
     sigma = std::numeric_limits<double>::quiet_NaN();
     half_width = std::numeric_limits<double>::quiet_NaN();
+    circumsolar_ratio = std::numeric_limits<double>::quiet_NaN();
     user_angle.clear();
     user_intensity.clear();
 
@@ -108,6 +123,11 @@ void Sun::set_shape(SunShape shape,
         break;
     case (SunShape::PILLBOX):
         set_pillbox_distribution(_half_width);
+        break;
+    case (SunShape::LIMBDARKENED):
+        break;
+    case (SunShape::BUIE_CSR):
+        set_buie_csr_distribution(_csr);
         break;
     case (SunShape::USER_DEFINED):
         set_user_defined_distribution(std::move(_user_angle), std::move(_user_intensity));

--- a/coretrace/simulation_data/sun.cpp
+++ b/coretrace/simulation_data/sun.cpp
@@ -87,7 +87,7 @@ void Sun::set_user_defined_distribution(std::vector<double> _user_angle,
     user_intensity = std::move(_user_intensity);
 }
 
-void Sun::set_shape(DistributionType shape,
+void Sun::set_shape(SunShape shape,
                     double _sigma,
                     double _half_width,
                     std::vector<double> _user_angle,
@@ -103,13 +103,13 @@ void Sun::set_shape(DistributionType shape,
 
     switch (shape)
     {
-    case (DistributionType::GAUSSIAN):
+    case (SunShape::GAUSSIAN):
         set_gaussian_distribution(_sigma);
         break;
-    case (DistributionType::PILLBOX):
+    case (SunShape::PILLBOX):
         set_pillbox_distribution(_half_width);
         break;
-    case (DistributionType::USER_DEFINED):
+    case (SunShape::USER_DEFINED):
         set_user_defined_distribution(std::move(_user_angle), std::move(_user_intensity));
         break;
     default:

--- a/coretrace/simulation_data/sun.hpp
+++ b/coretrace/simulation_data/sun.hpp
@@ -52,6 +52,7 @@ public:
                            double _csr,        
                            std::vector<double> _user_angle = {},
                            std::vector<double> _user_intensity = {});
+    virtual void calculate_buie_parameters(double& kappa, double& gamma);
 
 private:
     void set_gaussian_distribution(double _sigma);

--- a/coretrace/simulation_data/sun.hpp
+++ b/coretrace/simulation_data/sun.hpp
@@ -49,12 +49,14 @@ public:
     virtual void set_shape(SunShape shape,
                            double _sigma,
                            double _half_width,
+                           double _csr,        
                            std::vector<double> _user_angle = {},
                            std::vector<double> _user_intensity = {});
 
 private:
     void set_gaussian_distribution(double _sigma);
     void set_pillbox_distribution(double _half_width);
+    void set_buie_csr_distribution(double _csr);
     void set_user_defined_distribution(std::vector<double> _user_angle,
                                        std::vector<double> _user_intensity);
 

--- a/coretrace/simulation_data/sun.hpp
+++ b/coretrace/simulation_data/sun.hpp
@@ -12,9 +12,7 @@
 #define SOLTRACE_SUN_H
 
 #include "ray_source.hpp"
-
 #include "datetime.hpp"
-#include "error_distributions.hpp"
 #include "vector3d.hpp"
 
 namespace SolTrace::Data {
@@ -44,11 +42,11 @@ public:
         return;
     }
     virtual void set_position(const DateTime &, double lat, double long) {}
-    virtual DistributionType get_shape() const
+    virtual SunShape get_shape() const
     {
         return this->my_shape;
     }
-    virtual void set_shape(DistributionType shape,
+    virtual void set_shape(SunShape shape,
                            double _sigma,
                            double _half_width,
                            std::vector<double> _user_angle = {},
@@ -60,7 +58,7 @@ private:
     void set_user_defined_distribution(std::vector<double> _user_angle,
                                        std::vector<double> _user_intensity);
 
-    DistributionType my_shape;
+    SunShape my_shape;
     Vector3d my_position;
 };
 

--- a/coretrace/simulation_runner/native_runner/native_runner.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner.cpp
@@ -89,20 +89,10 @@ namespace SolTrace::NativeRunner
         case SunShape::BUIE_CSR: {
             this->tsys.Sun.MaxAngle = 43.6; // [mrad]
             this->tsys.Sun.MaxIntensity = 1.0;
-            // Calculate kappa and gamma parameters
-            // Creates the Buie (2003) sun shape based on CSR
-            // [1] Buie, D., Dey, C., & Bosi, S. (2003). The effective size of the solar cone for solar concentrating systems. Solar energy, 74(2003), 417-427.
-            // [2] Buie, D., Monger, A., & Dey, C. (2003). Sun shape distributions for terrestrial solar simulations. Solar Energy, 74(March 2003), 113-122.
-            double csr = sun->get_circumsolar_ratio();
-            double chi;
-            if (csr > 0.145)
-                chi = -0.04419909985804843 + csr * (1.401323894233574 + csr * (-0.3639746714505299 + csr * (-0.9579768560161194 + 1.1550475450828657 * csr)));
-            else if (csr > 0.035)
-                chi = 0.022652077593662934 + csr * (0.5252380349996234 + (2.5484334534423887 - 0.8763755326550412 * csr) * csr);
-            else
-                chi = 0.004733749294807862 + csr * (4.716738065192151 + csr * (-463.506669149804 + csr * (24745.88727411664 + csr * (-606122.7511711778 + 5521693.445014727 * csr))));
-            this->tsys.Sun.buie_kappa = 0.9 * log(13.5 * chi) * pow(chi, -0.3);
-            this->tsys.Sun.buie_gamma = 2.2 * log(0.52 * chi) * pow(chi, 0.43) - 0.1;
+            double kappa, gamma;
+            sun->calculate_buie_parameters(kappa, gamma);
+            this->tsys.Sun.buie_kappa = kappa;
+            this->tsys.Sun.buie_gamma = gamma;
             break;
         }
         case SunShape::USER_DEFINED: {

--- a/coretrace/simulation_runner/native_runner/native_runner.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner.cpp
@@ -76,13 +76,13 @@ namespace SolTrace::NativeRunner
         // Set sunshape data
         switch (sun->get_shape())
         {
-        case DistributionType::GAUSSIAN:
+        case SunShape::GAUSSIAN:
             this->tsys.Sun.Sigma = sun->get_sigma();
             break;
-        case DistributionType::PILLBOX:
+        case SunShape::PILLBOX:
             this->tsys.Sun.Sigma = sun->get_half_width();
             break;
-        case DistributionType::USER_DEFINED:
+        case SunShape::USER_DEFINED:
             std::vector<double> angle, intensity;
             sun->get_user_data(angle, intensity);
             int npoints = angle.size();

--- a/coretrace/simulation_runner/native_runner/native_runner.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner.cpp
@@ -91,8 +91,8 @@ namespace SolTrace::NativeRunner
             this->tsys.Sun.MaxIntensity = 1.0;
             // Calculate kappa and gamma parameters
             // Creates the Buie (2003) sun shape based on CSR
-            // [1] Buie, D., Dey, C., & Bosi, S. (2003). The effective size of the solar cone for solar concentrating systems. Solar energy, 74(2003), 417–427.
-            // [2] Buie, D., Monger, A., & Dey, C. (2003). Sun shape distributions for terrestrial solar simulations. Solar Energy, 74(March 2003), 113–122.
+            // [1] Buie, D., Dey, C., & Bosi, S. (2003). The effective size of the solar cone for solar concentrating systems. Solar energy, 74(2003), 417-427.
+            // [2] Buie, D., Monger, A., & Dey, C. (2003). Sun shape distributions for terrestrial solar simulations. Solar Energy, 74(March 2003), 113-122.
             double csr = sun->get_circumsolar_ratio();
             double chi;
             if (csr > 0.145)

--- a/coretrace/simulation_runner/native_runner/native_runner.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner.cpp
@@ -105,7 +105,7 @@ namespace SolTrace::NativeRunner
             this->tsys.Sun.buie_gamma = 2.2 * log(0.52 * chi) * pow(chi, 0.43) - 0.1;
             break;
         }
-        case SunShape::USER_DEFINED:
+        case SunShape::USER_DEFINED: {
             std::vector<double> angle, intensity;
             sun->get_user_data(angle, intensity);
             int npoints = angle.size();
@@ -127,13 +127,17 @@ namespace SolTrace::NativeRunner
                 if (intensity[i] > this->tsys.Sun.MaxIntensity)
                     this->tsys.Sun.MaxIntensity = intensity[i];
             }
-
-            // fill negative angle side of array
-            for (int i = 0; i < npoints - 1; i++)
-            {
-                this->tsys.Sun.SunShapeAngle[i] = -angle[npoints - i - 1];
-                this->tsys.Sun.SunShapeIntensity[i] = intensity[npoints - i - 1];
-            }
+            // fill negative angle side of array -> I don't think we need this.
+            //for (int i = 0; i < npoints - 1; i++)
+            //{
+            //    this->tsys.Sun.SunShapeAngle[i] = -angle[npoints - i - 1];
+            //    this->tsys.Sun.SunShapeIntensity[i] = intensity[npoints - i - 1];
+            //}
+            break;
+        }
+        default:
+            // TODO: add error
+            break;
         }
 
         return RunnerStatus::SUCCESS;

--- a/coretrace/simulation_runner/native_runner/native_runner.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner.cpp
@@ -82,6 +82,29 @@ namespace SolTrace::NativeRunner
         case SunShape::PILLBOX:
             this->tsys.Sun.Sigma = sun->get_half_width();
             break;
+        case SunShape::LIMBDARKENED:
+            this->tsys.Sun.MaxAngle = 4.65; // [mrad]
+            this->tsys.Sun.MaxIntensity = 1.0;
+            break;
+        case SunShape::BUIE_CSR: {
+            this->tsys.Sun.MaxAngle = 43.6; // [mrad]
+            this->tsys.Sun.MaxIntensity = 1.0;
+            // Calculate kappa and gamma parameters
+            // Creates the Buie (2003) sun shape based on CSR
+            // [1] Buie, D., Dey, C., & Bosi, S. (2003). The effective size of the solar cone for solar concentrating systems. Solar energy, 74(2003), 417–427.
+            // [2] Buie, D., Monger, A., & Dey, C. (2003). Sun shape distributions for terrestrial solar simulations. Solar Energy, 74(March 2003), 113–122.
+            double csr = sun->get_circumsolar_ratio();
+            double chi;
+            if (csr > 0.145)
+                chi = -0.04419909985804843 + csr * (1.401323894233574 + csr * (-0.3639746714505299 + csr * (-0.9579768560161194 + 1.1550475450828657 * csr)));
+            else if (csr > 0.035)
+                chi = 0.022652077593662934 + csr * (0.5252380349996234 + (2.5484334534423887 - 0.8763755326550412 * csr) * csr);
+            else
+                chi = 0.004733749294807862 + csr * (4.716738065192151 + csr * (-463.506669149804 + csr * (24745.88727411664 + csr * (-606122.7511711778 + 5521693.445014727 * csr))));
+            this->tsys.Sun.buie_kappa = 0.9 * log(13.5 * chi) * pow(chi, -0.3);
+            this->tsys.Sun.buie_gamma = 2.2 * log(0.52 * chi) * pow(chi, 0.43) - 0.1;
+            break;
+        }
         case SunShape::USER_DEFINED:
             std::vector<double> angle, intensity;
             sun->get_user_data(angle, intensity);

--- a/coretrace/simulation_runner/native_runner/native_runner_types.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner_types.cpp
@@ -170,7 +170,7 @@ namespace SolTrace::NativeRunner
 
         PointSource = false;
         // ShapeIndex = ' ';
-        ShapeIndex = DistributionType::GAUSSIAN;
+        ShapeIndex = SunShape::GAUSSIAN;
         Sigma = 0;
 
         MaxAngle = 0;

--- a/coretrace/simulation_runner/native_runner/native_runner_types.hpp
+++ b/coretrace/simulation_runner/native_runner/native_runner_types.hpp
@@ -198,8 +198,10 @@ namespace SolTrace::NativeRunner
 
 		std::vector<double> SunShapeAngle;
 		std::vector<double> SunShapeIntensity;
-		double MaxAngle;
+		double MaxAngle;	// maximum sun angle (mrad)
 		double MaxIntensity;
+		double buie_kappa;	// Buie CSR model kappa parameter
+		double buie_gamma;	// Buie CSR model gamma parameter
 
 		double Origin[3];
 

--- a/coretrace/simulation_runner/native_runner/native_runner_types.hpp
+++ b/coretrace/simulation_runner/native_runner/native_runner_types.hpp
@@ -192,7 +192,7 @@ namespace SolTrace::NativeRunner
 		// void set_values(ray_source_ptr rsrc);
 
 		// char ShapeIndex;
-		SolTrace::Data::DistributionType ShapeIndex;
+		SolTrace::Data::SunShape ShapeIndex;
 		double Sigma;
 		bool PointSource;
 

--- a/coretrace/simulation_runner/native_runner/tracing_errors.cpp
+++ b/coretrace/simulation_runner/native_runner/tracing_errors.cpp
@@ -5,7 +5,19 @@
 
 namespace SolTrace::NativeRunner {
 
-// TODO: These two functions have a lot of overlap
+    // TODO: These two functions are basically the same. Refactor to avoid code duplication.
+	// NOTES:
+	// SurfaceNormalErrors()						Errors()
+    //     - uses slope error							- uses specularity error
+    //     - applies to surface normal (input)		    - applies to ray direction (input)
+    //     - no diffuse option  						- has diffuse option
+	//													- has an dot product check (goto) for surface reflection (requires DFXYZ)
+    //													- handles sun shape errors
+	//      
+    // Plan: Break up surface and sun shape error handling into separate functions
+	//     - remove the special case of diffuse surfaces before Errors()
+    //     - Reduce the random number calls. I.e., sample theta directly rather than thetax and thetay -> this will break tests because the number of RNG calls will change.
+
 void SurfaceNormalErrors(MTRand &myrng,
 						 double CosIn[3],
 						 const OpticalProperties *OptProperties,
@@ -28,8 +40,8 @@ void SurfaceNormalErrors(MTRand &myrng,
 	double PosIn[3] = {0.0, 0.0, 0.0},
 		   PosOut[3] = {0.0, 0.0, 0.0};
 	DistributionType dist;
-	double delop = 0.0, delop3 = 0.0, thetax = 0.0,
-		   thetay = 0.0, ttheta = 0.0, theta2 = 0.0,
+	double delop = 0.0, thetax = 0.0,
+		   thetay = 0.0, theta2 = 0.0,
 		   phi = 0.0, theta = 0.0;
 	double RRefToLoc[3][3] = {{0.0, 0.0, 0.0},
 							  {0.0, 0.0, 0.0},
@@ -67,7 +79,6 @@ void SurfaceNormalErrors(MTRand &myrng,
 	// delop = OptProperties->RMSSlopeError / 1000.0;
 	delop = OptProperties->slope_error / 1000.0;
 
-	int nninner = 0;
 	switch (dist)
 	{
 	case DistributionType::GAUSSIAN:		// case 'g':
@@ -99,9 +110,8 @@ void SurfaceNormalErrors(MTRand &myrng,
 	/* {Generate errors in terms of direction cosines in local ray coordinate system} */
 	theta = sqrt(theta2);
 	// phi = atan2(thetay, thetax); //This function appears to  present irregularities that bias results incorrectly for small values of thetay or thetax
-	phi = myrng() * 2.0 * 3.1415926535897932385; // Therefore have chosen to randomize phi rather than calculate from randomized theta components
-												 //  obtained from the distribution. The two approaches are equivalent save for this issue with
-												 //  arctan2.      wendelin 01-12-11
+	phi = myrng() * 2.0 * PI; // Therefore have chosen to randomize phi rather than calculate from randomized theta components
+	                          //  obtained from the distribution. The two approaches are equivalent save for this issue with arctan2.      wendelin 01-12-11
 
 	CosOut[0] = sin(theta) * cos(phi);
 	CosOut[1] = sin(theta) * sin(phi);
@@ -152,7 +162,7 @@ void Errors(
 	double PosIn[3] = {0.0, 0.0, 0.0};
 	double PosOut[3] = {0.0, 0.0, 0.0};
 	// char dist = 'g';
-	double delop = 0, delop3 = 0, thetax = 0, thetay = 0, ttheta = 0, theta2 = 0, phi = 0, theta = 0, stest = 0;
+	double delop = 0, thetax = 0, thetay = 0, theta2 = 0, phi = 0, theta = 0, stest = 0;
 	uint_fast64_t i;
 	double RRefToLoc[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
 	double RLocToRef[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
@@ -309,9 +319,8 @@ void Errors(
 	theta = sqrt(theta2);
 
 	// phi = atan2(thetay, thetax); //This function appears to  present irregularities that bias results incorrectly for small values of thetay or thetax
-	phi = myrng() * 2.0 * 3.1415926535897932385; // Therefore have chosen to randomize phi rather than calculate from randomized theta components
-												 //  obtained from the distribution. The two approaches are equivalent save for this issue with
-												 //  arctan2.      wendelin 01-12-11
+	phi = myrng() * 2.0 * PI; // Therefore have chosen to randomize phi rather than calculate from randomized theta components
+							  //  obtained from the distribution. The two approaches are equivalent save for this issue with arctan2.      wendelin 01-12-11
 
 	CosOut[0] = sin(theta) * cos(phi);
 	CosOut[1] = sin(theta) * sin(phi);

--- a/coretrace/simulation_runner/native_runner/tracing_errors.cpp
+++ b/coretrace/simulation_runner/native_runner/tracing_errors.cpp
@@ -5,9 +5,9 @@
 
 namespace SolTrace::NativeRunner {
 
+// TODO: These two functions have a lot of overlap
 void SurfaceNormalErrors(MTRand &myrng,
 						 double CosIn[3],
-						 //  TOpticalProperties *OptProperties,
 						 const OpticalProperties *OptProperties,
 						 double CosOut[3]) noexcept(false) // throw(nanexcept)
 {
@@ -27,7 +27,6 @@ void SurfaceNormalErrors(MTRand &myrng,
 		   Euler[3] = {0.0, 0.0, 0.0};
 	double PosIn[3] = {0.0, 0.0, 0.0},
 		   PosOut[3] = {0.0, 0.0, 0.0};
-	// char dist = ' ';
 	DistributionType dist;
 	double delop = 0.0, delop3 = 0.0, thetax = 0.0,
 		   thetay = 0.0, ttheta = 0.0, theta2 = 0.0,
@@ -45,19 +44,19 @@ void SurfaceNormalErrors(MTRand &myrng,
 		{
 			Euler[0] = 0.0;
 			Euler[1] = PI / 2.0;
-			goto Label_9;
 		}
 		else
 		{
 			Euler[0] = PI / 2.0;
-			goto Label_8;
+			Euler[1] = atan2(CosIn[1], sqrt(CosIn[0] * CosIn[0] + CosIn[2] * CosIn[2]));
 		}
 	}
+	else
+	{
+		Euler[0] = atan2(CosIn[0], CosIn[2]);
+		Euler[1] = atan2(CosIn[1], sqrt(CosIn[0] * CosIn[0] + CosIn[2] * CosIn[2]));
+	}
 
-	Euler[0] = atan2(CosIn[0], CosIn[2]);
-Label_8:
-	Euler[1] = atan2(CosIn[1], sqrt(CosIn[0] * CosIn[0] + CosIn[2] * CosIn[2]));
-Label_9:
 	Euler[2] = 0.0;
 
 	CalculateTransformMatrices(Euler, RRefToLoc, RLocToRef);
@@ -71,20 +70,14 @@ Label_9:
 	int nninner = 0;
 	switch (dist)
 	{
-	// case 'g':
-	// case 'G':
-	case DistributionType::GAUSSIAN:
+	case DistributionType::GAUSSIAN:		// case 'g':
 		// gaussian distribution
 		thetax = myrng.randNorm(0., delop);
 		thetay = myrng.randNorm(0., delop);
 
 		theta2 = thetax * thetax + thetay * thetay;
-
 		break;
-
-	// case 'p':
-	// case 'P':
-	case DistributionType::PILLBOX:
+	case DistributionType::PILLBOX:			// case 'p':
 		// pillbox distribution
 		do
 		{
@@ -92,7 +85,6 @@ Label_9:
 			thetay = 2.0 * delop * myrng() - delop;
 			theta2 = thetax * thetax + thetay * thetay;
 		} while (theta2 > (delop * delop));
-
 		break;
 	default:
 		// TODO: Need an error here.
@@ -160,13 +152,10 @@ void Errors(
 	double PosIn[3] = {0.0, 0.0, 0.0};
 	double PosOut[3] = {0.0, 0.0, 0.0};
 	// char dist = 'g';
-	DistributionType dist = DistributionType::GAUSSIAN;
 	double delop = 0, delop3 = 0, thetax = 0, thetay = 0, ttheta = 0, theta2 = 0, phi = 0, theta = 0, stest = 0;
 	uint_fast64_t i;
 	double RRefToLoc[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
 	double RLocToRef[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
-
-	// TODO: Rework function without goto statements...
 
 	if (CosIn[2] == 0.0)
 	{
@@ -174,102 +163,110 @@ void Errors(
 		{
 			Euler[0] = 0.0;
 			Euler[1] = PI / 2.0;
-			goto Label_9;
 		}
 		else
 		{
 			Euler[0] = PI / 2.0;
-			goto Label_8;
+			Euler[1] = atan2(CosIn[1], sqrt(CosIn[0] * CosIn[0] + CosIn[2] * CosIn[2]));
 		}
 	}
+	else
+	{
+		Euler[0] = atan2(CosIn[0], CosIn[2]);
+		Euler[1] = atan2(CosIn[1], sqrt(CosIn[0] * CosIn[0] + CosIn[2] * CosIn[2]));
+	}
 
-	Euler[0] = atan2(CosIn[0], CosIn[2]);
-
-Label_8:
-	Euler[1] = atan2(CosIn[1], sqrt(CosIn[0] * CosIn[0] + CosIn[2] * CosIn[2]));
-
-Label_9:
 	Euler[2] = 0.0;
 
 	CalculateTransformMatrices(Euler, RRefToLoc, RLocToRef);
 
+	unsigned int maxcall = 0;
 	// g,p,d
-	if (Source == 1)
+	if (Source == 1)  // sun error
 	{
-		dist = Sun->ShapeIndex; // sun
 		delop = Sun->Sigma / 1000.0;
+
+		switch (Sun->ShapeIndex)
+		{
+		case SunShape::GAUSSIAN:			// case 'g':
+			thetax = myrng.randNorm(0., delop);
+			thetay = myrng.randNorm(0., delop);
+
+			theta2 = thetax * thetax + thetay * thetay;
+			break;
+
+		case SunShape::PILLBOX:				// case 'p':
+			do
+			{
+				thetax = 2.0 * delop * myrng() - delop;
+				thetay = 2.0 * delop * myrng() - delop;
+				theta2 = thetax * thetax + thetay * thetay;
+			} while (theta2 > (delop * delop));
+			break;
+
+		case SunShape::USER_DEFINED:		// sunshape data  (for sunshape only)
+			do
+			{
+				thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
+				thetay = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
+				theta2 = thetax * thetax + thetay * thetay;
+				theta = sqrt(theta2); // wendelin 1-9-12  do the test once on theta NOT individually on thetax and thetay as before
+
+				i = 0;
+				while (i < Sun->SunShapeAngle.size() - 1 && Sun->SunShapeAngle[i] < theta)
+					i++;
+
+				if (i == 0)
+					stest = Sun->SunShapeIntensity[0];
+				else // change from average interpolation between data points to linear interpolation  12-20-11 wendelin
+					stest = Sun->SunShapeIntensity[i - 1]
+					+ (Sun->SunShapeIntensity[i] - Sun->SunShapeIntensity[i - 1]) * (theta - Sun->SunShapeAngle[i - 1]) /
+					(Sun->SunShapeAngle[i] - Sun->SunShapeAngle[i - 1]);
+				// stest = (Sun->SunShapeIntensity[i] + Sun->SunShapeIntensity[i-1])/2.0;
+			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
+
+			theta2 = theta2 / 1000000.0;
+			break;
+
+		default:
+			// TODO: Add error message here.
+			break;
+		}
 	}
 
-	if (Source == 2)
+	if (Source == 2)	// surface error
 	{
 		// dist = OptProperties->DistributionType; // errors
-		dist = OptProperties->error_distribution_type;
 		// // delop = sqrt(4.0*sqr(OptProperties->RMSSlopeError)+sqr(OptProperties->RMSSpecError))/1000.0;
-		// delop = OptProperties->RMSSpecError / 1000.0;
 		delop = OptProperties->specularity_error / 1000.0;
-	}
 
-	unsigned int maxcall = 0;
+	Label_50:
+		switch (OptProperties->error_distribution_type)
+		{
+		case DistributionType::GAUSSIAN:			// case 'g':
+			thetax = myrng.randNorm(0., delop);
+			thetay = myrng.randNorm(0., delop);
 
-Label_50:
-	switch (dist)
-	{
-	// case 'g':
-	// case 'G': // gaussian distribution
-	case DistributionType::GAUSSIAN:
-		thetax = myrng.randNorm(0., delop);
-		thetay = myrng.randNorm(0., delop);
+			theta2 = thetax * thetax + thetay * thetay;
+			break;
 
-		theta2 = thetax * thetax + thetay * thetay;
+		case DistributionType::PILLBOX:				// case 'p':
+			do
+			{
+				thetax = 2.0 * delop * myrng() - delop;
+				thetay = 2.0 * delop * myrng() - delop;
+				theta2 = thetax * thetax + thetay * thetay;
+			} while (theta2 > (delop * delop));
+			break;
 
-		break;
+		case DistributionType::DIFFUSE:
+			theta2 = pow(asin(sqrt(myrng())), 2);
+			break;
 
-	// case 'p':
-	// case 'P': // pillbox distribution
-	case DistributionType::PILLBOX:
-	Label_200:
-		thetax = 2.0 * delop * myrng() - delop;
-		thetay = 2.0 * delop * myrng() - delop;
-		theta2 = thetax * thetax + thetay * thetay;
-		if (theta2 > (delop * delop))
-			goto Label_200;
-		break;
-
-		// TODO: Do we need to the below code?
-		// case 'd':
-		// case 'D': // sunshape data  (for sunshape only)
-		// Label_300:
-		// 	thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
-		// 	thetay = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
-		// 	theta2 = thetax * thetax + thetay * thetay;
-		// 	theta = sqrt(theta2); // wendelin 1-9-12  do the test once on theta NOT individually on thetax and thetay as before
-
-		// 	i = 0;
-		// 	while (i < Sun->SunShapeAngle.size() - 1 && Sun->SunShapeAngle[i] < theta)
-		// 		i++;
-
-		// 	if (i == 0)
-		// 		stest = Sun->SunShapeIntensity[0];
-		// 	else // change from average interpolation between data points to linear interpolation  12-20-11 wendelin
-		// 		stest = Sun->SunShapeIntensity[i - 1] + (Sun->SunShapeIntensity[i] - Sun->SunShapeIntensity[i - 1]) * (theta - Sun->SunShapeAngle[i - 1]) /
-		// 													(Sun->SunShapeAngle[i] - Sun->SunShapeAngle[i - 1]);
-		// 	// stest = (Sun->SunShapeIntensity[i] + Sun->SunShapeIntensity[i-1])/2.0;
-
-		// 	if (myrng() > (stest / Sun->MaxIntensity))
-		// 		goto Label_300;
-
-		// 	if (theta2 > (Sun->MaxAngle * Sun->MaxAngle))
-		// 		goto Label_300;
-		// 	theta2 = theta2 / 1000000.0;
-		// 	break;
-
-		// case 'f': // gray diffuse distribution
-		// case 'F':
-		// 	theta2 = pow(asin(sqrt(myrng())), 2);
-		// 	break;
-	default:
-		// TODO: Add error message here.
-		break;
+		default:
+			// TODO: Add error message here.
+			break;
+		}
 	}
 
 	/*{Transform to local coordinate system of ray to set up rotation matrices for coord and inverse
@@ -297,7 +294,7 @@ Label_50:
 	//{Transform perturbed ray back to element system}
 	TransformToReference(PosIn, CosIn, Origin, RLocToRef, PosOut, CosOut);
 
-	/*{If reflection error applicaton and new ray direction (after errors) physically goes through opaque surface,
+	/*{If reflection error application and new ray direction (after errors) physically goes through opaque surface,
 	then go back and get new perturbation 06-12-07}*/
 	if ((Source == 2) &&
 		(OptProperties->my_type == InteractionType::REFLECTION) &&

--- a/coretrace/simulation_runner/native_runner/tracing_errors.cpp
+++ b/coretrace/simulation_runner/native_runner/tracing_errors.cpp
@@ -214,12 +214,12 @@ void Errors(
 				stest = 1.0 - 0.5138 * std::pow((theta / Sun->MaxAngle), 4);
 			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
 
-			theta2 = theta2 / 1.e6;
-
+			theta2 = theta2 / 1.e6; // convert from mrad^2 to rad^2
 			break;
 
 		case SunShape::BUIE_CSR:
 			// This sun model has long tales so this might take more iterations
+			// TODO: add an option to set the max angle (thereby reducing the tale)
 			do 
 			{
 				thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
@@ -230,15 +230,14 @@ void Errors(
 				if (std::abs(theta) <= 4.65) // within solar disc
 					stest = cos(0.326 * theta) / cos(0.308 * theta);
 				else // within circumsolar region
-					stest = std::exp(Sun->buie_kappa) * std::pow(theta, Sun->buie_gamma);
+					stest = std::exp(Sun->buie_kappa) * std::pow(std::abs(theta), Sun->buie_gamma);
 
 			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
 
-			theta2 = theta2 / 1.e6;
-
+			theta2 = theta2 / 1.e6; // convert from mrad^2 to rad^2
 			break;
 
-		case SunShape::USER_DEFINED:		// sunshape data  (for sunshape only)
+		case SunShape::USER_DEFINED:
 			do
 			{
 				thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
@@ -258,11 +257,12 @@ void Errors(
 
 			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
 
-			theta2 = theta2 / 1000000.0;
+            theta2 = theta2 / 1.e6;	// convert from mrad^2 to rad^2
 			break;
 
 		default:
 			// TODO: Add error message here.
+            throw std::exception("Unsupported sun shape in Errors function.");
 			break;
 		}
 	}
@@ -302,8 +302,7 @@ void Errors(
 		}
 	}
 
-	/*{Transform to local coordinate system of ray to set up rotation matrices for coord and inverse
-	  transforms}*/
+	// {Transform to local coordinate system of ray to set up rotation matrices for coordinate and inverse transforms}
 	TransformToLocal(PosIn, CosIn, Origin, RRefToLoc, PosOut, CosOut);
 
 	// {Generate errors in terms of direction cosines in local ray coordinate system}
@@ -327,8 +326,10 @@ void Errors(
 	//{Transform perturbed ray back to element system}
 	TransformToReference(PosIn, CosIn, Origin, RLocToRef, PosOut, CosOut);
 
+	// TODO: Remove goto, should we always do dot product check? // We could move this out of the function and into the caller.
+
 	/*{If reflection error application and new ray direction (after errors) physically goes through opaque surface,
-	then go back and get new perturbation 06-12-07}*/
+    then go back and get new perturbation 06-12-07}*/		
 	if ((Source == 2) &&
 		(OptProperties->my_type == InteractionType::REFLECTION) &&
 		(DOT(CosOut, DFXYZ) < 0) &&

--- a/coretrace/simulation_runner/native_runner/tracing_errors.cpp
+++ b/coretrace/simulation_runner/native_runner/tracing_errors.cpp
@@ -204,6 +204,40 @@ void Errors(
 			} while (theta2 > (delop * delop));
 			break;
 
+		case SunShape::LIMBDARKENED:
+			do {
+				thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
+				thetay = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
+				theta2 = thetax * thetax + thetay * thetay;
+				theta = sqrt(theta2);
+
+				stest = 1.0 - 0.5138 * std::pow((theta / Sun->MaxAngle), 4);
+			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
+
+			theta2 = theta2 / 1.e6;
+
+			break;
+
+		case SunShape::BUIE_CSR:
+			// This sun model has long tales so this might take more iterations
+			do 
+			{
+				thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
+				thetay = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
+				theta2 = thetax * thetax + thetay * thetay;
+				theta = sqrt(theta2);
+
+				if (std::abs(theta) <= 4.65) // within solar disc
+					stest = cos(0.326 * theta) / cos(0.308 * theta);
+				else // within circumsolar region
+					stest = std::exp(Sun->buie_kappa) * std::pow(theta, Sun->buie_gamma);
+
+			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
+
+			theta2 = theta2 / 1.e6;
+
+			break;
+
 		case SunShape::USER_DEFINED:		// sunshape data  (for sunshape only)
 			do
 			{
@@ -218,11 +252,10 @@ void Errors(
 
 				if (i == 0)
 					stest = Sun->SunShapeIntensity[0];
-				else // change from average interpolation between data points to linear interpolation  12-20-11 wendelin
-					stest = Sun->SunShapeIntensity[i - 1]
-					+ (Sun->SunShapeIntensity[i] - Sun->SunShapeIntensity[i - 1]) * (theta - Sun->SunShapeAngle[i - 1]) /
+				else // linear interpolation (switched from average) 12-20-11 wendelin
+					stest = Sun->SunShapeIntensity[i - 1] + (Sun->SunShapeIntensity[i] - Sun->SunShapeIntensity[i - 1]) * (theta - Sun->SunShapeAngle[i - 1]) /
 					(Sun->SunShapeAngle[i] - Sun->SunShapeAngle[i - 1]);
-				// stest = (Sun->SunShapeIntensity[i] + Sun->SunShapeIntensity[i-1])/2.0;
+
 			} while ((myrng() > (stest / Sun->MaxIntensity)) || (theta2 > (Sun->MaxAngle * Sun->MaxAngle)));
 
 			theta2 = theta2 / 1000000.0;

--- a/coretrace/simulation_runner/native_runner/tracing_errors.cpp
+++ b/coretrace/simulation_runner/native_runner/tracing_errors.cpp
@@ -218,8 +218,8 @@ void Errors(
 			break;
 
 		case SunShape::BUIE_CSR:
-			// This sun model has long tales so this might take more iterations
-			// TODO: add an option to set the max angle (thereby reducing the tale)
+			// This sun model has long tails so this might take more iterations
+			// TODO: add an option to set the max angle (thereby reducing the tail)
 			do 
 			{
 				thetax = 2.0 * Sun->MaxAngle * myrng() - Sun->MaxAngle;
@@ -262,7 +262,7 @@ void Errors(
 
 		default:
 			// TODO: Add error message here.
-            throw std::exception("Unsupported sun shape in Errors function.");
+            //throw std::exception("Unsupported sun shape in Errors function.");
 			break;
 		}
 	}

--- a/google-tests/regression-tests/native_runner_performance_test.cpp
+++ b/google-tests/regression-tests/native_runner_performance_test.cpp
@@ -140,7 +140,7 @@ TEST(NativeRunner, PerformanceTest)
 
     auto sun = make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SunShape::PILLBOX, 0.0, 0.5);
+    sun->set_shape(SunShape::PILLBOX, 0.0, 0.5, 0.0);
     sdata.add_ray_source(sun);
 
     RunnerStatus sts = my_runner.initialize();

--- a/google-tests/regression-tests/native_runner_performance_test.cpp
+++ b/google-tests/regression-tests/native_runner_performance_test.cpp
@@ -140,7 +140,7 @@ TEST(NativeRunner, PerformanceTest)
 
     auto sun = make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(DistributionType::PILLBOX, 0.0, 0.5);
+    sun->set_shape(SunShape::PILLBOX, 0.0, 0.5);
     sdata.add_ray_source(sun);
 
     RunnerStatus sts = my_runner.initialize();

--- a/google-tests/unit-tests/simulation_data/cst-templates/heliostat_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/heliostat_test.cpp
@@ -269,7 +269,7 @@ TEST(Heliostat, Trace)
 
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // // We can go over all the elements added
@@ -461,7 +461,7 @@ TEST(Heliostat, UpdateGeometry)
 
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // std::cout << "Sun Position: " << sun_pos

--- a/google-tests/unit-tests/simulation_data/cst-templates/heliostat_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/heliostat_test.cpp
@@ -269,7 +269,7 @@ TEST(Heliostat, Trace)
 
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // // We can go over all the elements added
@@ -461,7 +461,7 @@ TEST(Heliostat, UpdateGeometry)
 
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // std::cout << "Sun Position: " << sun_pos

--- a/google-tests/unit-tests/simulation_data/cst-templates/linear_fresnel_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/linear_fresnel_test.cpp
@@ -249,7 +249,7 @@ TEST(LinearFresnel, Tracing)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // Assumes that reference and global coordinates are the same
@@ -377,7 +377,7 @@ TEST(LinearFresnel, UpdateGeometry)
     sun_position_vector_degrees(sun_pos, sun_az, sun_el);
     sun_pos.scalar_mult(1000.0);
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     auto lf = SolTrace::Data::make_element<LinearFresnel>();

--- a/google-tests/unit-tests/simulation_data/cst-templates/linear_fresnel_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/linear_fresnel_test.cpp
@@ -249,7 +249,7 @@ TEST(LinearFresnel, Tracing)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // Assumes that reference and global coordinates are the same
@@ -377,7 +377,7 @@ TEST(LinearFresnel, UpdateGeometry)
     sun_position_vector_degrees(sun_pos, sun_az, sun_el);
     sun_pos.scalar_mult(1000.0);
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, 0.0);
     my_sim.add_ray_source(sun);
 
     auto lf = SolTrace::Data::make_element<LinearFresnel>();

--- a/google-tests/unit-tests/simulation_data/cst-templates/parabolic_dish_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/parabolic_dish_test.cpp
@@ -110,7 +110,7 @@ TEST(ParabolicDish, Tracing)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
     my_sim.add_ray_source(sun);
 
     // Assumes that reference and global coordinates are the same
@@ -212,7 +212,7 @@ TEST(ParabolicDish, UpdateGeometry)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     // sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
     sun_position_vector_degrees(sun->get_position(), sun_az, sun_el);
     // sun->get_position().scalar_mult(1000.0);
     // std::cout << "Sun Position: " << sun->get_position() << std::endl;

--- a/google-tests/unit-tests/simulation_data/cst-templates/parabolic_dish_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/parabolic_dish_test.cpp
@@ -110,7 +110,7 @@ TEST(ParabolicDish, Tracing)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // Assumes that reference and global coordinates are the same
@@ -212,7 +212,7 @@ TEST(ParabolicDish, UpdateGeometry)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     // sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0, 0.0);
     sun_position_vector_degrees(sun->get_position(), sun_az, sun_el);
     // sun->get_position().scalar_mult(1000.0);
     // std::cout << "Sun Position: " << sun->get_position() << std::endl;

--- a/google-tests/unit-tests/simulation_data/cst-templates/parabolic_trough_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/parabolic_trough_test.cpp
@@ -254,7 +254,7 @@ TEST(ParabolicTrough, Tracing)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     // Assumes that reference and global coordinates are the same
@@ -389,7 +389,7 @@ TEST(ParabolicTrough, UpdateGeometry)
     sun_pos.scalar_mult(1000.0);
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     std::cout << "Sun Position: " << sun_pos

--- a/google-tests/unit-tests/simulation_data/cst-templates/parabolic_trough_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/parabolic_trough_test.cpp
@@ -254,7 +254,7 @@ TEST(ParabolicTrough, Tracing)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 1000.0);
     // double NaN = std::numeric_limits<double>::quiet_NaN();
-    sun->set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
     my_sim.add_ray_source(sun);
 
     // Assumes that reference and global coordinates are the same
@@ -389,7 +389,7 @@ TEST(ParabolicTrough, UpdateGeometry)
     sun_pos.scalar_mult(1000.0);
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(sun_pos);
-    sun->set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 1.0);
     my_sim.add_ray_source(sun);
 
     std::cout << "Sun Position: " << sun_pos

--- a/google-tests/unit-tests/simulation_data/element_test.cpp
+++ b/google-tests/unit-tests/simulation_data/element_test.cpp
@@ -80,7 +80,7 @@ TEST(Element, SingleElementAccessors)
     EXPECT_EQ(opf->slope_error, opb->slope_error);
     EXPECT_EQ(opf->specularity_error, opb->specularity_error);
 
-    OpticalProperties op(SolTrace::Data::REFLECTION, SolTrace::Data::GAUSSIAN,
+    OpticalProperties op(SolTrace::Data::REFLECTION, SolTrace::Data::DistributionType::GAUSSIAN,
                          0.75, 0.25, 0.1, 0.001, 1.0, 1.0);
     ref.set_front_optical_properties(op);
     // EXPECT_EQ(*opf, op);
@@ -852,7 +852,7 @@ TEST(Element, SingleElementEnforceUserFieldsSet)
     EXPECT_NO_THROW(elem->enforce_user_fields_set());
 
     // Test with optical properties set as well
-    OpticalProperties op(SolTrace::Data::REFLECTION, SolTrace::Data::GAUSSIAN,
+    OpticalProperties op(SolTrace::Data::REFLECTION, SolTrace::Data::DistributionType::GAUSSIAN,
                          0.75, 0.25, 0.1, 0.001, 1.0, 1.0);
     elem->set_front_optical_properties(op);
     elem->set_back_optical_properties(op);

--- a/google-tests/unit-tests/simulation_data/sun_test.cpp
+++ b/google-tests/unit-tests/simulation_data/sun_test.cpp
@@ -13,25 +13,25 @@ TEST(Sun, GaussianDistributionErrors)
     
     // Test negative sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, -1.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, -1.0, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test zero sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, 0.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, 0.0, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test NaN sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, std::numeric_limits<double>::quiet_NaN(), 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test infinite sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, std::numeric_limits<double>::infinity(), 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, std::numeric_limits<double>::infinity(), 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
 }
@@ -43,25 +43,55 @@ TEST(Sun, PillboxDistributionErrors)
     
     // Test negative half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, -1.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, -1.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test zero half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test NaN half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, std::numeric_limits<double>::quiet_NaN(), {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, std::numeric_limits<double>::quiet_NaN(), 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test infinite half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, std::numeric_limits<double>::infinity(), {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, std::numeric_limits<double>::infinity(), 0.0, {}, {}),
+        std::invalid_argument
+    );
+}
+
+// Test Buie CSR distribution error handling
+TEST(Sun, BuieCsrDistributionErrors)
+{
+    Sun sun;
+
+    // Test negative CSR
+    EXPECT_THROW(
+        sun.set_shape(SolTrace::Data::SunShape::BUIE_CSR, 0.0, 0.0, -1.0, {}, {}),
+        std::invalid_argument
+    );
+
+    // Test high CSR
+    EXPECT_THROW(
+        sun.set_shape(SolTrace::Data::SunShape::BUIE_CSR, 0.0, 0.0, 0.81, {}, {}),
+        std::invalid_argument
+    );
+
+    // Test NaN CSR
+    EXPECT_THROW(
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, std::numeric_limits<double>::quiet_NaN(), {}, {}),
+        std::invalid_argument
+    );
+
+    // Test infinite CSR
+    EXPECT_THROW(
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, std::numeric_limits<double>::infinity(), {}, {}),
         std::invalid_argument
     );
 }
@@ -73,57 +103,57 @@ TEST(Sun, UserDefinedDistributionErrors)
     
     // Test empty angle vector
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {}, {1.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {}, {1.0}),
         std::invalid_argument
     );
     
     // Test empty intensity vector
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {1.0}, {}),
         std::invalid_argument
     );
     
     // Test both vectors empty
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test mismatched vector sizes
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0, 2.0}, {1.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {1.0, 2.0}, {1.0}),
         std::invalid_argument
     );
     
     // Test negative angle
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {-1.0, 2.0}, {1.0, 2.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {-1.0, 2.0}, {1.0, 2.0}),
         std::invalid_argument
     );
     
     // Test negative intensity
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0, 2.0}, {-1.0, 2.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {1.0, 2.0}, {-1.0, 2.0}),
         std::invalid_argument
     );
     
     // Test NaN in angles
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0,
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0,
                      {std::numeric_limits<double>::quiet_NaN(), 2.0}, {1.0, 2.0}),
         std::invalid_argument
     );
     
     // Test NaN in intensities
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0,
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0,
                      {1.0, 2.0}, {1.0, std::numeric_limits<double>::quiet_NaN()}),
         std::invalid_argument
     );
     
     // Test unsorted angles
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {2.0, 1.0}, {1.0, 2.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {2.0, 1.0}, {1.0, 2.0}),
         std::invalid_argument
     );
 }
@@ -135,25 +165,37 @@ TEST(Sun, ValidDistributions)
     
     // Valid Gaussian distribution
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, {}, {})
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, 0.0, {}, {})
     );
     EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::GAUSSIAN);
     
     // Valid Pillbox distribution
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 2.0, {}, {})
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 2.0, 0.0, {}, {})
     );
     EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::PILLBOX);
+
+	// Valid Limb Darkened distribution
+    EXPECT_NO_THROW(
+        sun.set_shape(SolTrace::Data::SunShape::LIMBDARKENED, 0.0, 0.0, 0.0, {}, {})
+	);
+	EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::LIMBDARKENED);
+
+	// Valid Buie CSR distribution
+    EXPECT_NO_THROW(
+        sun.set_shape(SolTrace::Data::SunShape::BUIE_CSR, 0.0, 0.0, 0.1, {}, {})
+	);
+	EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::BUIE_CSR);
     
     // Valid User-defined distribution
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {0.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {0.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
     );
     EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::USER_DEFINED);
     
     // Valid User-defined distribution with equal angles (edge case)
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, 0.0, {1.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
     );
 }
 
@@ -164,7 +206,7 @@ TEST(Sun, UnknownDistributionType)
     
     // Cast an invalid enum value to test default case
     EXPECT_THROW(
-        sun.set_shape(static_cast<SolTrace::Data::SunShape>(999), 1.0, 1.0, {}, {}),
+        sun.set_shape(static_cast<SolTrace::Data::SunShape>(999), 1.0, 1.0, 0.0, {}, {}),
         std::invalid_argument
     );
 }

--- a/google-tests/unit-tests/simulation_data/sun_test.cpp
+++ b/google-tests/unit-tests/simulation_data/sun_test.cpp
@@ -85,13 +85,13 @@ TEST(Sun, BuieCsrDistributionErrors)
 
     // Test NaN CSR
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, std::numeric_limits<double>::quiet_NaN(), {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::BUIE_CSR, 0.0, 0.0, std::numeric_limits<double>::quiet_NaN(), {}, {}),
         std::invalid_argument
     );
 
     // Test infinite CSR
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, std::numeric_limits<double>::infinity(), {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::BUIE_CSR, 0.0, 0.0, std::numeric_limits<double>::infinity(), {}, {}),
         std::invalid_argument
     );
 }

--- a/google-tests/unit-tests/simulation_data/sun_test.cpp
+++ b/google-tests/unit-tests/simulation_data/sun_test.cpp
@@ -13,25 +13,25 @@ TEST(Sun, GaussianDistributionErrors)
     
     // Test negative sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::GAUSSIAN, -1.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, -1.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test zero sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 0.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test NaN sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::GAUSSIAN, std::numeric_limits<double>::quiet_NaN(), 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, std::numeric_limits<double>::quiet_NaN(), 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test infinite sigma
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::GAUSSIAN, std::numeric_limits<double>::infinity(), 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, std::numeric_limits<double>::infinity(), 0.0, {}, {}),
         std::invalid_argument
     );
 }
@@ -43,25 +43,25 @@ TEST(Sun, PillboxDistributionErrors)
     
     // Test negative half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, -1.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, -1.0, {}, {}),
         std::invalid_argument
     );
     
     // Test zero half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test NaN half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, std::numeric_limits<double>::quiet_NaN(), {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, std::numeric_limits<double>::quiet_NaN(), {}, {}),
         std::invalid_argument
     );
     
     // Test infinite half_width
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, std::numeric_limits<double>::infinity(), {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, std::numeric_limits<double>::infinity(), {}, {}),
         std::invalid_argument
     );
 }
@@ -73,57 +73,57 @@ TEST(Sun, UserDefinedDistributionErrors)
     
     // Test empty angle vector
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {}, {1.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {}, {1.0}),
         std::invalid_argument
     );
     
     // Test empty intensity vector
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {1.0}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0}, {}),
         std::invalid_argument
     );
     
     // Test both vectors empty
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {}, {}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {}, {}),
         std::invalid_argument
     );
     
     // Test mismatched vector sizes
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {1.0, 2.0}, {1.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0, 2.0}, {1.0}),
         std::invalid_argument
     );
     
     // Test negative angle
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {-1.0, 2.0}, {1.0, 2.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {-1.0, 2.0}, {1.0, 2.0}),
         std::invalid_argument
     );
     
     // Test negative intensity
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {1.0, 2.0}, {-1.0, 2.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0, 2.0}, {-1.0, 2.0}),
         std::invalid_argument
     );
     
     // Test NaN in angles
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, 
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0,
                      {std::numeric_limits<double>::quiet_NaN(), 2.0}, {1.0, 2.0}),
         std::invalid_argument
     );
     
     // Test NaN in intensities
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, 
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0,
                      {1.0, 2.0}, {1.0, std::numeric_limits<double>::quiet_NaN()}),
         std::invalid_argument
     );
     
     // Test unsorted angles
     EXPECT_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {2.0, 1.0}, {1.0, 2.0}),
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {2.0, 1.0}, {1.0, 2.0}),
         std::invalid_argument
     );
 }
@@ -135,25 +135,25 @@ TEST(Sun, ValidDistributions)
     
     // Valid Gaussian distribution
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 1.0, 0.0, {}, {})
+        sun.set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, 0.0, {}, {})
     );
-    EXPECT_EQ(sun.get_shape(), SolTrace::Data::DistributionType::GAUSSIAN);
+    EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::GAUSSIAN);
     
     // Valid Pillbox distribution
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::PILLBOX, 0.0, 2.0, {}, {})
+        sun.set_shape(SolTrace::Data::SunShape::PILLBOX, 0.0, 2.0, {}, {})
     );
-    EXPECT_EQ(sun.get_shape(), SolTrace::Data::DistributionType::PILLBOX);
+    EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::PILLBOX);
     
     // Valid User-defined distribution
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {0.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {0.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
     );
-    EXPECT_EQ(sun.get_shape(), SolTrace::Data::DistributionType::USER_DEFINED);
+    EXPECT_EQ(sun.get_shape(), SolTrace::Data::SunShape::USER_DEFINED);
     
     // Valid User-defined distribution with equal angles (edge case)
     EXPECT_NO_THROW(
-        sun.set_shape(SolTrace::Data::DistributionType::USER_DEFINED, 0.0, 0.0, {1.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
+        sun.set_shape(SolTrace::Data::SunShape::USER_DEFINED, 0.0, 0.0, {1.0, 1.0, 2.0}, {1.0, 0.8, 0.6})
     );
 }
 
@@ -164,7 +164,7 @@ TEST(Sun, UnknownDistributionType)
     
     // Cast an invalid enum value to test default case
     EXPECT_THROW(
-        sun.set_shape(static_cast<SolTrace::Data::DistributionType>(999), 1.0, 1.0, {}, {}),
+        sun.set_shape(static_cast<SolTrace::Data::SunShape>(999), 1.0, 1.0, {}, {}),
         std::invalid_argument
     );
 }

--- a/google-tests/unit-tests/simulation_runner/native_runner/native_runner_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/native_runner_test.cpp
@@ -44,7 +44,7 @@ TEST(NativeRunnerTypes, TSun)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     Vector3d spos(1.0, 2.0, 3.0);
     sun->set_position(spos);
-    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, -1.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, -1.0, 1.0, 0.0);
     my_sim.add_ray_source(sun);
 
     NativeRunner runner;
@@ -117,7 +117,7 @@ TEST(NativeRunner, SmokeTest)
 
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 100.0);
-    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, -5.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, -5.0, 0.0);
     my_sim.add_ray_source(sun);
 
     auto my_st = SolTrace::Data::make_stage(0);
@@ -358,7 +358,7 @@ TEST(NativeRunner, SingleRayValidationTest)
     // Sun
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 100.0);
-    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, -1.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, -1.0, 1.0, 0.0);
     sd.add_ray_source(sun);
 
     auto sph = SolTrace::Data::make_element<SingleElement>();

--- a/google-tests/unit-tests/simulation_runner/native_runner/native_runner_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/native_runner_test.cpp
@@ -44,14 +44,14 @@ TEST(NativeRunnerTypes, TSun)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     Vector3d spos(1.0, 2.0, 3.0);
     sun->set_position(spos);
-    sun->set_shape(SolTrace::Data::PILLBOX, -1.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, -1.0, 1.0);
     my_sim.add_ray_source(sun);
 
     NativeRunner runner;
     runner.setup_sun(&my_sim);
     auto sys = runner.get_system();
     EXPECT_TRUE(is_identical(sys->Sun.Origin, sun->get_position()));
-    EXPECT_EQ(sys->Sun.ShapeIndex, SolTrace::Data::PILLBOX);
+    EXPECT_EQ(sys->Sun.ShapeIndex, SolTrace::Data::SunShape::PILLBOX);
 }
 
 TEST(NativeRunnerTypes, TElement)
@@ -117,7 +117,7 @@ TEST(NativeRunner, SmokeTest)
 
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 100.0);
-    sun->set_shape(SolTrace::Data::DistributionType::GAUSSIAN, 1.0, -5.0);
+    sun->set_shape(SolTrace::Data::SunShape::GAUSSIAN, 1.0, -5.0);
     my_sim.add_ray_source(sun);
 
     auto my_st = SolTrace::Data::make_stage(0);
@@ -358,7 +358,7 @@ TEST(NativeRunner, SingleRayValidationTest)
     // Sun
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 100.0);
-    sun->set_shape(SolTrace::Data::DistributionType::PILLBOX, -1.0, 1.0);
+    sun->set_shape(SolTrace::Data::SunShape::PILLBOX, -1.0, 1.0);
     sd.add_ray_source(sun);
 
     auto sph = SolTrace::Data::make_element<SingleElement>();

--- a/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
@@ -20,6 +20,9 @@
 using SolTrace::Runner::RunnerStatus;
 using SolTrace::NativeRunner::NativeRunner;
 
+
+// TODO: Create a master configuration then test individual features through modifications
+
 TEST(TowerDemo, NativeRunnerWithStages)
 {
     SimulationData sd;
@@ -353,6 +356,123 @@ TEST(TowerDemo, NativeRunnerWithErrors)
 
     // Set parameters
     SimulationParameters &params = sd.get_simulation_parameters();
+    params.number_of_rays = 100000;
+    // params.number_of_rays = 10; // Above takes too long
+    params.max_number_of_rays = params.number_of_rays * 100;
+    params.include_optical_errors = true;
+    params.include_sun_shape_errors = true;
+    params.seed = 12345;
+
+    NativeRunner runner;
+    RunnerStatus sts = runner.initialize();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Setup runs but is not complete
+    sts = runner.setup_simulation(&sd);
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Run simulation runs but returns RunnerStatus::ERROR
+    sts = runner.run_simulation();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Do some post processing tests here
+
+    // const TSystem *sys = runner.get_system();
+    // // auto ray_data = sys->AllRayData;
+    // sys->AllRayData.Print();
+}
+
+TEST(TowerDemo, NativeRunnerWithUserDefinedSunErrors)
+{
+    SimulationData sd;
+
+    // Sun
+    auto sun = make_ray_source<Sun>();
+    sun->set_position(0.0, 0.0, 100.0);
+	// Limb darkened sun shape
+    std::vector<double> angles =      { 0.0,    0.25,      0.5,    1.0,   1.5,   2.0,  3.0,  4.0,   4.5, 4.65 };
+	std::vector<double> intensities = { 1.0, 0.99999, 0.999893, 0.9991, 0.993, 0.981, 0.90, 0.71, 0.563, 0.0 };
+	sun->set_shape(SunShape::USER_DEFINED, 0.0, 0.0, 0.0, angles, intensities);
+    sd.add_ray_source(sun);
+
+    // Absorber -- Flat
+    auto absorber = make_element<SingleElement>();
+    absorber->set_origin(0.0, 0.0, 10.0);
+    absorber->set_aim_vector(0.0, 5.0, 0.0);
+    absorber->set_zrot(0.0);
+    absorber->compute_coordinate_rotations();
+    absorber->set_surface(make_surface<Flat>()); // surface(nullptr)
+    absorber->set_aperture(make_aperture<Rectangle>(2.0, 2.0));
+    OpticalProperties* foptics = absorber->get_front_optical_properties();
+    foptics->my_type = InteractionType::REFLECTION;
+    foptics->reflectivity = 0.0;
+    absorber->set_name("Absorber");
+
+    // Make stage 1 -- second stage -- these can be added to SimulationData
+    // in any order but should be numbered in the desired order
+    auto st1 = make_stage(1);
+    // Origin is initialized to zero but set it explicitly
+    st1->set_origin(0.0, 0.0, 0.0);
+    // Set aim vector so stage and global coordinates are identical
+    st1->set_aim_vector(0.0, 0.0, 1.0);
+    st1->set_zrot(0.0);
+    st1->compute_coordinate_rotations();
+    st1->add_element(absorber);
+    // Optional -- to help the user identify things
+    st1->set_name("Stage 1--Absorber");
+
+    // Make stage 0 -- this will be the first stage if the runner uses stages
+    auto st0 = make_stage(0);
+    st0->set_origin(0.0, 0.0, 0.0);
+    st0->set_aim_vector(0.0, 0.0, 1.0);
+    st0->set_zrot(0.0);
+    st0->compute_coordinate_rotations();
+    st0->set_name("Stage 0--Reflectors");
+
+    Vector3d rvec, svec, avec;
+    Vector3d aim, pos;
+
+    for (int i = -1; i < 2; ++i)
+    {
+        auto el = make_element<SingleElement>();
+        foptics = el->get_front_optical_properties();
+        foptics->reflectivity = 1.0;
+
+        pos.set_values(5 * sin(i * PI / 2.0),
+            5 * cos(i * PI / 2.0),
+            0.0);
+        el->set_origin(pos);
+        vector_add(1.0, absorber->get_origin_global(),
+            -1.0, pos,
+            rvec);
+        make_unit_vector(rvec);
+        svec = sun->get_position();
+        make_unit_vector(svec);
+        vector_add(0.5, rvec, 0.5, svec, avec);
+
+        vector_add(1.0, pos, 100.0, avec, aim);
+        el->set_aim_vector(aim);
+
+        // TODO: Set zrot as in python file?
+        el->set_zrot(30.0 * i);
+        // // Could also be set in radians
+        // el->set_zrot_radians(PI / 3.0 * i);
+        el->compute_coordinate_rotations();
+
+        el->set_surface(make_surface<Flat>());
+        el->set_aperture(make_aperture<Rectangle>(1.0, 1.95));
+
+        std::stringstream name;
+        name << "Reflector " << i;
+        el->set_name(name.str());
+
+        st0->add_element(el);
+    }
+
+    // Stages must have all elements present before adding to SimulationData!!
+    sd.add_stage(st0);
+    sd.add_stage(st1);
+
+    // Set parameters
+    SimulationParameters& params = sd.get_simulation_parameters();
     params.number_of_rays = 100000;
     // params.number_of_rays = 10; // Above takes too long
     params.max_number_of_rays = params.number_of_rays * 100;

--- a/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
@@ -29,6 +29,7 @@ SimulationData create_tower_demo_simulation_data(bool create_stages)
     // Sun
     auto sun = make_ray_source<Sun>();
     sun->set_position(0.0, 0.0, 100.0);
+    sun->set_shape(SunShape::GAUSSIAN, 1.0, 0.0, 0.0);
     sd.add_ray_source(sun);
 
     // Absorber -- Flat
@@ -245,9 +246,43 @@ TEST(TowerDemo, NativeRunnerWithErrors)
     // sys->AllRayData.Print();
 }
 
+TEST(TowerDemo, NativeRunnerWithPillboxSunErrors)
+{
+    SimulationData sd = create_tower_demo_simulation_data(true);
+
+    SimulationParameters& params = sd.get_simulation_parameters();
+    params.include_optical_errors = true;
+    params.include_sun_shape_errors = true;
+
+    // modify the sun to have user defined shape
+    auto sun = sd.get_ray_source();
+    // Limb darkened sun shape
+    sun->set_shape(SunShape::PILLBOX, 0.0, 4.65, 0.0);
+
+    NativeRunner runner;
+    RunnerStatus sts = runner.initialize();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Setup runs but is not complete
+    sts = runner.setup_simulation(&sd);
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Run simulation runs but returns RunnerStatus::ERROR
+    sts = runner.run_simulation();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Do some post processing tests here
+
+    // const TSystem *sys = runner.get_system();
+    // // auto ray_data = sys->AllRayData;
+    // sys->AllRayData.Print();
+}
+
 TEST(TowerDemo, NativeRunnerWithUserDefinedSunErrors)
 {
     SimulationData sd = create_tower_demo_simulation_data(true);
+
+    SimulationParameters& params = sd.get_simulation_parameters();
+    params.include_optical_errors = true;
+    params.include_sun_shape_errors = true;
 
     // modify the sun to have user defined shape
     auto sun = sd.get_ray_source();
@@ -277,6 +312,10 @@ TEST(TowerDemo, NativeRunnerWithLimbDarkenedSunErrors)
 {
     SimulationData sd = create_tower_demo_simulation_data(true);
 
+    SimulationParameters& params = sd.get_simulation_parameters();
+    params.include_optical_errors = true;
+    params.include_sun_shape_errors = true;
+
     // modify the sun to have user defined shape
     auto sun = sd.get_ray_source();
     // Limb darkened sun shape
@@ -302,6 +341,10 @@ TEST(TowerDemo, NativeRunnerWithLimbDarkenedSunErrors)
 TEST(TowerDemo, NativeRunnerWithBuieCsrSunErrors)
 {
     SimulationData sd = create_tower_demo_simulation_data(true);
+
+    SimulationParameters& params = sd.get_simulation_parameters();
+    params.include_optical_errors = true;
+    params.include_sun_shape_errors = true;
 
     // modify the sun to have user defined shape
     auto sun = sd.get_ray_source();

--- a/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
@@ -22,8 +22,7 @@ using SolTrace::NativeRunner::NativeRunner;
 
 
 // TODO: Create a master configuration then test individual features through modifications
-
-TEST(TowerDemo, NativeRunnerWithStages)
+SimulationData create_tower_demo_simulation_data(bool create_stages)
 {
     SimulationData sd;
 
@@ -40,44 +39,38 @@ TEST(TowerDemo, NativeRunnerWithStages)
     absorber->compute_coordinate_rotations();
     absorber->set_surface(make_surface<Flat>()); // surface(nullptr)
     absorber->set_aperture(make_aperture<Rectangle>(2.0, 2.0));
-    OpticalProperties *foptics = absorber->get_front_optical_properties();
+    OpticalProperties* foptics = absorber->get_front_optical_properties();
     foptics->my_type = SolTrace::Data::REFLECTION;
     foptics->reflectivity = 0.0;
     absorber->set_name("Absorber");
 
-    // // Absorber -- Cylindrical -- MAY NOT WORK DUE TO UNIMPLEMENTED CODE!
-    // auto absorber = make_element<SingleElement>();
-    // const double r = 5.0;
-    // absorber->set_origin(0.0, -r, 0.0);
-    // absorber->set_zrot(0.0);
-    // absorber->set_aim_vector(0.0, 100.0, -(r + 50.0));
-    // // These are the default options but to show off the constructor
-    // OpticalProperties op(REFLECTION, 0.0, 0.0, 0.0, 0.0);
-    // // Alternative to getting the pointer and setting values
-    // absorber->set_front_optical_properties(op);
-    // absorber->set_surface(make_surface<Cylinder>());
-    // absorber->set_aperture(make_aperture<SingleAxisCurvatureSection>());
+    stage_ptr st0, st1;
+    if (create_stages) {
+        // Make stage 1 -- second stage -- these can be added to SimulationData
+        // in any order but should be numbered in the desired order
+        st1 = make_stage(1);
+        // Origin is initialized to zero but set it explicitly
+        st1->set_origin(0.0, 0.0, 0.0);
+        // Set aim vector so stage and global coordinates are identical
+        st1->set_aim_vector(0.0, 0.0, 1.0);
+        st1->set_zrot(0.0);
+        st1->compute_coordinate_rotations();
+        st1->add_element(absorber);
+        // Optional -- to help the user identify things
+        st1->set_name("Stage 1--Absorber");
 
-    // Make stage 1 -- second stage -- these can be added to SimulationData
-    // in any order but should be numbered in the desired order
-    auto st1 = make_stage(1);
-    // Origin is initialized to zero but set it explicitly
-    st1->set_origin(0.0, 0.0, 0.0);
-    // Set aim vector so stage and global coordinates are identical
-    st1->set_aim_vector(0.0, 0.0, 1.0);
-    st1->set_zrot(0.0);
-    st1->compute_coordinate_rotations();
-    st1->add_element(absorber);
-    // Optional -- to help the user identify things
-    st1->set_name("Stage 1--Absorber");
-
-    // Make stage 0 -- this will be the first stage if the runner uses stages
-    auto st0 = make_stage(0);
-    st0->set_origin(0.0, 0.0, 0.0);
-    st0->set_aim_vector(0.0, 0.0, 1.0);
-    st0->set_zrot(0.0);
-    st0->compute_coordinate_rotations();
-    st0->set_name("Stage 0--Reflectors");
+        // Make stage 0 -- this will be the first stage if the runner uses stages
+        st0 = make_stage(0);
+        st0->set_origin(0.0, 0.0, 0.0);
+        st0->set_aim_vector(0.0, 0.0, 1.0);
+        st0->set_zrot(0.0);
+        st0->compute_coordinate_rotations();
+        st0->set_name("Stage 0--Reflectors");
+    }
+    else {
+        // Add absorber directly
+        sd.add_element(absorber);
+    }
 
     Vector3d rvec, svec, avec;
     Vector3d aim, pos;
@@ -89,12 +82,12 @@ TEST(TowerDemo, NativeRunnerWithStages)
         foptics->reflectivity = 1.0;
 
         pos.set_values(5 * sin(i * PI / 2.0),
-                       5 * cos(i * PI / 2.0),
-                       0.0);
+            5 * cos(i * PI / 2.0),
+            0.0);
         el->set_origin(pos);
         vector_add(1.0, absorber->get_origin_global(),
-                   -1.0, pos,
-                   rvec);
+            -1.0, pos,
+            rvec);
         make_unit_vector(rvec);
         svec = sun->get_position();
         make_unit_vector(svec);
@@ -116,21 +109,47 @@ TEST(TowerDemo, NativeRunnerWithStages)
         name << "Reflector " << i;
         el->set_name(name.str());
 
-        st0->add_element(el);
+        if (create_stages)
+            st0->add_element(el);
+        else
+            sd.add_element(el);
     }
 
-    // Stages must have all elements present before adding to SimulationData!!
-    sd.add_stage(st0);
-    sd.add_stage(st1);
+    if (create_stages) {
+        // Stages must have all elements present before adding to SimulationData!!
+        sd.add_stage(st0);
+        sd.add_stage(st1);
+    }
 
     // Set parameters
-    SimulationParameters &params = sd.get_simulation_parameters();
+    SimulationParameters& params = sd.get_simulation_parameters();
     params.number_of_rays = 100000;
     // params.number_of_rays = 10; // Above takes too long
     params.max_number_of_rays = params.number_of_rays * 100;
     params.include_optical_errors = false;
     params.include_sun_shape_errors = false;
     params.seed = 12345;
+
+    return sd;
+}
+
+
+TEST(TowerDemo, NativeRunnerWithStages)
+{
+    SimulationData sd = create_tower_demo_simulation_data(true);
+
+    // // Absorber -- Cylindrical -- MAY NOT WORK DUE TO UNIMPLEMENTED CODE!
+    // auto absorber = make_element<SingleElement>();
+    // const double r = 5.0;
+    // absorber->set_origin(0.0, -r, 0.0);
+    // absorber->set_zrot(0.0);
+    // absorber->set_aim_vector(0.0, 100.0, -(r + 50.0));
+    // // These are the default options but to show off the constructor
+    // OpticalProperties op(REFLECTION, 0.0, 0.0, 0.0, 0.0);
+    // // Alternative to getting the pointer and setting values
+    // absorber->set_front_optical_properties(op);
+    // absorber->set_surface(make_surface<Cylinder>());
+    // absorber->set_aperture(make_aperture<SingleAxisCurvatureSection>());
 
     // // We can go over all the elements added
     // for (auto iter = sd.get_iterator();
@@ -181,74 +200,7 @@ TEST(TowerDemo, NativeRunnerWithStages)
 
 TEST(TowerDemo, NativeRunnerWithoutStages)
 {
-    SimulationData sd;
-
-    // Sun
-    auto sun = make_ray_source<Sun>();
-    sun->set_position(0.0, 0.0, 100.0);
-    sd.add_ray_source(sun);
-
-    // Absorber -- Flat
-    auto absorber = make_element<SingleElement>();
-    absorber->set_origin(0.0, 0.0, 10.0);
-    absorber->set_aim_vector(0.0, 5.0, 0.0);
-    absorber->set_zrot(0.0);
-    absorber->compute_coordinate_rotations();
-    absorber->set_surface(make_surface<Flat>()); // surface(nullptr)
-    absorber->set_aperture(make_aperture<Rectangle>(2.0, 2.0));
-    OpticalProperties *foptics = absorber->get_front_optical_properties();
-    foptics->my_type = InteractionType::REFLECTION;
-    foptics->reflectivity = 0.0;
-    absorber->set_name("Absorber");
-    sd.add_element(absorber);
-
-    Vector3d rvec, svec, avec;
-    Vector3d aim, pos;
-
-    for (int i = -1; i < 2; ++i)
-    {
-        auto el = make_element<SingleElement>();
-        foptics = el->get_front_optical_properties();
-        foptics->reflectivity = 1.0;
-
-        pos.set_values(5 * sin(i * PI / 2.0),
-                       5 * cos(i * PI / 2.0),
-                       0.0);
-        el->set_origin(pos);
-        vector_add(1.0, absorber->get_origin_global(),
-                   -1.0, pos,
-                   rvec);
-        make_unit_vector(rvec);
-        svec = sun->get_position();
-        make_unit_vector(svec);
-        vector_add(0.5, rvec, 0.5, svec, avec);
-
-        vector_add(1.0, pos, 100.0, avec, aim);
-        el->set_aim_vector(aim);
-
-        // TODO: Set zrot as in python file?
-        el->set_zrot(30.0 * i);
-        // // Could also be set in radians
-        // el->set_zrot_radians(PI / 3.0 * i);
-        el->compute_coordinate_rotations();
-
-        el->set_surface(make_surface<Flat>());
-        el->set_aperture(make_aperture<Rectangle>(1.0, 1.95));
-
-        std::stringstream name;
-        name << "Reflector " << i;
-        el->set_name(name.str());
-
-        sd.add_element(el);
-    }
-
-    // Set parameters
-    SimulationParameters &params = sd.get_simulation_parameters();
-    params.number_of_rays = 100000;
-    params.max_number_of_rays = params.number_of_rays * 100;
-    params.include_optical_errors = false;
-    params.include_sun_shape_errors = false;
-    params.seed = 12345;
+    SimulationData sd = create_tower_demo_simulation_data(false);
 
     NativeRunner runner;
     RunnerStatus sts = runner.initialize();
@@ -269,99 +221,12 @@ TEST(TowerDemo, NativeRunnerWithoutStages)
 
 TEST(TowerDemo, NativeRunnerWithErrors)
 {
-    SimulationData sd;
-
-    // Sun
-    auto sun = make_ray_source<Sun>();
-    sun->set_position(0.0, 0.0, 100.0);
-    sd.add_ray_source(sun);
-
-    // Absorber -- Flat
-    auto absorber = make_element<SingleElement>();
-    absorber->set_origin(0.0, 0.0, 10.0);
-    absorber->set_aim_vector(0.0, 5.0, 0.0);
-    absorber->set_zrot(0.0);
-    absorber->compute_coordinate_rotations();
-    absorber->set_surface(make_surface<Flat>()); // surface(nullptr)
-    absorber->set_aperture(make_aperture<Rectangle>(2.0, 2.0));
-    OpticalProperties *foptics = absorber->get_front_optical_properties();
-    foptics->my_type = InteractionType::REFLECTION;
-    foptics->reflectivity = 0.0;
-    absorber->set_name("Absorber");
-
-    // Make stage 1 -- second stage -- these can be added to SimulationData
-    // in any order but should be numbered in the desired order
-    auto st1 = make_stage(1);
-    // Origin is initialized to zero but set it explicitly
-    st1->set_origin(0.0, 0.0, 0.0);
-    // Set aim vector so stage and global coordinates are identical
-    st1->set_aim_vector(0.0, 0.0, 1.0);
-    st1->set_zrot(0.0);
-    st1->compute_coordinate_rotations();
-    st1->add_element(absorber);
-    // Optional -- to help the user identify things
-    st1->set_name("Stage 1--Absorber");
-
-    // Make stage 0 -- this will be the first stage if the runner uses stages
-    auto st0 = make_stage(0);
-    st0->set_origin(0.0, 0.0, 0.0);
-    st0->set_aim_vector(0.0, 0.0, 1.0);
-    st0->set_zrot(0.0);
-    st0->compute_coordinate_rotations();
-    st0->set_name("Stage 0--Reflectors");
-
-    Vector3d rvec, svec, avec;
-    Vector3d aim, pos;
-
-    for (int i = -1; i < 2; ++i)
-    {
-        auto el = make_element<SingleElement>();
-        foptics = el->get_front_optical_properties();
-        foptics->reflectivity = 1.0;
-
-        pos.set_values(5 * sin(i * PI / 2.0),
-                       5 * cos(i * PI / 2.0),
-                       0.0);
-        el->set_origin(pos);
-        vector_add(1.0, absorber->get_origin_global(),
-                   -1.0, pos,
-                   rvec);
-        make_unit_vector(rvec);
-        svec = sun->get_position();
-        make_unit_vector(svec);
-        vector_add(0.5, rvec, 0.5, svec, avec);
-
-        vector_add(1.0, pos, 100.0, avec, aim);
-        el->set_aim_vector(aim);
-
-        // TODO: Set zrot as in python file?
-        el->set_zrot(30.0 * i);
-        // // Could also be set in radians
-        // el->set_zrot_radians(PI / 3.0 * i);
-        el->compute_coordinate_rotations();
-
-        el->set_surface(make_surface<Flat>());
-        el->set_aperture(make_aperture<Rectangle>(1.0, 1.95));
-
-        std::stringstream name;
-        name << "Reflector " << i;
-        el->set_name(name.str());
-
-        st0->add_element(el);
-    }
-
-    // Stages must have all elements present before adding to SimulationData!!
-    sd.add_stage(st0);
-    sd.add_stage(st1);
+    SimulationData sd = create_tower_demo_simulation_data(true);
 
     // Set parameters
     SimulationParameters &params = sd.get_simulation_parameters();
-    params.number_of_rays = 100000;
-    // params.number_of_rays = 10; // Above takes too long
-    params.max_number_of_rays = params.number_of_rays * 100;
     params.include_optical_errors = true;
     params.include_sun_shape_errors = true;
-    params.seed = 12345;
 
     NativeRunner runner;
     RunnerStatus sts = runner.initialize();
@@ -382,103 +247,66 @@ TEST(TowerDemo, NativeRunnerWithErrors)
 
 TEST(TowerDemo, NativeRunnerWithUserDefinedSunErrors)
 {
-    SimulationData sd;
+    SimulationData sd = create_tower_demo_simulation_data(true);
 
-    // Sun
-    auto sun = make_ray_source<Sun>();
-    sun->set_position(0.0, 0.0, 100.0);
+    // modify the sun to have user defined shape
+    auto sun = sd.get_ray_source();
 	// Limb darkened sun shape
     std::vector<double> angles =      { 0.0,    0.25,      0.5,    1.0,   1.5,   2.0,  3.0,  4.0,   4.5, 4.65 };
 	std::vector<double> intensities = { 1.0, 0.99999, 0.999893, 0.9991, 0.993, 0.981, 0.90, 0.71, 0.563, 0.0 };
 	sun->set_shape(SunShape::USER_DEFINED, 0.0, 0.0, 0.0, angles, intensities);
-    sd.add_ray_source(sun);
 
-    // Absorber -- Flat
-    auto absorber = make_element<SingleElement>();
-    absorber->set_origin(0.0, 0.0, 10.0);
-    absorber->set_aim_vector(0.0, 5.0, 0.0);
-    absorber->set_zrot(0.0);
-    absorber->compute_coordinate_rotations();
-    absorber->set_surface(make_surface<Flat>()); // surface(nullptr)
-    absorber->set_aperture(make_aperture<Rectangle>(2.0, 2.0));
-    OpticalProperties* foptics = absorber->get_front_optical_properties();
-    foptics->my_type = InteractionType::REFLECTION;
-    foptics->reflectivity = 0.0;
-    absorber->set_name("Absorber");
+    NativeRunner runner;
+    RunnerStatus sts = runner.initialize();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Setup runs but is not complete
+    sts = runner.setup_simulation(&sd);
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Run simulation runs but returns RunnerStatus::ERROR
+    sts = runner.run_simulation();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // Make stage 1 -- second stage -- these can be added to SimulationData
-    // in any order but should be numbered in the desired order
-    auto st1 = make_stage(1);
-    // Origin is initialized to zero but set it explicitly
-    st1->set_origin(0.0, 0.0, 0.0);
-    // Set aim vector so stage and global coordinates are identical
-    st1->set_aim_vector(0.0, 0.0, 1.0);
-    st1->set_zrot(0.0);
-    st1->compute_coordinate_rotations();
-    st1->add_element(absorber);
-    // Optional -- to help the user identify things
-    st1->set_name("Stage 1--Absorber");
+    // TODO: Do some post processing tests here
 
-    // Make stage 0 -- this will be the first stage if the runner uses stages
-    auto st0 = make_stage(0);
-    st0->set_origin(0.0, 0.0, 0.0);
-    st0->set_aim_vector(0.0, 0.0, 1.0);
-    st0->set_zrot(0.0);
-    st0->compute_coordinate_rotations();
-    st0->set_name("Stage 0--Reflectors");
+    // const TSystem *sys = runner.get_system();
+    // // auto ray_data = sys->AllRayData;
+    // sys->AllRayData.Print();
+}
 
-    Vector3d rvec, svec, avec;
-    Vector3d aim, pos;
+TEST(TowerDemo, NativeRunnerWithLimbDarkenedSunErrors)
+{
+    SimulationData sd = create_tower_demo_simulation_data(true);
 
-    for (int i = -1; i < 2; ++i)
-    {
-        auto el = make_element<SingleElement>();
-        foptics = el->get_front_optical_properties();
-        foptics->reflectivity = 1.0;
+    // modify the sun to have user defined shape
+    auto sun = sd.get_ray_source();
+    // Limb darkened sun shape
+    sun->set_shape(SunShape::LIMBDARKENED, 0.0, 0.0, 0.0);
 
-        pos.set_values(5 * sin(i * PI / 2.0),
-            5 * cos(i * PI / 2.0),
-            0.0);
-        el->set_origin(pos);
-        vector_add(1.0, absorber->get_origin_global(),
-            -1.0, pos,
-            rvec);
-        make_unit_vector(rvec);
-        svec = sun->get_position();
-        make_unit_vector(svec);
-        vector_add(0.5, rvec, 0.5, svec, avec);
+    NativeRunner runner;
+    RunnerStatus sts = runner.initialize();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Setup runs but is not complete
+    sts = runner.setup_simulation(&sd);
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    // Run simulation runs but returns RunnerStatus::ERROR
+    sts = runner.run_simulation();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
-        vector_add(1.0, pos, 100.0, avec, aim);
-        el->set_aim_vector(aim);
+    // TODO: Do some post processing tests here
 
-        // TODO: Set zrot as in python file?
-        el->set_zrot(30.0 * i);
-        // // Could also be set in radians
-        // el->set_zrot_radians(PI / 3.0 * i);
-        el->compute_coordinate_rotations();
+    // const TSystem *sys = runner.get_system();
+    // // auto ray_data = sys->AllRayData;
+    // sys->AllRayData.Print();
+}
 
-        el->set_surface(make_surface<Flat>());
-        el->set_aperture(make_aperture<Rectangle>(1.0, 1.95));
+TEST(TowerDemo, NativeRunnerWithBuieCsrSunErrors)
+{
+    SimulationData sd = create_tower_demo_simulation_data(true);
 
-        std::stringstream name;
-        name << "Reflector " << i;
-        el->set_name(name.str());
-
-        st0->add_element(el);
-    }
-
-    // Stages must have all elements present before adding to SimulationData!!
-    sd.add_stage(st0);
-    sd.add_stage(st1);
-
-    // Set parameters
-    SimulationParameters& params = sd.get_simulation_parameters();
-    params.number_of_rays = 100000;
-    // params.number_of_rays = 10; // Above takes too long
-    params.max_number_of_rays = params.number_of_rays * 100;
-    params.include_optical_errors = true;
-    params.include_sun_shape_errors = true;
-    params.seed = 12345;
+    // modify the sun to have user defined shape
+    auto sun = sd.get_ray_source();
+    // Buie CSR sun shape
+    sun->set_shape(SunShape::BUIE_CSR, 0.0, 0.0, 0.1);
 
     NativeRunner runner;
     RunnerStatus sts = runner.initialize();


### PR DESCRIPTION
This pull request introduces a new, more robust way to handle sun shape distributions in the simulation codebase. It refactors the previous `DistributionType` usage for sun shapes, replacing it with a dedicated `SunShape` enum, and adds support for additional sun shape models, including the Buie CSR and Limb Darkened model. 

**Sun shape distribution refactor and feature additions:**

* Introduced a new `SunShape` enum to represent sun shape types, replacing the previous use of `DistributionType` for sun sources. This change affects the API for setting and getting sun shapes, and improves clarity and type safety. [[1]](diffhunk://#diff-d0600c276f5815a95ebdb349cf5269c19466f2f02f0cea1139ec09c3ed869315L19-R31) [[2]](diffhunk://#diff-3811459cefdf804c0ddf5818b5ff9c100bd9554b61c873f6a0b82d2e500ffb7fL47-R63)
* Updated the `RaySource` and `Sun` classes to use the new `SunShape` enum, including changes to the `set_shape` and `get_shape` methods and their signatures. [[1]](diffhunk://#diff-d0600c276f5815a95ebdb349cf5269c19466f2f02f0cea1139ec09c3ed869315L35-R44) [[2]](diffhunk://#diff-d0600c276f5815a95ebdb349cf5269c19466f2f02f0cea1139ec09c3ed869315R55-R58) [[3]](diffhunk://#diff-3811459cefdf804c0ddf5818b5ff9c100bd9554b61c873f6a0b82d2e500ffb7fL47-R63)
* Added support for the Buie CSR sun shape model, including validation and calculation of Buie model parameters (`kappa`, `gamma`) in both the `Sun` class and the native runner. [[1]](diffhunk://#diff-639d3b587b75034488b63a9f216477b4a3678244db7efe21c9171d4099e0b419R38-R50) [[2]](diffhunk://#diff-598d94e20a2c2c871fbd4c92acf093f32e324c524809734f3d9d43104c82db52L79-R108)
* Refactored sun shape parsing and initialization in simulation data I/O, adding a dedicated `char_to_sunshape` function and updating sun shape assignment logic. [[1]](diffhunk://#diff-9119309dc173326cca2bdc226d4b15f12c7d83fb7ed0a14103c01c663ade504aR80-R102) [[2]](diffhunk://#diff-9119309dc173326cca2bdc226d4b15f12c7d83fb7ed0a14103c01c663ade504aL269-R300)

**General improvements and code cleanup:**

* Refactored error distribution handling to use `enum class DistributionType`, and updated usages throughout the codebase for improved type safety. [[1]](diffhunk://#diff-bccf5a25379f3e45a534ae2786444c0ba4c45c1a6e414887d4aefb613d86f00cL15-R20) [[2]](diffhunk://#diff-bf04a6fec540c7aea9892fed7488b5ab82149faeeb366856a15d1fa6818cac05L35-R35) [[3]](diffhunk://#diff-9119309dc173326cca2bdc226d4b15f12c7d83fb7ed0a14103c01c663ade504aR65-R68)
* Improved the implementation of surface normal error calculations by removing unused code and simplifying logic. [[1]](diffhunk://#diff-da6f6c418fe88eb3aca3cfaf1d95027e90deea60f5fb9112fd5608870ac48b02R8-L10) [[2]](diffhunk://#diff-da6f6c418fe88eb3aca3cfaf1d95027e90deea60f5fb9112fd5608870ac48b02L30) [[3]](diffhunk://#diff-da6f6c418fe88eb3aca3cfaf1d95027e90deea60f5fb9112fd5608870ac48b02L48-R59) [[4]](diffhunk://#diff-da6f6c418fe88eb3aca3cfaf1d95027e90deea60f5fb9112fd5608870ac48b02L74-L95)

**Simulation runner and data structure updates:**

* Updated simulation runner types and logic to use `SunShape` instead of `DistributionType` for sun shape specification. Added new fields for Buie CSR parameters in simulation data structures. [[1]](diffhunk://#diff-4ca546ed6079a2f775c5907f4d1053c83dfc642295ca18f0e796cc059f4528d3L173-R173) [[2]](diffhunk://#diff-6662ee4e7760660ee41965dd506ee59bb8178b44301792b4c3a7c058e775e6a4L195-R204)
* Updated code to include the new `SunShape` type where relevant, such as in simulation data export and runner initialization.

**Minor corrections and documentation:**

* Added TODO comments and improved documentation in several places to highlight areas for future improvement or implementation. [[1]](diffhunk://#diff-da6f6c418fe88eb3aca3cfaf1d95027e90deea60f5fb9112fd5608870ac48b02R8-L10) [[2]](diffhunk://#diff-9119309dc173326cca2bdc226d4b15f12c7d83fb7ed0a14103c01c663ade504aL269-R300)
