### PR TITLE
74 fix parabola intersection missed case

### DIFF
--- a/coretrace/simulation_data/CMakeLists.txt
+++ b/coretrace/simulation_data/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SIMDATA_SRC
     composite_element.cpp
     element.cpp
     matvec.cpp
+    optical_properties.cpp
     simdata_io.cpp
     simulation_data.cpp
     single_element.cpp
@@ -45,7 +46,7 @@ set(SIMDATA_HDRS
     sun.hpp
     surface.hpp
     vector3d.hpp
-    virtual_element.hpp
+    # virtual_element.hpp
     cst_templates/arclength.hpp
     cst_templates/heliostat.hpp
     cst_templates/linear_fresnel.hpp

--- a/coretrace/simulation_data/aperture.cpp
+++ b/coretrace/simulation_data/aperture.cpp
@@ -43,7 +43,9 @@ aperture_ptr Aperture::make_aperture_from_type(ApertureType type,
         if (args.size() < 3)
             break;
         return make_aperture<Rectangle>(
-            args[1] - args[0], args[2], args[0], 0.5 * args[2]);
+            args[1] - args[0], args[2], 
+            -0.5 * (args[1] - args[0]), -0.5 * args[2]);
+        // return make_aperture<Rectangle>(args[1] - args[0], args[2]);
     case ApertureType::IRREGULAR_TRIANGLE:
         if (args.size() < 6)
             break;
@@ -243,7 +245,7 @@ aperture_ptr Hexagon::make_copy() const
 IrregularTriangle::IrregularTriangle(double x1, double y1,
                                      double x2, double y2,
                                      double x3, double y3)
-    : Aperture(IRREGULAR_TRIANGLE),
+    : Aperture(ApertureType::IRREGULAR_TRIANGLE),
       x1(x1), y1(y1),
       x2(x2), y2(y2),
       x3(x3), y3(y3)
@@ -293,7 +295,7 @@ IrregularQuadrilateral::IrregularQuadrilateral(double x1, double y1,
                                                double x2, double y2,
                                                double x3, double y3,
                                                double x4, double y4)
-    : Aperture(IRREGULAR_QUADRILATERAL),
+    : Aperture(ApertureType::IRREGULAR_QUADRILATERAL),
       x1(x1), y1(y1),
       x2(x2), y2(y2),
       x3(x3), y3(y3),
@@ -348,7 +350,7 @@ aperture_ptr IrregularQuadrilateral::make_copy() const
 }
 
 Rectangle::Rectangle(double xlen, double ylen)
-    : Aperture(RECTANGLE),
+    : Aperture(ApertureType::RECTANGLE),
       x_length(xlen),
       y_length(ylen)
 {
@@ -384,7 +386,7 @@ bool Rectangle::is_in(double x, double y) const
 }
 
 Rectangle::Rectangle(double xlen, double ylen, double xl, double yl)
-    : Aperture(RECTANGLE),
+    : Aperture(ApertureType::RECTANGLE),
       x_length(xlen),
       y_length(ylen),
       x_coord(xl),

--- a/coretrace/simulation_data/aperture.hpp
+++ b/coretrace/simulation_data/aperture.hpp
@@ -140,8 +140,10 @@ namespace SolTrace::Data
          * @param arc Arc angle in radians (2*pi for full annulus)
          */
         Annulus(double ri, double ro, double arc)
-            : Aperture(ANNULUS),
-              inner_radius(ri), outer_radius(ro), arc_angle(arc)
+            : Aperture(ApertureType::ANNULUS),
+              inner_radius(ri),
+              outer_radius(ro),
+              arc_angle(arc)
         {
         }
         virtual ~Annulus() {}
@@ -183,7 +185,7 @@ namespace SolTrace::Data
          * @brief Constructor for circular aperture
          * @param d Diameter of the circle
          */
-        Circle(double d) : Aperture(CIRCLE), diameter(d) {}
+        Circle(double d) : Aperture(ApertureType::CIRCLE), diameter(d) {}
         virtual ~Circle() {}
 
         /**
@@ -225,8 +227,9 @@ namespace SolTrace::Data
          * @brief Constructor for equilateral triangle aperture
          * @param cd Diameter of circumscribed circle
          */
-        EqualateralTriangle(double cd) : Aperture(EQUILATERAL_TRIANGLE),
-                                         circumscribe_diameter(cd)
+        EqualateralTriangle(double cd)
+            : Aperture(ApertureType::EQUILATERAL_TRIANGLE),
+              circumscribe_diameter(cd)
         {
         }
         virtual ~EqualateralTriangle() {}
@@ -268,7 +271,9 @@ namespace SolTrace::Data
          * @brief Constructor for hexagonal aperture
          * @param d Diameter of circumscribed circle
          */
-        Hexagon(double d) : Aperture(HEXAGON), circumscribe_diameter(d) {}
+        Hexagon(double d)
+            : Aperture(ApertureType::HEXAGON),
+              circumscribe_diameter(d) {}
         virtual ~Hexagon() {}
 
         /**

--- a/coretrace/simulation_data/composite_element.cpp
+++ b/coretrace/simulation_data/composite_element.cpp
@@ -3,132 +3,157 @@
 
 #include <sstream>
 
-namespace SolTrace::Data {
-
-CompositeElement::CompositeElement() : ElementBase(),
-                                       number_of_elements(0),
-                                       my_elements()
+namespace SolTrace::Data
 {
-    return;
-}
 
-CompositeElement::~CompositeElement()
-{
-    this->clear();
-    return;
-}
-
-void CompositeElement::disable() const
-{
-    this->active = false;
-    for (auto iter = this->get_const_iterator();
-         !this->is_at_end(iter);
-         ++iter)
+    CompositeElement::CompositeElement() : ElementBase(),
+                                           number_of_elements(0),
+                                           my_elements()
     {
-        iter->second->disable();
-    }
-    return;
-}
-
-void CompositeElement::enable() const
-{
-    this->active = true;
-    for (auto iter = this->get_const_iterator();
-         !this->is_at_end(iter);
-         ++iter)
-    {
-        iter->second->enable();
-    }
-    return;
-}
-
-void CompositeElement::set_stage(int_fast64_t stage)
-{
-    this->stage = stage;
-    for (auto iter = this->get_iterator(); !this->is_at_end(iter); ++iter)
-    {
-        iter->second->set_stage(stage);
-    }
-    return;
-}
-
-element_id CompositeElement::add_element(element_ptr el)
-{
-    // Cannot nest a StageElement in another CompositeElement
-    // assert(!el->is_stage());
-    // Disable adding CompositeElements unless `this` is a StageElement
-    // assert(this->is_stage() || el->is_single());
-
-    if (el->is_stage() ||
-        (el->is_composite() && !this->is_stage()))
-    {
-        return ELEMENT_INVALID_SETUP;
+        return;
     }
 
-    el->enforce_user_fields_set();
-
-    element_id id = this->my_elements.add_item(el);
-    if (is_success(id))
+    CompositeElement::~CompositeElement()
     {
-        this->number_of_elements += el->get_number_of_elements();
-        el->set_reference_element(this);
-    }
-    return id;
-}
-
-uint_fast64_t CompositeElement::remove_element(element_id id)
-{
-    element_ptr el = this->my_elements.get_item(id);
-    uint_fast64_t nremoved = this->my_elements.remove_item(id);
-
-    if (nremoved > 0)
-    {
-        nremoved = el->get_number_of_elements();
-        this->number_of_elements -= nremoved;
+        this->clear();
+        return;
     }
 
-    return nremoved;
-}
-
-element_ptr CompositeElement::get_element(element_id id)
-{
-    return this->my_elements.get_item(id);
-}
-
-bool CompositeElement::replace_element(element_id id, element_ptr el)
-{
-    element_ptr old_el = this->my_elements.get_item(id);
-    bool replaced = this->my_elements.replace_item(id, el);
-
-    if (replaced)
+    void CompositeElement::disable() const
     {
-        this->number_of_elements -= old_el->get_number_of_elements();
-        this->number_of_elements += el->get_number_of_elements();
+        this->active = false;
+        for (auto iter = this->get_const_iterator();
+             !this->is_at_end(iter);
+             ++iter)
+        {
+            iter->second->disable();
+        }
+        return;
     }
 
-    return replaced;
-}
-
-void CompositeElement::clear()
-{
-    this->number_of_elements = 0;
-    this->my_elements.clear();
-    return;
-}
-
-void CompositeElement::enforce_user_fields_set() const
-{
-    ElementBase::enforce_user_fields_set();
-
-    if (this->number_of_elements == 0)
+    void CompositeElement::enable() const
     {
-        std::stringstream ss;
-        ss << "CompositeElement (Name: " << this->get_name()
-           << ", UUID: " << this->get_id()
-           << ") has no subelements.";
-        throw std::invalid_argument(ss.str());
+        this->active = true;
+        for (auto iter = this->get_const_iterator();
+             !this->is_at_end(iter);
+             ++iter)
+        {
+            iter->second->enable();
+        }
+        return;
     }
-    return;
-}
+
+    void CompositeElement::mark_virtual() const
+    {
+        this->ElementBase::mark_virtual();
+        for (auto iter = this->get_const_iterator();
+             !this->is_at_end(iter);
+             ++iter)
+        {
+            iter->second->mark_virtual();
+        }
+        return;
+    }
+
+    void CompositeElement::unmark_virtual() const
+    {
+        this->ElementBase::unmark_virtual();
+        for (auto iter = this->get_const_iterator();
+             !this->is_at_end(iter);
+             ++iter)
+        {
+            iter->second->unmark_virtual();
+        }
+        return;
+    }
+
+    void CompositeElement::set_stage(int_fast64_t stage)
+    {
+        this->stage = stage;
+        for (auto iter = this->get_iterator(); !this->is_at_end(iter); ++iter)
+        {
+            iter->second->set_stage(stage);
+        }
+        return;
+    }
+
+    element_id CompositeElement::add_element(element_ptr el)
+    {
+        // Cannot nest a StageElement in another CompositeElement
+        // assert(!el->is_stage());
+        // Disable adding CompositeElements unless `this` is a StageElement
+        // assert(this->is_stage() || el->is_single());
+
+        if (el->is_stage() ||
+            (el->is_composite() && !this->is_stage()))
+        {
+            return ELEMENT_INVALID_SETUP;
+        }
+
+        el->enforce_user_fields_set();
+
+        element_id id = this->my_elements.add_item(el);
+        if (is_success(id))
+        {
+            this->number_of_elements += el->get_number_of_elements();
+            el->set_reference_element(this);
+        }
+        return id;
+    }
+
+    uint_fast64_t CompositeElement::remove_element(element_id id)
+    {
+        element_ptr el = this->my_elements.get_item(id);
+        uint_fast64_t nremoved = this->my_elements.remove_item(id);
+
+        if (nremoved > 0)
+        {
+            nremoved = el->get_number_of_elements();
+            this->number_of_elements -= nremoved;
+        }
+
+        return nremoved;
+    }
+
+    element_ptr CompositeElement::get_element(element_id id)
+    {
+        return this->my_elements.get_item(id);
+    }
+
+    bool CompositeElement::replace_element(element_id id, element_ptr el)
+    {
+        element_ptr old_el = this->my_elements.get_item(id);
+        bool replaced = this->my_elements.replace_item(id, el);
+
+        if (replaced)
+        {
+            this->number_of_elements -= old_el->get_number_of_elements();
+            this->number_of_elements += el->get_number_of_elements();
+        }
+
+        return replaced;
+    }
+
+    void CompositeElement::clear()
+    {
+        this->number_of_elements = 0;
+        this->my_elements.clear();
+        return;
+    }
+
+    void CompositeElement::enforce_user_fields_set() const
+    {
+        ElementBase::enforce_user_fields_set();
+
+        if (this->number_of_elements == 0)
+        {
+            std::stringstream ss;
+            ss << "CompositeElement (Name: " << this->get_name()
+               << ", UUID: " << this->get_id()
+               << ") has no subelements.";
+            throw std::invalid_argument(ss.str());
+        }
+        return;
+    }
 
 } // namespace SolTrace::Data

--- a/coretrace/simulation_data/composite_element.hpp
+++ b/coretrace/simulation_data/composite_element.hpp
@@ -19,206 +19,210 @@
 #include "container.hpp"
 #include "element.hpp"
 
-namespace SolTrace::Data {
-
-class CompositeElement : public ElementBase
+namespace SolTrace::Data
 {
-public:
-    /**
-     * @brief Default constructor for composite element
-     */
-    CompositeElement();
-    virtual ~CompositeElement();
 
-    /**
-     * @brief Disable this composite element and all sub-elements
-     */
-    virtual void disable() const override;
-
-    /**
-     * @brief Enable this composite element and all sub-elements
-     */
-    virtual void enable() const override;
-
-    /**
-     * @brief Check if this element is composite
-     * @return Always returns true for composite elements
-     */
-    virtual bool is_composite() const override
+    class CompositeElement : public ElementBase
     {
-        return true;
-    }
+    public:
+        /**
+         * @brief Default constructor for composite element
+         */
+        CompositeElement();
+        virtual ~CompositeElement();
 
-    /**
-     * @brief Set the stage number for this composite element
-     * @param stage Stage number to assign
-     */
-    virtual void set_stage(int_fast64_t stage) override;
+        /**
+         * @brief Disable this composite element and all sub-elements
+         */
+        virtual void disable() const override;
 
-    /**
-     * @brief Get the number of sub-elements in this composite
-     * @return Number of elements contained in this composite
-     */
-    virtual uint_fast64_t get_number_of_elements() const override
-    {
-        // return this->my_elements.get_number_of_items();
-        return this->number_of_elements;
-    }
+        /**
+         * @brief Enable this composite element and all sub-elements
+         */
+        virtual void enable() const override;
 
-    // Element interface functions
-    /**
-     * @brief Get aperture pointer (always null for composite elements)
-     * @return nullptr (composite elements don't have apertures)
-     */
-    virtual const aperture_ptr get_aperture() const override { return nullptr; }
+        /**
+         * @brief Check if this element is composite
+         * @return Always returns true for composite elements
+         */
+        virtual bool is_composite() const override
+        {
+            return true;
+        }
 
-    /**
-     * @brief Get aperture pointer (always null for composite elements)
-     * @return nullptr (composite elements don't have apertures)
-     */
-    virtual aperture_ptr get_aperture() override { return nullptr; }
+        virtual void mark_virtual() const override;
+        virtual void unmark_virtual() const override;
 
-    /**
-     * @brief Set aperture (no-op for composite elements)
-     * @param aperture_ptr Ignored for composite elements
-     */
-    virtual void set_aperture(aperture_ptr) override {}
+        /**
+         * @brief Set the stage number for this composite element
+         * @param stage Stage number to assign
+         */
+        virtual void set_stage(int_fast64_t stage) override;
 
-    /**
-     * @brief Get surface pointer (always null for composite elements)
-     * @return nullptr (composite elements don't have surfaces)
-     */
-    virtual const surface_ptr get_surface() const override { return nullptr; }
+        /**
+         * @brief Get the number of sub-elements in this composite
+         * @return Number of elements contained in this composite
+         */
+        virtual uint_fast64_t get_number_of_elements() const override
+        {
+            // return this->my_elements.get_number_of_items();
+            return this->number_of_elements;
+        }
 
-    /**
-     * @brief Get surface pointer (always null for composite elements)
-     * @return nullptr (composite elements don't have surfaces)
-     */
-    virtual surface_ptr get_surface() override { return nullptr; }
+        // Element interface functions
+        /**
+         * @brief Get aperture pointer (always null for composite elements)
+         * @return nullptr (composite elements don't have apertures)
+         */
+        virtual const aperture_ptr get_aperture() const override { return nullptr; }
 
-    /**
-     * @brief Set surface (no-op for composite elements)
-     * @param surface_ptr Ignored for composite elements
-     */
-    virtual void set_surface(surface_ptr) override {}
+        /**
+         * @brief Get aperture pointer (always null for composite elements)
+         * @return nullptr (composite elements don't have apertures)
+         */
+        virtual aperture_ptr get_aperture() override { return nullptr; }
 
-    /**
-     * @brief Get front optical properties (always null for composite elements)
-     * @return nullptr (composite elements don't have optical properties)
-     */
-    virtual const OpticalProperties *get_front_optical_properties() const override
-    {
-        return nullptr;
-    }
+        /**
+         * @brief Set aperture (no-op for composite elements)
+         * @param aperture_ptr Ignored for composite elements
+         */
+        virtual void set_aperture(aperture_ptr) override {}
 
-    /**
-     * @brief Get front optical properties (always null for composite elements)
-     * @return nullptr (composite elements don't have optical properties)
-     */
-    virtual OpticalProperties *get_front_optical_properties() override
-    {
-        return nullptr;
-    }
+        /**
+         * @brief Get surface pointer (always null for composite elements)
+         * @return nullptr (composite elements don't have surfaces)
+         */
+        virtual const surface_ptr get_surface() const override { return nullptr; }
 
-    /**
-     * @brief Set front optical properties (no-op for composite elements)
-     * @param op Ignored for composite elements
-     */
-    virtual void set_front_optical_properties(const OpticalProperties &) override {}
+        /**
+         * @brief Get surface pointer (always null for composite elements)
+         * @return nullptr (composite elements don't have surfaces)
+         */
+        virtual surface_ptr get_surface() override { return nullptr; }
 
-    /**
-     * @brief Get back optical properties (always null for composite elements)
-     * @return nullptr (composite elements don't have optical properties)
-     */
-    virtual const OpticalProperties *get_back_optical_properties() const override
-    {
-        return nullptr;
-    }
+        /**
+         * @brief Set surface (no-op for composite elements)
+         * @param surface_ptr Ignored for composite elements
+         */
+        virtual void set_surface(surface_ptr) override {}
 
-    /**
-     * @brief Get back optical properties (always null for composite elements)
-     * @return nullptr (composite elements don't have optical properties)
-     */
-    virtual OpticalProperties *get_back_optical_properties() override
-    {
-        return nullptr;
-    }
+        /**
+         * @brief Get front optical properties (always null for composite elements)
+         * @return nullptr (composite elements don't have optical properties)
+         */
+        virtual const OpticalProperties *get_front_optical_properties() const override
+        {
+            return nullptr;
+        }
 
-    /**
-     * @brief Set back optical properties (no-op for composite elements)
-     * @param op Ignored for composite elements
-     */
-    virtual void set_back_optical_properties(const OpticalProperties &) override {};
+        /**
+         * @brief Get front optical properties (always null for composite elements)
+         * @return nullptr (composite elements don't have optical properties)
+         */
+        virtual OpticalProperties *get_front_optical_properties() override
+        {
+            return nullptr;
+        }
 
-    // CompositeElement accessors
-    /**
-     * @brief Add an element to this composite
-     * @param el Shared pointer to element to add
-     * @return Element ID of the added element
-     */
-    element_id add_element(element_ptr el);
+        /**
+         * @brief Set front optical properties (no-op for composite elements)
+         * @param op Ignored for composite elements
+         */
+        virtual void set_front_optical_properties(const OpticalProperties &) override {}
 
-    /**
-     * @brief Remove an element from this composite
-     * @param id Element ID to remove
-     * @return Number of elements removed (0 or 1)
-     */
-    uint_fast64_t remove_element(element_id id);
+        /**
+         * @brief Get back optical properties (always null for composite elements)
+         * @return nullptr (composite elements don't have optical properties)
+         */
+        virtual const OpticalProperties *get_back_optical_properties() const override
+        {
+            return nullptr;
+        }
 
-    /**
-     * @brief Get an element by ID
-     * @param id Element ID to retrieve
-     * @return Shared pointer to element, or null if not found
-     */
-    element_ptr get_element(element_id id);
+        /**
+         * @brief Get back optical properties (always null for composite elements)
+         * @return nullptr (composite elements don't have optical properties)
+         */
+        virtual OpticalProperties *get_back_optical_properties() override
+        {
+            return nullptr;
+        }
 
-    /**
-     * @brief Replace an element with a new one
-     * @param id Element ID to replace
-     * @param el New element to insert
-     * @return True if replacement was successful
-     */
-    bool replace_element(element_id id, element_ptr el);
+        /**
+         * @brief Set back optical properties (no-op for composite elements)
+         * @param op Ignored for composite elements
+         */
+        virtual void set_back_optical_properties(const OpticalProperties &) override {};
 
-    /**
-     * @brief Remove all elements from this composite
-     */
-    void clear();
+        // CompositeElement accessors
+        /**
+         * @brief Add an element to this composite
+         * @param el Shared pointer to element to add
+         * @return Element ID of the added element
+         */
+        element_id add_element(element_ptr el);
 
-    // uint64_t get_total_number_of_elements() const
-    // {
-    //     return this->my_elements.get_total_number_of_items();
-    // }
+        /**
+         * @brief Remove an element from this composite
+         * @param id Element ID to remove
+         * @return Number of elements removed (0 or 1)
+         */
+        uint_fast64_t remove_element(element_id id);
 
-    /**
-     * @brief Get iterator to beginning of element container
-     * @return Iterator to first element
-     */
-    virtual ElementContainer::iterator get_iterator()
-    {
-        return this->my_elements.get_iterator();
-    }
-    virtual ElementContainer::const_iterator get_const_iterator() const
-    {
-        return this->my_elements.get_const_iterator();
-    }
-    virtual bool is_at_end(ElementContainer::iterator iter)
-    {
-        return this->my_elements.is_at_end(iter);
-    }
-    virtual bool is_at_end(ElementContainer::const_iterator citer) const
-    {
-        return this->my_elements.is_at_end(citer);
-    }
+        /**
+         * @brief Get an element by ID
+         * @param id Element ID to retrieve
+         * @return Shared pointer to element, or null if not found
+         */
+        element_ptr get_element(element_id id);
 
-    virtual void enforce_user_fields_set() const override;
+        /**
+         * @brief Replace an element with a new one
+         * @param id Element ID to replace
+         * @param el New element to insert
+         * @return True if replacement was successful
+         */
+        bool replace_element(element_id id, element_ptr el);
 
-private:
-    uint_fast64_t number_of_elements;
-    ElementContainer my_elements;
-};
+        /**
+         * @brief Remove all elements from this composite
+         */
+        void clear();
 
-using composite_element_ptr = std::shared_ptr<CompositeElement>;
+        // uint64_t get_total_number_of_elements() const
+        // {
+        //     return this->my_elements.get_total_number_of_items();
+        // }
+
+        /**
+         * @brief Get iterator to beginning of element container
+         * @return Iterator to first element
+         */
+        virtual ElementContainer::iterator get_iterator()
+        {
+            return this->my_elements.get_iterator();
+        }
+        virtual ElementContainer::const_iterator get_const_iterator() const
+        {
+            return this->my_elements.get_const_iterator();
+        }
+        virtual bool is_at_end(ElementContainer::iterator iter)
+        {
+            return this->my_elements.is_at_end(iter);
+        }
+        virtual bool is_at_end(ElementContainer::const_iterator citer) const
+        {
+            return this->my_elements.is_at_end(citer);
+        }
+
+        virtual void enforce_user_fields_set() const override;
+
+    private:
+        uint_fast64_t number_of_elements;
+        ElementContainer my_elements;
+    };
+
+    using composite_element_ptr = std::shared_ptr<CompositeElement>;
 
 } // namespace SolTrace::Data
 
@@ -227,4 +231,3 @@ using composite_element_ptr = std::shared_ptr<CompositeElement>;
 /**
  * @}
  */
-

--- a/coretrace/simulation_data/cst_templates/linear_fresnel.cpp
+++ b/coretrace/simulation_data/cst_templates/linear_fresnel.cpp
@@ -10,619 +10,629 @@
 
 #include "cst_templates/utilities.hpp"
 
-namespace SolTrace::Data {
-
-LinearFresnel::LinearFresnel()
-    : CompositeElement(),
-      initialized(false),
-      receiver_height(-1.0),
-      azimuth(-1.0),
-      tilt(-1.0),
-      focused_panels(false),
-      aperture_size_x(-1.0),
-      aperture_size_y(-1.0),
-      num_panels_x(-1),
-      num_panels_y(-1),
-      gap_x(-1.0),
-      gap_y(-1.0),
-      gap_center(-1.0),
-      abs_diameter(-1.0),
-      env_diameter(-1.0),
-      env_thickness(-1.0),
-      // tracking_angle(0.0),
-      tracking_limit_lower(-180.0),
-      tracking_limit_upper(180.0)
+namespace SolTrace::Data
 {
-    this->optics_absorber.set_ideal_absorption();
-    this->optics_mirror.set_ideal_reflection();
-    this->optics_env_out.set_ideal_transmission();
-    this->optics_env_in.set_ideal_transmission();
 
-    this->tracking_origin.set_values(1.0, 0.0, 0.0);
-    this->rotation_axis.set_values(0.0, 1.0, 0.0);
-    this->neutral_normal.set_values(0.0, 0.0, 1.0);
-}
-
-LinearFresnel::~LinearFresnel()
-{
-    // Clear vectors
-    this->mirrors.clear();
-    this->absorbers.clear();
-    this->envelope.clear();
-
-    return;
-}
-
-// double LinearFresnel::get_tracking_angle_degrees() const
-// {
-//     return this->tracking_angle;
-// }
-
-// double LinearFresnel::get_tracking_angle_radians() const
-// {
-//     return D2R * this->get_tracking_angle_degrees();
-// }
-
-void LinearFresnel::set_angles(double azimuth, double tilt)
-{
-    if (azimuth < -180.0 || azimuth > 180.0)
+    LinearFresnel::LinearFresnel()
+        : CompositeElement(),
+          initialized(false),
+          receiver_height(-1.0),
+          azimuth(-1.0),
+          tilt(-1.0),
+          focused_panels(false),
+          aperture_size_x(-1.0),
+          aperture_size_y(-1.0),
+          num_panels_x(-1),
+          num_panels_y(-1),
+          gap_x(-1.0),
+          gap_y(-1.0),
+          gap_center(-1.0),
+          abs_diameter(-1.0),
+          env_diameter(-1.0),
+          env_thickness(-1.0),
+          // tracking_angle(0.0),
+          tracking_limit_lower(-180.0),
+          tracking_limit_upper(180.0)
     {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_angles: Invalid azimuth angle ("
-           << azimuth << "). Must be between -180 and 180 degrees.";
-        throw std::invalid_argument(ss.str());
+        this->optics_absorber.set_ideal_absorption();
+        this->optics_mirror.set_ideal_reflection();
+        this->optics_env_out.set_ideal_transmission();
+        this->optics_env_in.set_ideal_transmission();
+
+        this->tracking_origin.set_values(1.0, 0.0, 0.0);
+        this->rotation_axis.set_values(0.0, 1.0, 0.0);
+        this->neutral_normal.set_values(0.0, 0.0, 1.0);
     }
 
-    if (tilt < 0.0 || tilt > 90.0)
+    LinearFresnel::~LinearFresnel()
     {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_angles: Invalid tilt angle ("
-           << tilt << "). Must be between 0 and 90 degrees.";
-        throw std::invalid_argument(ss.str());
-    }
+        // Clear vectors
+        this->mirrors.clear();
+        this->absorbers.clear();
+        this->envelope.clear();
 
-    this->coordinates_initialized = false;
-    this->azimuth = azimuth;
-    this->tilt = tilt;
-
-    // Convert input angles to spherical coordinate angles
-    double az = azimuth * D2R;
-    double el = tilt * D2R;
-    double pol = 0.5 * PI - az;
-    double inc = 0.5 * PI - el;
-
-    // Convert spherical coordinates to cartesian coordinates
-    // y-axis
-    this->rotation_axis.set_values(sin(inc) * cos(pol),
-                                   sin(inc) * sin(pol),
-                                   cos(inc));
-
-    // z-axis
-    this->neutral_normal.set_values(sin(-el) * cos(pol),
-                                    sin(-el) * sin(pol),
-                                    cos(-el));
-
-    cross_product(this->rotation_axis,
-                  this->neutral_normal,
-                  this->tracking_origin);
-
-    return;
-}
-
-void LinearFresnel::set_aperture_size(double len_x, double len_y)
-{
-    if (len_x <= 0.0 || len_y <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_aperture_size: Invalid aperture dimensions. "
-           << "len_x (" << len_x << ") and len_y (" << len_y
-           << ") must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->aperture_size_x = len_x;
-    this->aperture_size_y = len_y;
-
-    return;
-}
-
-void LinearFresnel::set_focused_panels(bool focused)
-{
-    this->initialized = false;
-    this->focused_panels = focused;
-    return;
-}
-
-void LinearFresnel::set_gaps(double gap_x,
-                             double gap_y,
-                             double gap_center)
-{
-    if (gap_x < 0.0 || gap_y < 0.0 || gap_center < 0.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_gaps: Invalid gap dimensions. "
-           << "gap_x (" << gap_x << "), gap_y (" << gap_y
-           << "), and gap_center (" << gap_center
-           << ") must be non-negative.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->gap_x = gap_x;
-    this->gap_y = gap_y;
-    this->gap_center = gap_center;
-
-    return;
-}
-
-void LinearFresnel::set_number_panels(int_fast64_t num_x,
-                                      int_fast64_t num_y)
-{
-    if (num_x <= 0 || num_y <= 0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_number_panels: Invalid panel count. "
-           << "num_x (" << num_x << ") and num_y (" << num_y
-           << ") must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->num_panels_x = num_x;
-    this->num_panels_y = num_y;
-
-    return;
-}
-
-void LinearFresnel::set_optics(const OpticalProperties &mirror,
-                               const OpticalProperties &absorber,
-                               const OpticalProperties &envelop_outer,
-                               const OpticalProperties &envelop_inner)
-{
-    this->optics_mirror = mirror;
-    this->optics_absorber = absorber;
-    this->optics_env_out = envelop_outer;
-    this->optics_env_in = envelop_inner;
-    return;
-}
-
-void LinearFresnel::set_receiver_height(double height)
-{
-    if (height <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_receiver_height: Invalid receiver height ("
-           << height << "). Height must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->receiver_height = height;
-
-    return;
-}
-
-void LinearFresnel::set_receiver_dimensions(double absorber_diameter,
-                                            double envelop_diameter,
-                                            double envelop_thickness)
-{
-    if (absorber_diameter <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_receiver_dimensions: "
-           << "Invalid absorber diameter (" << absorber_diameter
-           << "). Must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (envelop_diameter <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_receiver_dimensions: "
-           << "Invalid envelope diameter (" << envelop_diameter
-           << "). Must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (envelop_thickness < 0.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_receiver_dimensions: "
-           << "Invalid envelope thickness (" << envelop_thickness
-           << "). Must be non-negative.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (absorber_diameter >= envelop_diameter)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::set_receiver_dimensions: "
-           << "Absorber diameter (" << absorber_diameter
-           << ") must be smaller than envelope diameter ("
-           << envelop_diameter << ").";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->abs_diameter = absorber_diameter;
-    this->env_diameter = envelop_diameter;
-    this->env_thickness = envelop_thickness;
-
-    return;
-}
-
-void LinearFresnel::set_tracking_limits(double lower, double upper)
-{
-    if (lower > upper)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_tracking_limits: Invalid tracking "
-           << "limits. Lower limit (" << lower
-           << ") must be less than or equal to upper limit ("
-           << upper << ").";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->tracking_limit_lower = lower;
-    this->tracking_limit_upper = upper;
-
-    return;
-}
-
-void LinearFresnel::create_geometry()
-{
-    if (this->initialized)
-    {
         return;
     }
 
-    this->enforce_user_fields_set();
+    // double LinearFresnel::get_tracking_angle_degrees() const
+    // {
+    //     return this->tracking_angle;
+    // }
 
-    this->mirrors.clear();
-    this->absorbers.clear();
-    this->envelope.clear();
-    this->clear();
+    // double LinearFresnel::get_tracking_angle_radians() const
+    // {
+    //     return D2R * this->get_tracking_angle_degrees();
+    // }
 
-    // Create mirrors
-    if (this->num_panels_x == 1 && this->gap_center != 0.0)
+    void LinearFresnel::set_angles(double azimuth, double tilt)
     {
-        // TODO: This should generate a warning.
-        this->gap_center = 0.0;
-        this->gap_x = 0.0;
+        if (azimuth < -180.0 || azimuth > 180.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_angles: Invalid azimuth angle ("
+               << azimuth << "). Must be between -180 and 180 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (tilt < 0.0 || tilt > 90.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_angles: Invalid tilt angle ("
+               << tilt << "). Must be between 0 and 90 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->coordinates_initialized = false;
+        this->azimuth = azimuth;
+        this->tilt = tilt;
+
+        // Convert input angles to spherical coordinate angles
+        double az = azimuth * D2R;
+        double el = tilt * D2R;
+        double pol = 0.5 * PI - az;
+        double inc = 0.5 * PI - el;
+
+        // Convert spherical coordinates to cartesian coordinates
+        // y-axis
+        this->rotation_axis.set_values(sin(inc) * cos(pol),
+                                       sin(inc) * sin(pol),
+                                       cos(inc));
+
+        // z-axis
+        this->neutral_normal.set_values(sin(-el) * cos(pol),
+                                        sin(-el) * sin(pol),
+                                        cos(-el));
+
+        cross_product(this->rotation_axis,
+                      this->neutral_normal,
+                      this->tracking_origin);
+
+        return;
     }
 
-    double panel_len_x = this->aperture_size_x -
-                         this->gap_x * (this->num_panels_x - 1);
-    panel_len_x -= this->gap_center - this->gap_x;
-    panel_len_x /= this->num_panels_x;
-    double panel_x = -0.5 * this->aperture_size_x + 0.5 * panel_len_x;
-
-    double panel_len_y = this->aperture_size_y -
-                         this->gap_y * (this->num_panels_y - 1);
-    panel_len_y /= this->num_panels_y;
-
-    element_id sts;
-    Vector3d origin;
-    Vector3d aim;
-    // TODO: Should mirrors aim at the receiver center or origin?
-    Vector3d receiver_pos(0.0,
-                          0.0,
-                          this->receiver_height - 0.5 * this->abs_diameter);
-    double panel_y, flen;
-    single_element_ptr mirror;
-    aperture_ptr ap;
-    surface_ptr surf;
-    Vector3d khat(0.0, 0.0, 1.0);
-
-    for (int_fast64_t i = 0; i < this->num_panels_x; ++i)
+    void LinearFresnel::set_aperture_size(double len_x, double len_y)
     {
-        panel_y = -0.5 * this->aperture_size_y + 0.5 * panel_len_y;
-        for (int_fast64_t j = 0; j < this->num_panels_y; ++j)
+        if (len_x <= 0.0 || len_y <= 0.0)
         {
-            mirror = make_element<SingleElement>();
+            std::stringstream ss;
+            ss << "LinearFresnel::set_aperture_size: Invalid aperture dimensions. "
+               << "len_x (" << len_x << ") and len_y (" << len_y
+               << ") must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
 
-            origin.set_values(panel_x, panel_y, 0.0);
-            vector_add(1.0, receiver_pos, -1.0, origin, aim);
-            make_unit_vector(aim);
-            vector_add(0.5, khat, 0.5, aim);
-            vector_add(1.0, origin, 1.0, aim);
-            make_unit_vector(aim);
-            aim.scalar_mult(1000.0);
-            mirror->set_reference_frame_geometry(origin, aim, 0.0);
+        this->initialized = false;
+        this->aperture_size_x = len_x;
+        this->aperture_size_y = len_y;
 
-            ap = make_aperture<Rectangle>(panel_len_x, panel_len_y);
-            mirror->set_aperture(ap);
+        return;
+    }
 
-            if (this->focused_panels)
+    void LinearFresnel::set_focused_panels(bool focused)
+    {
+        this->initialized = false;
+        this->focused_panels = focused;
+        return;
+    }
+
+    void LinearFresnel::set_gaps(double gap_x,
+                                 double gap_y,
+                                 double gap_center)
+    {
+        if (gap_x < 0.0 || gap_y < 0.0 || gap_center < 0.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_gaps: Invalid gap dimensions. "
+               << "gap_x (" << gap_x << "), gap_y (" << gap_y
+               << "), and gap_center (" << gap_center
+               << ") must be non-negative.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->gap_x = gap_x;
+        this->gap_y = gap_y;
+        this->gap_center = gap_center;
+
+        return;
+    }
+
+    void LinearFresnel::set_number_panels(int_fast64_t num_x,
+                                          int_fast64_t num_y)
+    {
+        if (num_x <= 0 || num_y <= 0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_number_panels: Invalid panel count. "
+               << "num_x (" << num_x << ") and num_y (" << num_y
+               << ") must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->num_panels_x = num_x;
+        this->num_panels_y = num_y;
+
+        return;
+    }
+
+    void LinearFresnel::set_optics(const OpticalProperties &mirror,
+                                   const OpticalProperties &absorber,
+                                   const OpticalProperties &envelop_outer,
+                                   const OpticalProperties &envelop_inner)
+    {
+        this->optics_mirror = mirror;
+        this->optics_absorber = absorber;
+        this->optics_env_out = envelop_outer;
+        this->optics_env_in = envelop_inner;
+        return;
+    }
+
+    void LinearFresnel::set_receiver_height(double height)
+    {
+        if (height <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_receiver_height: Invalid receiver height ("
+               << height << "). Height must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->receiver_height = height;
+
+        return;
+    }
+
+    void LinearFresnel::set_receiver_dimensions(double absorber_diameter,
+                                                double envelop_diameter,
+                                                double envelop_thickness)
+    {
+        if (absorber_diameter <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_receiver_dimensions: "
+               << "Invalid absorber diameter (" << absorber_diameter
+               << "). Must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (envelop_diameter <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_receiver_dimensions: "
+               << "Invalid envelope diameter (" << envelop_diameter
+               << "). Must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (envelop_thickness < 0.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_receiver_dimensions: "
+               << "Invalid envelope thickness (" << envelop_thickness
+               << "). Must be non-negative.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (absorber_diameter >= envelop_diameter)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::set_receiver_dimensions: "
+               << "Absorber diameter (" << absorber_diameter
+               << ") must be smaller than envelope diameter ("
+               << envelop_diameter << ").";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->abs_diameter = absorber_diameter;
+        this->env_diameter = envelop_diameter;
+        this->env_thickness = envelop_thickness;
+
+        return;
+    }
+
+    void LinearFresnel::set_tracking_limits(double lower, double upper)
+    {
+        if (lower > upper)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_tracking_limits: Invalid tracking "
+               << "limits. Lower limit (" << lower
+               << ") must be less than or equal to upper limit ("
+               << upper << ").";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->tracking_limit_lower = lower;
+        this->tracking_limit_upper = upper;
+
+        return;
+    }
+
+    void LinearFresnel::create_geometry()
+    {
+        if (this->initialized)
+        {
+            return;
+        }
+
+        // TODO: Does receiver height give the height to the center or bottom edge?
+        // Currently assumes it is the center.
+
+        this->enforce_user_fields_set();
+
+        this->mirrors.clear();
+        this->absorbers.clear();
+        this->envelope.clear();
+        this->clear();
+
+        // Create mirrors
+        if (this->num_panels_x == 1 && this->gap_center != 0.0)
+        {
+            // TODO: This should generate a warning.
+            this->gap_center = 0.0;
+            this->gap_x = 0.0;
+        }
+
+        double panel_len_x = this->aperture_size_x -
+                             this->gap_x * (this->num_panels_x - 1);
+        panel_len_x -= this->gap_center - this->gap_x;
+        panel_len_x /= this->num_panels_x;
+        double panel_x = -0.5 * this->aperture_size_x + 0.5 * panel_len_x;
+
+        double panel_len_y = this->aperture_size_y -
+                             this->gap_y * (this->num_panels_y - 1);
+        panel_len_y /= this->num_panels_y;
+
+        element_id sts;
+        Vector3d origin;
+        Vector3d aim;
+        Vector3d receiver_pos(0.0,
+                              0.0,
+                              this->receiver_height);
+        double panel_y, flen;
+        single_element_ptr mirror;
+        aperture_ptr ap;
+        surface_ptr surf;
+        Vector3d khat(0.0, 0.0, 1.0);
+
+        for (int_fast64_t i = 0; i < this->num_panels_x; ++i)
+        {
+            panel_y = -0.5 * this->aperture_size_y + 0.5 * panel_len_y;
+            for (int_fast64_t j = 0; j < this->num_panels_y; ++j)
             {
-                flen = sqrt(panel_x * panel_x +
-                            this->receiver_height * this->receiver_height);
-                surf = make_surface<Parabola>(flen, 0.0);
+                mirror = make_element<SingleElement>();
+
+                origin.set_values(panel_x, panel_y, 0.0);
+                vector_add(1.0, receiver_pos, -1.0, origin, aim);
+                // Project into xz-plane
+                aim[1] = 0.0;
+                make_unit_vector(aim);
+                // std::cout << "Panel x: " << panel_x
+                //           << "\nPanel y: " << panel_y
+                //           << "\nRec: " << aim
+                //           << std::endl;
+                vector_add(0.5, khat, 0.5, aim);
+                // std::cout << "Aim: " << aim << std::endl;
+                vector_add(1.0, origin, 1000.0, aim);
+                // std::cout << "Aim Point: " << aim << std::endl;
+                // std::cout << "Origin: " << origin << std::endl;
+                mirror->set_reference_frame_geometry(origin, aim, 0.0);
+
+                ap = make_aperture<Rectangle>(panel_len_x, panel_len_y);
+                mirror->set_aperture(ap);
+
+                if (this->focused_panels)
+                {
+                    flen = sqrt(panel_x * panel_x +
+                                this->receiver_height * this->receiver_height);
+                    // surf = make_surface<Parabola>(flen,
+                    //     std::numeric_limits<double>::infinity());
+                    surf = make_surface<Parabola>(flen, 0.0);
+                }
+                else
+                {
+                    surf = make_surface<Flat>();
+                }
+                mirror->set_surface(surf);
+
+                mirror->set_front_optical_properties(this->optics_mirror);
+                mirror->set_back_optical_properties(this->optics_mirror);
+                mirror->enable();
+
+                std::stringstream name;
+                name << "Mirror_" << this->num_panels_y * i + j;
+                mirror->set_name(name.str());
+
+                this->mirrors.push_back(mirror);
+                sts = this->add_element(mirror);
+                if (!Element::is_success(sts))
+                {
+                    // TODO: Make this more helpful
+                    throw std::runtime_error("Failed to add mirror element");
+                }
+
+                panel_y += panel_len_y + this->gap_y;
+            }
+            panel_x += panel_len_x;
+            if (i == this->num_panels_x / 2 - 1)
+            {
+                panel_x += this->gap_center;
             }
             else
             {
-                surf = make_surface<Flat>();
+                panel_x += this->gap_x;
             }
-            mirror->set_surface(surf);
-
-            mirror->set_front_optical_properties(this->optics_mirror);
-            mirror->set_back_optical_properties(this->optics_mirror);
-            mirror->enable();
-
-            std::stringstream name;
-            name << "Mirror_" << this->num_panels_y * i + j;
-            mirror->set_name(name.str());
-
-            this->mirrors.push_back(mirror);
-            sts = this->add_element(mirror);
-            if (!Element::is_success(sts))
-            {
-                // TODO: Make this more helpful
-                throw std::runtime_error("Failed to add mirror element");
-            }
-
-            panel_y += panel_len_y + this->gap_y;
         }
-        panel_x += panel_len_x;
-        if (i == this->num_panels_x / 2 - 1)
+
+        // Absorber
+        // TODO: Single element at the moment. Break up into multiple tubes.
+        auto abs = make_element<SingleElement>();
+        abs->set_name("Absorber");
+        origin.set_values(0.0, 0.0,
+                          this->receiver_height - 0.5 * this->abs_diameter);
+        aim.set_values(0.0, 0.0, 1.0);
+        vector_add(1.0, origin, 1.0, aim);
+        abs->set_reference_frame_geometry(origin, aim, 0.0);
+        abs->set_aperture(make_aperture<Rectangle>(this->abs_diameter,
+                                                   this->aperture_size_y));
+        abs->set_surface(make_surface<Cylinder>(0.5 * this->abs_diameter));
+        abs->set_front_optical_properties(this->optics_absorber);
+        abs->set_back_optical_properties(this->optics_absorber);
+        abs->enable();
+
+        this->absorbers.push_back(abs);
+        sts = this->add_element(abs);
+        if (!Element::is_success(sts))
         {
-            panel_x += this->gap_center;
+            // TODO: Make this more helpful
+            throw std::runtime_error("Failed to add absorber element");
         }
-        else
+
+        // Envelope -- Outer
+        auto envout = make_element<SingleElement>();
+        envout->set_name("EnvelopeOuter");
+        origin.set_values(0.0, 0.0,
+                          this->receiver_height - 0.5 * this->env_diameter);
+        aim.set_values(0.0, 0.0, 1.0);
+        vector_add(1.0, origin, 1.0, aim);
+        envout->set_reference_frame_geometry(origin, aim, 0.0);
+        envout->set_aperture(make_aperture<Rectangle>(this->env_diameter,
+                                                      this->aperture_size_y));
+        envout->set_surface(make_surface<Cylinder>(0.5 * this->env_diameter));
+        envout->set_front_optical_properties(this->optics_env_out);
+        envout->set_back_optical_properties(this->optics_env_out);
+        envout->enable();
+
+        this->envelope.push_back(envout);
+        sts = this->add_element(envout);
+        if (!Element::is_success(sts))
         {
-            panel_x += this->gap_x;
+            throw std::runtime_error("Failed to add outer envelope element");
         }
-    }
 
-    // Absorber
-    // TODO: Single element at the moment. Break up into multiple tubes.
-    auto abs = make_element<SingleElement>();
-    abs->set_name("Absorber");
-    origin.set_values(0.0, 0.0,
-                      this->receiver_height - 0.5 * this->abs_diameter);
-    aim.set_values(0.0, 0.0, 1.0);
-    vector_add(1.0, origin, 1.0, aim);
-    abs->set_reference_frame_geometry(origin, aim, 0.0);
-    abs->set_aperture(make_aperture<Rectangle>(this->abs_diameter,
-                                               this->aperture_size_y));
-    abs->set_surface(make_surface<Cylinder>(0.5 * this->abs_diameter));
-    abs->set_front_optical_properties(this->optics_absorber);
-    abs->set_back_optical_properties(this->optics_absorber);
-    abs->enable();
-
-    this->absorbers.push_back(abs);
-    sts = this->add_element(abs);
-    if (!Element::is_success(sts))
-    {
-        // TODO: Make this more helpful
-        throw std::runtime_error("Failed to add absorber element");
-    }
-
-    // Envelope -- Outer
-    auto envout = make_element<SingleElement>();
-    envout->set_name("EnvelopeOuter");
-    origin.set_values(0.0, 0.0,
-                      this->receiver_height - 0.5 * this->env_diameter);
-    aim.set_values(0.0, 0.0, 1.0);
-    vector_add(1.0, origin, 1.0, aim);
-    envout->set_reference_frame_geometry(origin, aim, 0.0);
-    envout->set_aperture(make_aperture<Rectangle>(this->env_diameter,
-                                                  this->aperture_size_y));
-    envout->set_surface(make_surface<Cylinder>(0.5 * this->env_diameter));
-    envout->set_front_optical_properties(this->optics_env_out);
-    envout->set_back_optical_properties(this->optics_env_out);
-    envout->enable();
-
-    this->envelope.push_back(envout);
-    sts = this->add_element(envout);
-    if (!Element::is_success(sts))
-    {
-        throw std::runtime_error("Failed to add outer envelope element");
-    }
-
-    // Envelope -- Inner
-    auto envin = make_element<SingleElement>();
-    envin->set_name("EnvelopeInner");
-    origin.set_values(0.0, 0.0,
-                      this->receiver_height -
-                          0.5 * this->env_diameter + this->env_thickness);
-    aim.set_values(0.0, 0.0, 1.0);
-    vector_add(1.0, origin, 1.0, aim);
-    envin->set_reference_frame_geometry(origin, aim, 0.0);
-    double ap_x = this->env_diameter - 2 * this->env_thickness;
-    double ap_y = this->aperture_size_y;
-    envin->set_aperture(make_aperture<Rectangle>(ap_x, ap_y));
-    envin->set_surface(make_surface<Cylinder>(0.5 * ap_x));
-    envin->set_front_optical_properties(this->optics_env_in);
-    envin->set_back_optical_properties(this->optics_env_in);
-    envin->enable();
-    this->envelope.push_back(envin);
-    sts = this->add_element(envin);
-    if (!Element::is_success(sts))
-    {
-        throw std::runtime_error("Failed to add inner envelope element");
-    }
-
-    this->initialized = true;
-
-    return;
-}
-
-void LinearFresnel::update_geometry(double azimuth, double elevation)
-{
-    if (elevation < 0.0 || elevation > 90.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::update_geometry: Invalid elevation ("
-           << elevation << "). Elevation must lie between 0 and 90 degrees.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (azimuth < -180.0 || azimuth > 180.0)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::update_geometry: Invalid azimuth ("
-           << elevation << "). Azimuth must lie between -180 and 180 degrees.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (!this->initialized)
-    {
-        std::stringstream ss;
-        ss << "LinearFresnel::update_geometry: Uninitialized. "
-           << "Call create_geometry() first.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    // NOTE: Setting the aim point and z-rotation only need to be done
-    // once. But they need to be done after the LinearFresnel object
-    // has been added to its reference element (if any) so we do it
-    // here at the cost of repeating ourselves.
-
-    // Set aim point
-    Vector3d z_axis_ref, y_axis_ref;
-    this->convert_global_to_reference(z_axis_ref, this->neutral_normal);
-    this->convert_global_to_reference(y_axis_ref, this->rotation_axis);
-    vector_add(1000.0, z_axis_ref, 1.0, this->origin, this->aim);
-
-    // Set z-rotation
-    double beta = asin(z_axis_ref[1]);
-    double gamma = acos(y_axis_ref[1] / cos(beta));
-    this->set_zrot_radians(gamma);
-
-    // Update coordinate conversions so we can use them below
-    this->coordinates_initialized = false;
-    this->compute_coordinate_rotations();
-
-    // std::cout << "Rotation axis: " << this->rotation_axis
-    //           << "\nNeutral normal: " << this->neutral_normal
-    //           << std::endl;
-
-    // std::cout << "Global to Local: " << this->get_global_to_local()
-    //           << std::endl;
-
-    // std::cout << "z axis ref: " << z_axis_ref
-    //           << "\ny axis ref: " << y_axis_ref
-    //           << "\nBeta: " << beta
-    //           << "\nGamma: " << gamma
-    //           << std::endl;
-
-    // Sun position projected into rotation plane and converted
-    // to LinearFresnel object coordinates
-    Vector3d sun_pos, sun_proj_local;
-    sun_position_vector_degrees(sun_pos, azimuth, elevation);
-    this->convert_global_to_local(sun_proj_local, sun_pos);
-    // Project to rotation plane
-    sun_proj_local[1] = 0.0;
-    sun_proj_local.make_unit();
-
-    // std::cout << "Sun Position: " << sun_pos
-    //           //   << "\nSun Proj Global: " << sun_proj
-    //           //   << "\nSun Proj Local: " << temp
-    //           << "\nSun Proj Local: " << sun_proj_local
-    //           << std::endl;
-
-    // Set aimpoint for mirrors
-    Vector3d aim_mirror_ref;
-    // Absorber position projected into the plane of rotation (the xz-plane)
-    Vector3d origin_abs_proj(0.0,
-                             0.0,
-                             this->receiver_height - 0.5 * this->abs_diameter);
-    // origin_abs_proj.make_unit();
-    for (auto iter : this->mirrors)
-    {
-        // Get mirror to to receiver vector
-        vector_add(1.0, origin_abs_proj,
-                   -1.0, iter->get_origin_ref(),
-                   aim_mirror_ref);
-
-        // Project onto the rotation plane
-        aim_mirror_ref[1] = 0.0;
-        aim_mirror_ref.make_unit();
-        // std::cout << "Origin: " << iter->get_origin_ref()
-        //           << "\nMirror to Receiver: " << aim_mirror_ref
-        //           << std::endl;
-
-        // Take bisector vector with the sun
-        vector_add(1.0, sun_proj_local, 1.0, aim_mirror_ref);
-        aim_mirror_ref.make_unit();
-        // std::cout << "Sun Proj Local: " << sun_proj_local
-        //           << "\nAim Mirror Ref: " << aim_mirror_ref
-        //           << std::endl;
-
-        // Dot product with [0, 0, 1]
-        double theta = acos(aim_mirror_ref[2]) * R2D;
-        // Dot product with [1, 0, 0]
-        if (aim_mirror_ref[0] < 0)
-            theta = -theta;
-        // std::cout << "Theta: " << theta << std::endl;
-
-        if (theta < this->tracking_limit_lower)
+        // Envelope -- Inner
+        auto envin = make_element<SingleElement>();
+        envin->set_name("EnvelopeInner");
+        origin.set_values(0.0, 0.0,
+                          this->receiver_height -
+                              0.5 * this->env_diameter + this->env_thickness);
+        aim.set_values(0.0, 0.0, 1.0);
+        vector_add(1.0, origin, 1.0, aim);
+        envin->set_reference_frame_geometry(origin, aim, 0.0);
+        double ap_x = this->env_diameter - 2 * this->env_thickness;
+        double ap_y = this->aperture_size_y;
+        envin->set_aperture(make_aperture<Rectangle>(ap_x, ap_y));
+        envin->set_surface(make_surface<Cylinder>(0.5 * ap_x));
+        envin->set_front_optical_properties(this->optics_env_in);
+        envin->set_back_optical_properties(this->optics_env_in);
+        envin->enable();
+        this->envelope.push_back(envin);
+        sts = this->add_element(envin);
+        if (!Element::is_success(sts))
         {
-            theta = this->tracking_limit_lower * D2R;
-            aim_mirror_ref.set_values(sin(theta), 0.0, cos(theta));
+            throw std::runtime_error("Failed to add inner envelope element");
         }
-        else if (theta > this->tracking_limit_upper)
+
+        this->initialized = true;
+
+        return;
+    }
+
+    void LinearFresnel::update_geometry(double azimuth, double elevation)
+    {
+        if (elevation < 0.0 || elevation > 90.0)
         {
-            theta = this->tracking_limit_upper * D2R;
-            aim_mirror_ref.set_values(sin(theta), 0.0, cos(theta));
+            std::stringstream ss;
+            ss << "LinearFresnel::update_geometry: Invalid elevation ("
+               << elevation << "). Elevation must lie between 0 and 90 degrees.";
+            throw std::invalid_argument(ss.str());
         }
 
-        // std::cout << "Theta 2: " << theta * R2D
-        //           << "\nAim Mirror Ref: " << aim_mirror_ref
-        //           << std::endl;
+        if (azimuth < -180.0 || azimuth > 180.0)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::update_geometry: Invalid azimuth ("
+               << elevation << "). Azimuth must lie between -180 and 180 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
 
-        // Add origin of mirror
-        vector_add(1.0, iter->get_origin_ref(), 1000.0, aim_mirror_ref);
-        // aim_mirror_ref.scalar_mult(1000.0);
+        if (!this->initialized)
+        {
+            std::stringstream ss;
+            ss << "LinearFresnel::update_geometry: Uninitialized. "
+               << "Call create_geometry() first.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        // NOTE: Setting the aim point and z-rotation only need to be done
+        // once. But they need to be done after the LinearFresnel object
+        // has been added to its reference element (if any) so we do it
+        // here at the cost of repeating ourselves.
 
         // Set aim point
-        iter->set_aim_vector(aim_mirror_ref);
-        iter->compute_coordinate_rotations();
+        Vector3d z_axis_ref, y_axis_ref;
+        this->convert_global_to_reference(z_axis_ref, this->neutral_normal);
+        this->convert_global_to_reference(y_axis_ref, this->rotation_axis);
+        vector_add(1000.0, z_axis_ref, 1.0, this->origin, this->aim);
+
+        // Set z-rotation
+        double beta = asin(z_axis_ref[1]);
+        double gamma = acos(y_axis_ref[1] / cos(beta));
+        this->set_zrot_radians(gamma);
+
+        // Update coordinate conversions so we can use them below
+        this->coordinates_initialized = false;
+        this->compute_coordinate_rotations();
+
+        // std::cout << "Rotation axis: " << this->rotation_axis
+        //           << "\nNeutral normal: " << this->neutral_normal
+        //           << std::endl;
+
+        // std::cout << "Global to Local: " << this->get_global_to_local()
+        //           << std::endl;
+
+        // std::cout << "z axis ref: " << z_axis_ref
+        //           << "\ny axis ref: " << y_axis_ref
+        //           << "\nBeta: " << beta
+        //           << "\nGamma: " << gamma
+        //           << std::endl;
+
+        // Sun position projected into rotation plane and converted
+        // to LinearFresnel object coordinates
+        Vector3d sun_pos, sun_proj_local;
+        sun_position_vector_degrees(sun_pos, azimuth, elevation);
+        this->convert_vector_global_to_local(sun_proj_local, sun_pos);
+        // Project to rotation plane
+        sun_proj_local[1] = 0.0;
+        sun_proj_local.make_unit();
+
+        // std::cout << "Sun Position: " << sun_pos
+        //           << "\nSun Proj Local: " << sun_proj_local
+        //           << std::endl;
+
+        // Set aimpoint for mirrors
+        Vector3d aim_mirror_ref;
+        // Absorber position projected into the plane of rotation (the xz-plane)
+        Vector3d origin_abs_proj(0.0,
+                                 0.0,
+                                 this->receiver_height);
+        // origin_abs_proj.make_unit();
+        for (auto iter : this->mirrors)
+        {
+            // Get mirror to to receiver vector
+            vector_add(1.0, origin_abs_proj,
+                       -1.0, iter->get_origin_ref(),
+                       aim_mirror_ref);
+
+            // Project onto the rotation plane
+            aim_mirror_ref[1] = 0.0;
+            aim_mirror_ref.make_unit();
+            // std::cout << "Origin: " << iter->get_origin_ref()
+            //           << "\nMirror to Receiver: " << aim_mirror_ref
+            //           << std::endl;
+
+            // Take bisector vector with the sun
+            vector_add(1.0, sun_proj_local, 1.0, aim_mirror_ref);
+            aim_mirror_ref.make_unit();
+            // std::cout << "Sun Proj Local: " << sun_proj_local
+            //           << "\nAim Mirror Ref: " << aim_mirror_ref
+            //           << std::endl;
+
+            // Dot product with [0, 0, 1]
+            double theta = acos(aim_mirror_ref[2]) * R2D;
+            // Dot product with [1, 0, 0]
+            if (aim_mirror_ref[0] < 0)
+                theta = -theta;
+            // std::cout << "Theta: " << theta << std::endl;
+
+            if (theta < this->tracking_limit_lower)
+            {
+                theta = this->tracking_limit_lower * D2R;
+                aim_mirror_ref.set_values(sin(theta), 0.0, cos(theta));
+            }
+            else if (theta > this->tracking_limit_upper)
+            {
+                theta = this->tracking_limit_upper * D2R;
+                aim_mirror_ref.set_values(sin(theta), 0.0, cos(theta));
+            }
+
+            // std::cout << "Theta 2: " << theta * R2D
+            //           << "\nAim Mirror Ref: " << aim_mirror_ref
+            //           << std::endl;
+
+            // Add origin of mirror
+            vector_add(1.0, iter->get_origin_ref(), 1000.0, aim_mirror_ref);
+            // aim_mirror_ref.scalar_mult(1000.0);
+
+            // Set aim point
+            iter->set_aim_vector(aim_mirror_ref);
+            iter->compute_coordinate_rotations();
+        }
+
+        return;
     }
 
-    return;
-}
-
-void LinearFresnel::enforce_user_fields_set() const
-{
-    if (this->initialized)
+    void LinearFresnel::enforce_user_fields_set() const
     {
-        CompositeElement::enforce_user_fields_set();
-    }
+        if (this->initialized)
+        {
+            CompositeElement::enforce_user_fields_set();
+        }
 
-    // Validate that all required parameters have been set
-    if (this->aperture_size_x <= 0.0 || this->aperture_size_y <= 0.0)
-    {
-        throw std::invalid_argument(
-            "LinearFresnel: Aperture size must be set "
-            "before creating geometry.");
-    }
+        // Validate that all required parameters have been set
+        if (this->aperture_size_x <= 0.0 || this->aperture_size_y <= 0.0)
+        {
+            throw std::invalid_argument(
+                "LinearFresnel: Aperture size must be set "
+                "before creating geometry.");
+        }
 
-    if (this->num_panels_x <= 0 || this->num_panels_y <= 0)
-    {
-        throw std::invalid_argument(
-            "LinearFresnel: Number of panels must be set "
-            "before creating geometry.");
-    }
+        if (this->num_panels_x <= 0 || this->num_panels_y <= 0)
+        {
+            throw std::invalid_argument(
+                "LinearFresnel: Number of panels must be set "
+                "before creating geometry.");
+        }
 
-    if (this->receiver_height <= 0.0)
-    {
-        throw std::invalid_argument(
-            "LinearFresnel: Receiver height must be set "
-            "before creating geometry.");
-    }
+        if (this->receiver_height <= 0.0)
+        {
+            throw std::invalid_argument(
+                "LinearFresnel: Receiver height must be set "
+                "before creating geometry.");
+        }
 
-    if (this->abs_diameter <= 0.0 ||
-        this->env_diameter <= 0.0)
-    {
-        throw std::invalid_argument(
-            "LinearFresnel: Receiver dimensions must be set "
-            "before creating geometry.");
-    }
+        if (this->abs_diameter <= 0.0 ||
+            this->env_diameter <= 0.0)
+        {
+            throw std::invalid_argument(
+                "LinearFresnel: Receiver dimensions must be set "
+                "before creating geometry.");
+        }
 
-    return;
-}
+        return;
+    }
 
 } // namespace SolTrace::Data

--- a/coretrace/simulation_data/element.cpp
+++ b/coretrace/simulation_data/element.cpp
@@ -12,6 +12,7 @@ namespace SolTrace::Data {
 ElementBase::ElementBase() : Element(),
                              coordinates_initialized(true),
                              active(true),
+                             virtual_flag(false),
                              my_id(ELEMENT_ID_UNASSIGNED),
                              stage(-1),
                              zrot(0.0),

--- a/coretrace/simulation_data/element.hpp
+++ b/coretrace/simulation_data/element.hpp
@@ -71,6 +71,8 @@ public:
   /// @brief Check whether the element is a VirtualElement
   /// @return true if VirtualElement, false otherwise
   virtual bool is_virtual() const = 0;
+  virtual void mark_virtual() const = 0;
+  virtual void unmark_virtual() const = 0;
 
   /// @brief Get the element id assigned when registered with SimulationData
   /// @return id if registered with SimulationData, ELEMENT_ID_UNASSIGNED if not
@@ -306,8 +308,10 @@ public:
   virtual bool is_composite() const override { return false; }
   virtual bool is_single() const override { return false; }
   virtual bool is_stage() const override { return false; }
-  // TODO: Do we need this?
-  virtual bool is_virtual() const override { return false; }
+
+  virtual bool is_virtual() const override { return this->virtual_flag; }
+  virtual void mark_virtual() const override {this->virtual_flag = true;}
+  virtual void unmark_virtual() const override {this->virtual_flag = false;}
 
   // virtual ElementContainer::iterator get_iterator();
   // virtual ElementContainer::const_iterator get_const_iterator();
@@ -485,6 +489,7 @@ public:
 protected:
   // TODO: Do these need to be mutable?
   mutable bool active;
+  mutable bool virtual_flag;
   mutable element_id my_id;
 
   bool coordinates_initialized;

--- a/coretrace/simulation_data/error_distributions.hpp
+++ b/coretrace/simulation_data/error_distributions.hpp
@@ -12,7 +12,7 @@
 
 namespace SolTrace::Data {
 
-enum DistributionType
+enum class DistributionType
 {
     GAUSSIAN,
     PILLBOX,

--- a/coretrace/simulation_data/matvec.cpp
+++ b/coretrace/simulation_data/matvec.cpp
@@ -54,360 +54,382 @@
 // #include "procs.h"
 #include "matvec.hpp"
 
-namespace SolTrace::Data {
-
-// inline void CopyVec3(double dest[3], const std::vector<double> &src)
-// {
-//  dest[0] = src[0];
-//  dest[1] = src[1];
-//  dest[2] = src[2];
-// }
-
-// inline void CopyVec3(std::vector<double> &dest, double src[3])
-// {
-//  dest[0] = src[0];
-//  dest[1] = src[1];
-//  dest[2] = src[2];
-// }
-
-// inline void CopyVec3(double dest[3], double src[3])
-// {
-//  dest[0] = src[0];
-//  dest[1] = src[1];
-//  dest[2] = src[2];
-// }
-
-void CopyMat3(double dest[3][3], const double src[3][3])
+namespace SolTrace::Data
 {
-    for (int i = 0; i < 3; ++i)
-        for (int j = 0; j < 3; ++j)
-            dest[i][j] = src[i][j];
-    return;
-}
 
-void IdentityMat3(double mat[3][3])
-{
-    for (int i = 0; i < 3; ++i)
-        for (int j = 0; j < 3; ++j)
-            mat[i][j] = i == j ? 1.0 : 0.0;
-    return;
-}
+    // inline void CopyVec3(double dest[3], const std::vector<double> &src)
+    // {
+    //  dest[0] = src[0];
+    //  dest[1] = src[1];
+    //  dest[2] = src[2];
+    // }
 
-void MatrixVectorMult(const double M[3][3], const double V[3], double MxV[3])
-{
-    /*{Purpose: To perform multiplication of a matrix (3,3) and a vector (3) to result
-              in new vector (3)
+    // inline void CopyVec3(std::vector<double> &dest, double src[3])
+    // {
+    //  dest[0] = src[0];
+    //  dest[1] = src[1];
+    //  dest[2] = src[2];
+    // }
 
-              Input -
-                    Matrix = Matrix
-                    Vector = Vector
-              Output -
-                     MxV = Matrix*Vector = new vector}*/
+    // inline void CopyVec3(double dest[3], double src[3])
+    // {
+    //  dest[0] = src[0];
+    //  dest[1] = src[1];
+    //  dest[2] = src[2];
+    // }
 
-    MxV[0] = M[0][0] * V[0] + M[0][1] * V[1] + M[0][2] * V[2];
-    MxV[1] = M[1][0] * V[0] + M[1][1] * V[1] + M[1][2] * V[2];
-    MxV[2] = M[2][0] * V[0] + M[2][1] * V[1] + M[2][2] * V[2];
-    /*
-        int i, j;
-        for (i=0;i<3;i++)
-        {
-            MxV[i] = 0.0;
-            for (j=0;j<3;j++)
-                MxV[i] = Matrix[i][j]*Vector[j] + MxV[i];
-        }*/
-}
-// End of procedure-------------------------------------------------------------
-
-void MatrixMatrixMult(const double A[3][3],
-                      const double B[3][3],
-                      double C[3][3])
-{
-    double sum;
-    for (int i = 0; i < 3; ++i)
+    void CopyMat3(double dest[3][3], const double src[3][3])
     {
-        for (int j = 0; j < 3; ++j)
-        {
-            sum = 0.0;
-            for (int k = 0; k < 3; ++k)
+        for (int i = 0; i < 3; ++i)
+            for (int j = 0; j < 3; ++j)
+                dest[i][j] = src[i][j];
+        return;
+    }
+
+    void IdentityMat3(double mat[3][3])
+    {
+        for (int i = 0; i < 3; ++i)
+            for (int j = 0; j < 3; ++j)
+                mat[i][j] = i == j ? 1.0 : 0.0;
+        return;
+    }
+
+    void MatrixVectorMult(const double M[3][3], const double V[3], double MxV[3])
+    {
+        /*{Purpose: To perform multiplication of a matrix (3,3) and a vector (3) to result
+                  in new vector (3)
+
+                  Input -
+                        Matrix = Matrix
+                        Vector = Vector
+                  Output -
+                         MxV = Matrix*Vector = new vector}*/
+
+        MxV[0] = M[0][0] * V[0] + M[0][1] * V[1] + M[0][2] * V[2];
+        MxV[1] = M[1][0] * V[0] + M[1][1] * V[1] + M[1][2] * V[2];
+        MxV[2] = M[2][0] * V[0] + M[2][1] * V[1] + M[2][2] * V[2];
+        /*
+            int i, j;
+            for (i=0;i<3;i++)
             {
-                sum += A[i][k] * B[k][j];
+                MxV[i] = 0.0;
+                for (j=0;j<3;j++)
+                    MxV[i] = Matrix[i][j]*Vector[j] + MxV[i];
+            }*/
+    }
+    // End of procedure-------------------------------------------------------------
+
+    void MatrixMatrixMult(const double A[3][3],
+                          const double B[3][3],
+                          double C[3][3])
+    {
+        double sum;
+        for (int i = 0; i < 3; ++i)
+        {
+            for (int j = 0; j < 3; ++j)
+            {
+                sum = 0.0;
+                for (int k = 0; k < 3; ++k)
+                {
+                    sum += A[i][k] * B[k][j];
+                }
+                C[i][j] = sum;
             }
-            C[i][j] = sum;
         }
     }
-}
 
-double DOT(const double A[3], const double B[3])
-{
-    //{Purpose: To compute the dot product of 2 N-dimensional vectors, A and B
-    //        Input -
-    //              A(N) = First input vector
-    //              B(N) = Second input vector
-    //              N = dimension of vectors
-    //        Output -
-    //             Result of DOT = dot product of A and B}
+    double DOT(const double A[3], const double B[3])
+    {
+        //{Purpose: To compute the dot product of 2 N-dimensional vectors, A and B
+        //        Input -
+        //              A(N) = First input vector
+        //              B(N) = Second input vector
+        //              N = dimension of vectors
+        //        Output -
+        //             Result of DOT = dot product of A and B}
 
-    return (A[0] * B[0] + A[1] * B[1] + A[2] * B[2]);
-}
+        return (A[0] * B[0] + A[1] * B[1] + A[2] * B[2]);
+    }
 
-void MatrixTranspose(const double InputMatrix[3][3],
-                     int NumRowsCols,
-                     double OutputMatrix[3][3])
-{
-    /*{Purpose: To obtain the transpose of a square matrix InputMatrix(NumRowsCols,NumRowscols)
-             Input -
-                   InputMatrix = Input Matrix
-                   NumRowsCols = Number of rows/columns in InputMatrix
-             Output -
-                    OutputMatrix = Output Matrix OutputMatrix(i,j) = InputMatrix(j,i)}*/
-    for (int i = 0; i < NumRowsCols; i++)
-        for (int j = 0; j < NumRowsCols; j++)
-            OutputMatrix[i][j] = InputMatrix[j][i];
-}
-// end of procedure--------------------------------------------------------------
+    void MatrixTranspose(const double InputMatrix[3][3],
+                         int NumRowsCols,
+                         double OutputMatrix[3][3])
+    {
+        /*{Purpose: To obtain the transpose of a square matrix InputMatrix(NumRowsCols,NumRowscols)
+                 Input -
+                       InputMatrix = Input Matrix
+                       NumRowsCols = Number of rows/columns in InputMatrix
+                 Output -
+                        OutputMatrix = Output Matrix OutputMatrix(i,j) = InputMatrix(j,i)}*/
+        for (int i = 0; i < NumRowsCols; i++)
+            for (int j = 0; j < NumRowsCols; j++)
+                OutputMatrix[i][j] = InputMatrix[j][i];
+    }
+    // end of procedure--------------------------------------------------------------
 
-// end of procedure--------------------------------------------------------------
+    // end of procedure--------------------------------------------------------------
 
-void TransformToLocal(const double PosRef[3],
-                      const double CosRef[3],
-                      const double Origin[3],
-                      const double RRefToLoc[3][3],
-                      double PosLoc[3],
-                      double CosLoc[3])
-{
-    /*{Purpose:  To perform coordinate transformation from reference system to local
-               system.
-               Input -
-                     PosRef = X,Y,Z coordinates of ray point in reference system
-                     CosRef = Direction cosines of ray in reference system
-                     Origin = X,Y,Z coordinates of origin of local system as measured
-                              in reference system
-                     RRefToLoc = Rotation matrices required for coordinate transform
-                                 from reference to local
-               Output -
-                     PosLoc = X,Y,Z coordinates of ray point in local system
-                     CosLoc = Direction cosines of ray in local system }*/
-
-    double PosDum[3];
-
-    /*{Multiply the position vector and the direction cosine vector by the transformation
-     matrix to get the new vectors in the local system.  The position vector is first
-     referenced to the origin of the local frame.}*/
-    for (int i = 0; i < 3; i++)
-        PosDum[i] = PosRef[i] - Origin[i];
-
-    MatrixVectorMult(RRefToLoc, PosDum, PosLoc);
-    MatrixVectorMult(RRefToLoc, CosRef, CosLoc);
-}
-// end of procedure--------------------------------------------------------------
-
-void TransformToReference(const double PosLoc[3],
-                          const double CosLoc[3],
+    void TransformToLocal(const double PosRef[3],
+                          const double CosRef[3],
                           const double Origin[3],
-                          const double RLocToRef[3][3],
-                          double PosRef[3],
-                          double CosRef[3])
-{
-    /*{Purpose:  To perform coordinate transformation from local system to reference
-               system.
-               Input -
-                     PosLoc = X,Y,Z coordinates of ray point in local system
-                     CosLoc = Direction cosines of ray in Loc system
-                     Origin = X,Y,Z coordinates of origin of local system as measured
-                              in reference system
-                     RLocToRef = Rotation matrices required for coordinate transform
-                                 from local to reference (inverse of reference to
-                                 local transformation)
-               Output -
-                     PosRef = X,Y,Z coordinates of ray point in reference system
-                     CosRef = Direction cosines of ray in reference system}*/
+                          const double RRefToLoc[3][3],
+                          double PosLoc[3],
+                          double CosLoc[3])
+    {
+        /*{Purpose:  To perform coordinate transformation from reference system to local
+                   system.
+                   Input -
+                         PosRef = X,Y,Z coordinates of ray point in reference system
+                         CosRef = Direction cosines of ray in reference system
+                         Origin = X,Y,Z coordinates of origin of local system as measured
+                                  in reference system
+                         RRefToLoc = Rotation matrices required for coordinate transform
+                                     from reference to local
+                   Output -
+                         PosLoc = X,Y,Z coordinates of ray point in local system
+                         CosLoc = Direction cosines of ray in local system }*/
 
-    double PosDum[3];
+        double PosDum[3];
 
-    /*{Use previously calculated RLocToRef matrix (in TransformToLocal) to obtain the
-     inverse transformation back to Reference system.}*/
-    MatrixVectorMult(RLocToRef, PosLoc, PosDum);
-    MatrixVectorMult(RLocToRef, CosLoc, CosRef);
+        /*{Multiply the position vector and the direction cosine vector by the transformation
+         matrix to get the new vectors in the local system.  The position vector is first
+         referenced to the origin of the local frame.}*/
+        for (int i = 0; i < 3; i++)
+            PosDum[i] = PosRef[i] - Origin[i];
 
-    for (int i = 0; i < 3; i++)
-        PosRef[i] = PosDum[i] + Origin[i];
-}
-// end of procedure--------------------------------------------------------------
-void CalculateTransformMatrices(const double Euler[3],
-                                double RRefToLoc[3][3],
-                                double RLocToRef[3][3])
-{
-    /*{input:  Euler = Euler angles
-     output: RRefToLoc = Transformation matrix from Reference to Local system
-             RLocToRef = ""             ""     ""   Local to Reference system (transpose of above)} */
-    double Alpha = 0.0;
-    double Beta = 0.0;
-    double Gamma = 0.0;
-    double CosAlpha = 0.0;
-    double CosBeta = 0.0;
-    double CosGamma = 0.0;
-    double SinAlpha = 0.0;
-    double SinBeta = 0.0;
-    double SinGamma = 0.0;
+        MatrixVectorMult(RRefToLoc, PosDum, PosLoc);
+        MatrixVectorMult(RRefToLoc, CosRef, CosLoc);
+    }
+    // end of procedure--------------------------------------------------------------
 
-    /*{Offload Alpha, Beta and Gamma: the three Euler rotations from Ref frame to Local
-     frame. Also calculate their cosines.}*/
-    Alpha = Euler[0];
-    Beta = Euler[1];
-    Gamma = Euler[2];
-    CosAlpha = cos(Alpha);
-    CosBeta = cos(Beta);
-    CosGamma = cos(Gamma);
-    SinAlpha = sin(Alpha);
-    SinBeta = sin(Beta);
-    SinGamma = sin(Gamma);
+    void TransformToReference(const double PosLoc[3],
+                              const double CosLoc[3],
+                              const double Origin[3],
+                              const double RLocToRef[3][3],
+                              double PosRef[3],
+                              double CosRef[3])
+    {
+        /*{Purpose:  To perform coordinate transformation from local system to reference
+                   system.
+                   Input -
+                         PosLoc = X,Y,Z coordinates of ray point in local system
+                         CosLoc = Direction cosines of ray in Loc system
+                         Origin = X,Y,Z coordinates of origin of local system as measured
+                                  in reference system
+                         RLocToRef = Rotation matrices required for coordinate transform
+                                     from local to reference (inverse of reference to
+                                     local transformation)
+                   Output -
+                         PosRef = X,Y,Z coordinates of ray point in reference system
+                         CosRef = Direction cosines of ray in reference system}*/
 
-    /*{Fill in elements of the transformation matrix as per Spencer and Murty paper
-     page 673 equation (2)}*/
-    RRefToLoc[0][0] = CosAlpha * CosGamma + SinAlpha * SinBeta * SinGamma;
-    RRefToLoc[0][1] = -CosBeta * SinGamma;
-    RRefToLoc[0][2] = -SinAlpha * CosGamma + CosAlpha * SinBeta * SinGamma;
-    RRefToLoc[1][0] = CosAlpha * SinGamma - SinAlpha * SinBeta * CosGamma;
-    RRefToLoc[1][1] = CosBeta * CosGamma;
-    RRefToLoc[1][2] = -SinAlpha * SinGamma - CosAlpha * SinBeta * CosGamma;
-    RRefToLoc[2][0] = SinAlpha * CosBeta;
-    RRefToLoc[2][1] = SinBeta;
-    RRefToLoc[2][2] = CosAlpha * CosBeta;
+        double PosDum[3];
 
-    /*{Transpose the matrix to get the inverse transformation matrix for going back
-     to reference system.  This is used by the TransformToReference procedure.}*/
-    MatrixTranspose(RRefToLoc, 3, RLocToRef);
-}
+        /*{Use previously calculated RLocToRef matrix (in TransformToLocal) to obtain the
+         inverse transformation back to Reference system.}*/
+        MatrixVectorMult(RLocToRef, PosLoc, PosDum);
+        MatrixVectorMult(RLocToRef, CosLoc, CosRef);
 
-// end of procedure--------------------------------------------------------------
-//  void EvalPoly(double ax, double ay, std::vector<double> &Coeffs, int POrder, double *az) //the 0.0's are values for DeltaX and DeltaY; **[need to look at this further]**
-//  {
-//      *az = 0.0;
-//      double r = sqrt(ax*ax + ay*ay);
-//      for (int i=0;i<=POrder;i++)
-//        *az = *az + Coeffs[i]*pow(r,i);
-//  }
+        for (int i = 0; i < 3; i++)
+            PosRef[i] = PosDum[i] + Origin[i];
+    }
+    // end of procedure--------------------------------------------------------------
+    void CalculateTransformMatrices(const double Euler[3],
+                                    double RRefToLoc[3][3],
+                                    double RLocToRef[3][3])
+    {
+        /*{input:  Euler = Euler angles
+         output: RRefToLoc = Transformation matrix from Reference to Local system
+                 RLocToRef = ""             ""     ""   Local to Reference system (transpose of above)} */
+        double Alpha = 0.0;
+        double Beta = 0.0;
+        double Gamma = 0.0;
+        double CosAlpha = 0.0;
+        double CosBeta = 0.0;
+        double CosGamma = 0.0;
+        double SinAlpha = 0.0;
+        double SinBeta = 0.0;
+        double SinGamma = 0.0;
 
-// //end of procedure--------------------------------------------------------------
-// void PolySlope( std::vector<double> &Coeffs, int POrder, double ax, double ay, double *dzdx, double *dzdy)
-// {
-//  double dzdr = 0.0;
-//  double r = sqrt(ax*ax + ay*ay);
-//  double drdx = ax/r;
-//  double drdy = ay/r;
-//  for (int i=1;i<=POrder;i++)
-//      dzdr = dzdr + i*Coeffs[i]*pow(r, i-1);
+        /*{Offload Alpha, Beta and Gamma: the three Euler rotations from Ref frame to Local
+         frame. Also calculate their cosines.}*/
+        Alpha = Euler[0];
+        Beta = Euler[1];
+        Gamma = Euler[2];
+        CosAlpha = cos(Alpha);
+        CosBeta = cos(Beta);
+        CosGamma = cos(Gamma);
+        SinAlpha = sin(Alpha);
+        SinBeta = sin(Beta);
+        SinGamma = sin(Gamma);
 
-//     *dzdx = dzdr*drdx;
-//     *dzdy = dzdr*drdy;
-// }
-// //end of procedure--------------------------------------------------------------
+        /*{Fill in elements of the transformation matrix as per Spencer and Murty paper
+         page 673 equation (2)}*/
+        RRefToLoc[0][0] = CosAlpha * CosGamma + SinAlpha * SinBeta * SinGamma;
+        RRefToLoc[0][1] = -CosBeta * SinGamma;
+        RRefToLoc[0][2] = -SinAlpha * CosGamma + CosAlpha * SinBeta * SinGamma;
+        RRefToLoc[1][0] = CosAlpha * SinGamma - SinAlpha * SinBeta * CosGamma;
+        RRefToLoc[1][1] = CosBeta * CosGamma;
+        RRefToLoc[1][2] = -SinAlpha * SinGamma - CosAlpha * SinBeta * CosGamma;
+        RRefToLoc[2][0] = SinAlpha * CosBeta;
+        RRefToLoc[2][1] = SinBeta;
+        RRefToLoc[2][2] = CosAlpha * CosBeta;
 
-// bool splint( std::vector<double> &xa,
-//          std::vector<double> &ya,
-//          std::vector<double> &y2a,
-//          int n,
-//          double x,
-//          double *y,
-//          double *dydx )
-// {
-//  int klo = 0,khi = 0,k = 0;
-//  double h = 0.0,b = 0.0,a = 0.0;
+        /*{Transpose the matrix to get the inverse transformation matrix for going back
+         to reference system.  This is used by the TransformToReference procedure.}*/
+        MatrixTranspose(RRefToLoc, 3, RLocToRef);
+    }
 
-//  klo = 0;
-//  khi = n-1;
-//  while( khi-klo > 1)
-//  {
-//      k = (khi+klo) / 2;
-//      if( xa[k] > x )
-//          khi = k;
-//      else
-//          klo = k;
-//  }
+    // void AddVec3(double a, const double x[3],
+    //              double b, double y[3])
+    // {
+    //     for (int i = 0; i < 3; ++i)
+    //     {
+    //         y[i] = a * x[i] + b * y[i];
+    //     }
+    //     return;
+    // }
 
-//  h = xa[khi]-xa[klo];
-//  if (h != 0.0)
-//  {
+    void AddVec3(double a, const double x[3],
+                 double b, const double y[3],
+                 double z[3])
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            z[i] = a * x[i] + b * y[i];
+        }
+        return;
+    }
 
-//      a = (xa[khi]-x)/h;
-//      b = (x-xa[klo])/h;
-//      *y = a*ya[klo]+b*ya[khi]+
-//          ((a*a*a-a)*y2a[klo]+(b*b*b-b)*y2a[khi])*(h*h)/6.0;
-//      *dydx = (ya[khi]-ya[klo])/(xa[khi]-xa[klo])-
-//          (3.0*a*a-1.0)*(xa[khi]-xa[klo])*y2a[klo]/6.0 + (3.0*b*b-1.0)*(xa[khi]-xa[klo])*y2a[khi]/6.0;
-//  }
-//  else
-//  {
-//      return false;
-//  }
+    // end of procedure--------------------------------------------------------------
+    //  void EvalPoly(double ax, double ay, std::vector<double> &Coeffs, int POrder, double *az) //the 0.0's are values for DeltaX and DeltaY; **[need to look at this further]**
+    //  {
+    //      *az = 0.0;
+    //      double r = sqrt(ax*ax + ay*ay);
+    //      for (int i=0;i<=POrder;i++)
+    //        *az = *az + Coeffs[i]*pow(r,i);
+    //  }
 
-//  return true;
-// }
+    // //end of procedure--------------------------------------------------------------
+    // void PolySlope( std::vector<double> &Coeffs, int POrder, double ax, double ay, double *dzdx, double *dzdy)
+    // {
+    //  double dzdr = 0.0;
+    //  double r = sqrt(ax*ax + ay*ay);
+    //  double drdx = ax/r;
+    //  double drdy = ay/r;
+    //  for (int i=1;i<=POrder;i++)
+    //      dzdr = dzdr + i*Coeffs[i]*pow(r, i-1);
 
-// //end of procedure--------------------------------------------------------------
+    //     *dzdx = dzdr*drdx;
+    //     *dzdy = dzdr*drdy;
+    // }
+    // //end of procedure--------------------------------------------------------------
 
-// void spline( std::vector<double> &x,
-//          std::vector<double> &y,
-//          int n,
-//          double yp1, double ypn,
-//          std::vector<double> &y2 )
-// {
-//  int i=0,k=0;
-//  double p = 0.0,qn = 0.0,sig = 0.0,un = 0.0;
-//  std::vector<double> u( x.size() );
+    // bool splint( std::vector<double> &xa,
+    //          std::vector<double> &ya,
+    //          std::vector<double> &y2a,
+    //          int n,
+    //          double x,
+    //          double *y,
+    //          double *dydx )
+    // {
+    //  int klo = 0,khi = 0,k = 0;
+    //  double h = 0.0,b = 0.0,a = 0.0;
 
-//  if (yp1 > 0.99e30)
-//  {
-//      y2[0] = 0.0;
-//      u[0] = 0.0;
-//  }
-//  else
-//  {
-//      y2[0] = -0.5;
-//      u[0] = (3.0/(x[1]-x[0]))*((y[1]-y[0])/(x[1]-x[0])-yp1);
-//  }
-//  for (i=1;i<n-1;i++)
-//  {
-//      sig = (x[i]-x[i-1])/(x[i+1]-x[i-1]);
-//      p = sig*y2[i-1]+2.0;
-//      y2[i] = (sig-1.0)/p;
-//      u[i] = (y[i+1]-y[i])/(x[i+1]-x[i])-(y[i]-y[i-1])/(x[i]-x[i-1]);
-//      u[i] = (6.0*u[i]/(x[i+1]-x[i-1])-sig*u[i-1])/p;
-//  }
+    //  klo = 0;
+    //  khi = n-1;
+    //  while( khi-klo > 1)
+    //  {
+    //      k = (khi+klo) / 2;
+    //      if( xa[k] > x )
+    //          khi = k;
+    //      else
+    //          klo = k;
+    //  }
 
-//  if (ypn > 0.99e30 )
-//  {
-//      qn = 0.0;
-//      un = 0.0;
-//  }
-//  else
-//  {
-//      qn = 0.5;
-//      un = (3.0/(x[n-1]-x[n-2]))*(ypn-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
-//  }
-//  y2[n-1] = (un-qn*u[n-2])/(qn*y2[n-2]+1.0);
-//  for (k=n-2;k>=0;k--)
-//    y2[k] = y2[k]*y2[k+1]+u[k];
+    //  h = xa[khi]-xa[klo];
+    //  if (h != 0.0)
+    //  {
 
-// }
-// //end of procedure--------------------------------------------------------------
+    //      a = (xa[khi]-x)/h;
+    //      b = (x-xa[klo])/h;
+    //      *y = a*ya[klo]+b*ya[khi]+
+    //          ((a*a*a-a)*y2a[klo]+(b*b*b-b)*y2a[khi])*(h*h)/6.0;
+    //      *dydx = (ya[khi]-ya[klo])/(xa[khi]-xa[klo])-
+    //          (3.0*a*a-1.0)*(xa[khi]-xa[klo])*y2a[klo]/6.0 + (3.0*b*b-1.0)*(xa[khi]-xa[klo])*y2a[khi]/6.0;
+    //  }
+    //  else
+    //  {
+    //      return false;
+    //  }
 
-// void piksrt(int n, double arr[5] )
-// {
-//  int i;
-//  for (int j=1;j<n;j++)
-//  {
-//      double a = arr[j];
-//      for (i = j-1; i >= 0; i--)
-//      {
-//          if (arr[i] <= a ) goto Label_10;
-//          arr[i+1] = arr[i];
-//      }
-//      i = 0;
-// Label_10:
-//      arr[i+1] = a;
-//  }
-// }
-// //end of procedure--------------------------------------------------------------
+    //  return true;
+    // }
+
+    // //end of procedure--------------------------------------------------------------
+
+    // void spline( std::vector<double> &x,
+    //          std::vector<double> &y,
+    //          int n,
+    //          double yp1, double ypn,
+    //          std::vector<double> &y2 )
+    // {
+    //  int i=0,k=0;
+    //  double p = 0.0,qn = 0.0,sig = 0.0,un = 0.0;
+    //  std::vector<double> u( x.size() );
+
+    //  if (yp1 > 0.99e30)
+    //  {
+    //      y2[0] = 0.0;
+    //      u[0] = 0.0;
+    //  }
+    //  else
+    //  {
+    //      y2[0] = -0.5;
+    //      u[0] = (3.0/(x[1]-x[0]))*((y[1]-y[0])/(x[1]-x[0])-yp1);
+    //  }
+    //  for (i=1;i<n-1;i++)
+    //  {
+    //      sig = (x[i]-x[i-1])/(x[i+1]-x[i-1]);
+    //      p = sig*y2[i-1]+2.0;
+    //      y2[i] = (sig-1.0)/p;
+    //      u[i] = (y[i+1]-y[i])/(x[i+1]-x[i])-(y[i]-y[i-1])/(x[i]-x[i-1]);
+    //      u[i] = (6.0*u[i]/(x[i+1]-x[i-1])-sig*u[i-1])/p;
+    //  }
+
+    //  if (ypn > 0.99e30 )
+    //  {
+    //      qn = 0.0;
+    //      un = 0.0;
+    //  }
+    //  else
+    //  {
+    //      qn = 0.5;
+    //      un = (3.0/(x[n-1]-x[n-2]))*(ypn-(y[n-1]-y[n-2])/(x[n-1]-x[n-2]));
+    //  }
+    //  y2[n-1] = (un-qn*u[n-2])/(qn*y2[n-2]+1.0);
+    //  for (k=n-2;k>=0;k--)
+    //    y2[k] = y2[k]*y2[k+1]+u[k];
+
+    // }
+    // //end of procedure--------------------------------------------------------------
+
+    // void piksrt(int n, double arr[5] )
+    // {
+    //  int i;
+    //  for (int j=1;j<n;j++)
+    //  {
+    //      double a = arr[j];
+    //      for (i = j-1; i >= 0; i--)
+    //      {
+    //          if (arr[i] <= a ) goto Label_10;
+    //          arr[i+1] = arr[i];
+    //      }
+    //      i = 0;
+    // Label_10:
+    //      arr[i+1] = a;
+    //  }
+    // }
+    // //end of procedure--------------------------------------------------------------
 
 } // namespace SolTrace::Data

--- a/coretrace/simulation_data/matvec.hpp
+++ b/coretrace/simulation_data/matvec.hpp
@@ -64,79 +64,86 @@
 #include <iostream>
 #include <fstream>
 
-namespace SolTrace::Data {
+namespace SolTrace::Data
+{
 
-void MatrixVectorMult(const double M[3][3],
-                      const double V[3],
-                      double MxV[3]);
-void MatrixTranspose(const double InputMatrix[3][3],
-                     int NumRowsCols,
-                     double OutputMatrix[3][3]);
-void MatrixMatrixMult(const double M1[3][3],
-                      const double M2[3][3],
-                      double OutputMatrix[3][3]);
+    void MatrixVectorMult(const double M[3][3],
+                          const double V[3],
+                          double MxV[3]);
+    void MatrixTranspose(const double InputMatrix[3][3],
+                         int NumRowsCols,
+                         double OutputMatrix[3][3]);
+    void MatrixMatrixMult(const double M1[3][3],
+                          const double M2[3][3],
+                          double OutputMatrix[3][3]);
 
-double DOT(const double A[3], const double B[3]);
+    double DOT(const double A[3], const double B[3]);
 
-void TransformToLocal(const double PosRef[3],
-                      const double CosRef[3],
-                      const double Origin[3],
-                      const double RRefToLoc[3][3],
-                      double PosLoc[3],
-                      double CosLoc[3]);
-
-void TransformToReference(const double PosLoc[3],
-                          const double CosLoc[3],
+    void TransformToLocal(const double PosRef[3],
+                          const double CosRef[3],
                           const double Origin[3],
-                          const double RLocToRef[3][3],
-                          double PosRef[3],
-                          double CosRef[3]);
+                          const double RRefToLoc[3][3],
+                          double PosLoc[3],
+                          double CosLoc[3]);
 
-void CalculateTransformMatrices(const double Euler[3],
-                                double RRefToLoc[3][3],
-                                double RLocToRef[3][3]);
+    void TransformToReference(const double PosLoc[3],
+                              const double CosLoc[3],
+                              const double Origin[3],
+                              const double RLocToRef[3][3],
+                              double PosRef[3],
+                              double CosRef[3]);
 
-// inline void CopyVec3(double dest[3], const std::vector<double> &src);
-// inline void CopyVec3(std::vector<double> &dest, const double src[3]);
-// inline void CopyVec3(double dest[3], const double src[3]);
+    void CalculateTransformMatrices(const double Euler[3],
+                                    double RRefToLoc[3][3],
+                                    double RLocToRef[3][3]);
 
-inline void ZeroVec3(double vec[3])
-{
-    vec[0] = vec[1] = vec[2] = 0.0;
-    return;
-}
+    // inline void CopyVec3(double dest[3], const std::vector<double> &src);
+    // inline void CopyVec3(std::vector<double> &dest, const double src[3]);
+    // inline void CopyVec3(double dest[3], const double src[3]);
 
-inline void SetVec3(double vec[3], double v1, double v2, double v3)
-{
-    vec[0] = v1;
-    vec[1] = v2;
-    vec[2] = v3;
-}
+    // void AddVec3(double a, const double x[3],
+    //              double b, const double y[3]);
+    void AddVec3(double a, const double x[3],
+                 double b, const double y[3],
+                 double z[3]);
 
-inline void CopyVec3(double dest[3], const std::vector<double> &src)
-{
-    dest[0] = src[0];
-    dest[1] = src[1];
-    dest[2] = src[2];
-}
+    inline void ZeroVec3(double vec[3])
+    {
+        vec[0] = vec[1] = vec[2] = 0.0;
+        return;
+    }
 
-inline void CopyVec3(std::vector<double> &dest, const double src[3])
-{
-    dest[0] = src[0];
-    dest[1] = src[1];
-    dest[2] = src[2];
-}
+    inline void SetVec3(double vec[3], double v1, double v2, double v3)
+    {
+        vec[0] = v1;
+        vec[1] = v2;
+        vec[2] = v3;
+    }
 
-inline void CopyVec3(double dest[3], const double src[3])
-{
-    dest[0] = src[0];
-    dest[1] = src[1];
-    dest[2] = src[2];
-}
+    inline void CopyVec3(double dest[3], const std::vector<double> &src)
+    {
+        dest[0] = src[0];
+        dest[1] = src[1];
+        dest[2] = src[2];
+    }
 
-void CopyMat3(double dest[3][3], const double src[3][3]);
+    inline void CopyVec3(std::vector<double> &dest, const double src[3])
+    {
+        dest[0] = src[0];
+        dest[1] = src[1];
+        dest[2] = src[2];
+    }
 
-void IdentityMat3(double mat[3][3]);
+    inline void CopyVec3(double dest[3], const double src[3])
+    {
+        dest[0] = src[0];
+        dest[1] = src[1];
+        dest[2] = src[2];
+    }
+
+    void CopyMat3(double dest[3][3], const double src[3][3]);
+
+    void IdentityMat3(double mat[3][3]);
 
 } // namespace SolTrace::Data
 

--- a/coretrace/simulation_data/optical_properties.cpp
+++ b/coretrace/simulation_data/optical_properties.cpp
@@ -1,0 +1,39 @@
+
+// #include <exception>
+// #include <sstream>
+
+#include "optical_properties.hpp"
+
+namespace SolTrace::Data
+{
+
+const std::string interaction_string(InteractionType it)
+{
+    if (it == InteractionType::REFLECTION)
+    {
+        return "Reflection";
+    }
+    else if(it == InteractionType::REFRACTION)
+    {
+        return "Refraction";
+    }
+    else
+    {
+        return "Unknown";
+    }
+}
+
+std::ostream &operator<<(std::ostream &os,
+    const OpticalProperties &op)
+{
+    os << "Type: " << interaction_string(op.my_type)
+    << "\nTransmitivity: " << op.transmitivity
+    << "\nReflectivity: " << op.reflectivity
+    << "\nSlope Error: " << op.slope_error
+    << "\nSpecularity Error: " << op.specularity_error
+    << "\nRefraction Index Front: " << op.refraction_index_front
+    << "\nRefraction Index Back: " << op.refraction_index_back;
+    return os;
+}
+
+} // namespace SolTrace::Data

--- a/coretrace/simulation_data/optical_properties.hpp
+++ b/coretrace/simulation_data/optical_properties.hpp
@@ -10,98 +10,104 @@
 #ifndef SOLTRACE_OPTICAL_PROPERTIES_H
 #define SOLTRACE_OPTICAL_PROPERTIES_H
 
+#include <iostream>
+
 #include "error_distributions.hpp"
 
-namespace SolTrace::Data {
-
-enum InteractionType
+namespace SolTrace::Data
 {
-    REFLECTION,
-    REFRACTION
-};
 
-struct OpticalProperties
-{
-    InteractionType my_type;
-    DistributionType error_distribution_type;
-    double transmitivity;
-    double reflectivity;
-    double slope_error;
-    double specularity_error;
-    double refraction_index_front;
-    double refraction_index_back;
+    enum class InteractionType
+    {
+        REFLECTION,
+        REFRACTION
+    };
 
-    OpticalProperties() : my_type(REFLECTION),
-                          error_distribution_type(GAUSSIAN),
-                          transmitivity(0.0),
-                          reflectivity(0.0),
-                          slope_error(0.0),
-                          specularity_error(0.0),
-                          refraction_index_front(0.0),
-                          refraction_index_back(0.0)
+    struct OpticalProperties
     {
-    }
+        InteractionType my_type;
+        DistributionType error_distribution_type;
+        double transmitivity;
+        double reflectivity;
+        double slope_error;
+        double specularity_error;
+        double refraction_index_front;
+        double refraction_index_back;
 
-    OpticalProperties(InteractionType itype,
-                      DistributionType dtype,
-                      double trans, double refl,
-                      double slope_err, double spec_err,
-                      double ri_front, double ri_back)
-        : my_type(itype),
-          error_distribution_type(dtype),
-          transmitivity(trans),
-          reflectivity(refl),
-          slope_error(slope_err),
-          specularity_error(spec_err),
-          refraction_index_front(ri_front),
-          refraction_index_back(ri_back)
-    {
-    }
+        OpticalProperties() : my_type(InteractionType::REFLECTION),
+                              error_distribution_type(DistributionType::GAUSSIAN),
+                              transmitivity(0.0),
+                              reflectivity(0.0),
+                              slope_error(0.0),
+                              specularity_error(0.0),
+                              refraction_index_front(0.0),
+                              refraction_index_back(0.0)
+        {
+        }
 
-    // TODO: What should the error settings be with the below?
+        OpticalProperties(InteractionType itype,
+                          DistributionType dtype,
+                          double trans, double refl,
+                          double slope_err, double spec_err,
+                          double ri_front, double ri_back)
+            : my_type(itype),
+              error_distribution_type(dtype),
+              transmitivity(trans),
+              reflectivity(refl),
+              slope_error(slope_err),
+              specularity_error(spec_err),
+              refraction_index_front(ri_front),
+              refraction_index_back(ri_back)
+        {
+        }
 
-    void set_ideal_absorption()
-    {
-        this->my_type = REFLECTION;
-        this->transmitivity = 0.0;
-        this->reflectivity = 0.0;
-        return;
-    }
-    void set_ideal_reflection()
-    {
-        this->my_type = REFLECTION;
-        this->transmitivity = 0.0;
-        this->reflectivity = 1.0;
-        return;
-    }
-    void set_ideal_transmission()
-    {
-        this->my_type = REFRACTION;
-        this->transmitivity = 1.0;
-        this->reflectivity = 0.0;
-        return;
-    }
-    void set_ideal_transmission(double refraction_index_front,
-                                double refraction_index_back)
-    {
-        this->set_ideal_transmission();
-        this->refraction_index_front = refraction_index_front;
-        this->refraction_index_back = refraction_index_back;
-        return;
-    }
+        // TODO: What should the error settings be with the below?
 
-    // OpticalProperties &operator=(const OpticalProperties &rhs)
-    // {
-    //     this->my_type = rhs.my_type;
-    //     this->transmitivity = rhs.transmitivity;
-    //     this->reflectivity = rhs.reflectivity;
-    //     this->slope_error = rhs.slope_error;
-    //     this->specularity_error = rhs.specularity_error;
-    //     this->refraction_index_front = rhs.refraction_index_front;
-    //     this->refraction_index_back = rhs.refraction_index_back;
-    //     return *this;
-    // }
-};
+        void set_ideal_absorption()
+        {
+            this->my_type = InteractionType::REFLECTION;
+            this->transmitivity = 0.0;
+            this->reflectivity = 0.0;
+            return;
+        }
+        void set_ideal_reflection()
+        {
+            this->my_type = InteractionType::REFLECTION;
+            this->transmitivity = 0.0;
+            this->reflectivity = 1.0;
+            return;
+        }
+        void set_ideal_transmission()
+        {
+            this->my_type = InteractionType::REFRACTION;
+            this->transmitivity = 1.0;
+            this->reflectivity = 0.0;
+            return;
+        }
+        void set_ideal_transmission(double refraction_index_front,
+                                    double refraction_index_back)
+        {
+            this->set_ideal_transmission();
+            this->refraction_index_front = refraction_index_front;
+            this->refraction_index_back = refraction_index_back;
+            return;
+        }
+
+        // OpticalProperties &operator=(const OpticalProperties &rhs)
+        // {
+        //     this->my_type = rhs.my_type;
+        //     this->transmitivity = rhs.transmitivity;
+        //     this->reflectivity = rhs.reflectivity;
+        //     this->slope_error = rhs.slope_error;
+        //     this->specularity_error = rhs.specularity_error;
+        //     this->refraction_index_front = rhs.refraction_index_front;
+        //     this->refraction_index_back = rhs.refraction_index_back;
+        //     return *this;
+        // }
+
+        friend std::ostream &operator<<(std::ostream &os,
+                                        const OpticalProperties &op);
+    };
 
 } // namespace SolTrace::Data
 

--- a/coretrace/simulation_data/simdata_io.cpp
+++ b/coretrace/simulation_data/simdata_io.cpp
@@ -528,6 +528,7 @@ bool read_element(
             throw std::invalid_argument("This should not happen!");
         }
         rect->x_length = 2.0 * cyl->radius;
+        rect->x_coord = -1.0 * cyl->radius;
     }
 
     // Set element position and orientation

--- a/coretrace/simulation_data/simulation_data_api.hpp
+++ b/coretrace/simulation_data/simulation_data_api.hpp
@@ -12,6 +12,7 @@
 #include "sun.hpp"
 #include "surface.hpp"
 #include "vector3d.hpp"
+#include "virtual_element.hpp"
 
 #include "cst_templates/heliostat.hpp"
 #include "cst_templates/linear_fresnel.hpp"

--- a/coretrace/simulation_data/simulation_data_export.hpp
+++ b/coretrace/simulation_data/simulation_data_export.hpp
@@ -30,6 +30,8 @@ using SolTrace::Data::Sun;
 using SolTrace::Data::Surface;
 using SolTrace::Data::SurfaceType;
 using SolTrace::Data::Vector3d;
+using SolTrace::Data::VirtualElement;
+using SolTrace::Data::VirtualPlane;
 
 // Template Types
 using SolTrace::Data::Heliostat;
@@ -62,6 +64,7 @@ using SolTrace::Data::matrix_vector_product;
 using SolTrace::Data::vector_add;
 using SolTrace::Data::vector_copy;
 using SolTrace::Data::vector_norm;
+using SolTrace::Data::AddVec3;
 using SolTrace::Data::CopyVec3;
 using SolTrace::Data::DOT;
 using SolTrace::Data::IdentityMat3;

--- a/coretrace/simulation_data/surface.cpp
+++ b/coretrace/simulation_data/surface.cpp
@@ -12,16 +12,16 @@ surface_ptr make_surface_from_type(SurfaceType type, const std::vector<double> &
 
     switch (type)
     {
-    case CONE:
+    case SurfaceType::CONE:
         retval = nargs < 1 ? nullptr : make_surface<Cone>(args[0]);
         break;
-    case CYLINDER:
+    case SurfaceType::CYLINDER:
         retval = nargs < 1 ? nullptr : make_surface<Cylinder>(1.0 / args[0]);
         break;
-    case FLAT:
+    case SurfaceType::FLAT:
         retval = make_surface<Flat>();
         break;
-    case PARABOLA:
+    case SurfaceType::PARABOLA:
     {
         if (nargs < 2)
             retval = nullptr;
@@ -35,12 +35,12 @@ surface_ptr make_surface_from_type(SurfaceType type, const std::vector<double> &
         }
         break;
     } 
-    case SPHERE:
+    case SurfaceType::SPHERE:
         retval = nargs < 1 ? nullptr : make_surface<Sphere>(args[0]);
         break;
-    case HYPER:
-    case GENERAL_SPENCER_MURTY:
-    case TORUS:
+    case SurfaceType::HYPER:
+    case SurfaceType::GENERAL_SPENCER_MURTY:
+    case SurfaceType::TORUS:
     default:
         retval = nullptr; // Not implemented yet
         break;

--- a/coretrace/simulation_data/surface.hpp
+++ b/coretrace/simulation_data/surface.hpp
@@ -50,7 +50,7 @@ struct Cone : public Surface
     // z(x,y) = sqrt(x^2 + y^2) / tan(theta)
     // where theta = half_angle
     double half_angle;
-    Cone(double ha) : Surface(CONE), half_angle(ha) {}
+    Cone(double ha) : Surface(SurfaceType::CONE), half_angle(ha) {}
     virtual ~Cone() {}
 };
 
@@ -59,7 +59,7 @@ struct Cylinder : public Surface
     // x^2 + (z - r)^2 = r^2
     // where r = radius
     double radius;
-    Cylinder(double r) : Surface(CYLINDER), radius(r)
+    Cylinder(double r) : Surface(SurfaceType::CYLINDER), radius(r)
     {
     }
     virtual ~Cylinder() {}
@@ -67,7 +67,7 @@ struct Cylinder : public Surface
 
 struct Flat : public Surface
 {
-    Flat() : Surface(FLAT) {}
+    Flat() : Surface(SurfaceType::FLAT) {}
     virtual ~Flat() {}
 };
 
@@ -79,7 +79,7 @@ struct Parabola : public Surface
     double focal_length_x;
     double focal_length_y;
 
-    Parabola(double focal_x, double focal_y) : Surface(PARABOLA),
+    Parabola(double focal_x, double focal_y) : Surface(SurfaceType::PARABOLA),
                                                focal_length_x(focal_x),
                                                focal_length_y(focal_y)
     {
@@ -98,7 +98,7 @@ struct Sphere : public Surface
     // Need to check on this.
     double vertex_curv;
 
-    Sphere(double curv) : Surface(SPHERE),
+    Sphere(double curv) : Surface(SurfaceType::SPHERE),
                           vertex_curv(curv)
     {
     }

--- a/coretrace/simulation_data/vector3d.cpp
+++ b/coretrace/simulation_data/vector3d.cpp
@@ -3,281 +3,312 @@
 
 // #include <cassert>
 
+#include <algorithm>
 #include <cmath>
 
 #include "matvec.hpp"
 
-namespace SolTrace::Data {
+namespace SolTrace::Data
+{
 
-// inline void vector_copy(double data[3], const Vector3d &x)
-// {
-//     CopyVec3(data, x.data);
-//     return;
-// }
-// inline void vector_copy(std::vector<double> &dest, const Vector3d &x)
-// {
-//     CopyVec3(dest, x.data);
-//     return;
-// }
-
-Vector3d::Vector3d()
-{
-    this->zero();
-    return;
-}
-
-Vector3d::Vector3d(const double data[3])
-{
-    for (int i = 0; i < 3; ++i)
-        this->data[i] = data[i];
-    return;
-}
-Vector3d::Vector3d(double x, double y, double z)
-{
-    this->data[0] = x;
-    this->data[1] = y;
-    this->data[2] = z;
-    return;
-}
-Vector3d::~Vector3d()
-{
-    return;
-}
-
-void Vector3d::zero()
-{
-    for (int i = 0; i < 3; ++i)
-        this->data[i] = 0.0;
-    return;
-}
-
-void Vector3d::set_values(double x, double y, double z)
-{
-    this->data[0] = x;
-    this->data[1] = y;
-    this->data[2] = z;
-    return;
-}
-
-void Vector3d::scalar_mult(double alpha)
-{
-    for (int i = 0; i < 3; ++i)
-        this->data[i] *= alpha;
-    return;
-}
-
-void Vector3d::make_unit()
-{
-    make_unit_vector(*this);
-    return;
-}
-
-double Vector3d::norm() const
-{
-    return vector_norm(*this);
-}
-
-const double &Vector3d::operator[](int idx) const
-{
-    assert(idx >= 0 && idx < 3);
-    return this->data[idx];
-}
-
-double &Vector3d::operator[](int idx)
-{
-    assert(idx >= 0 && idx < 3);
-    return this->data[idx];
-}
-
-std::ostream &operator<<(std::ostream &os, const Vector3d &x)
-{
-    os << "[" << x.data[0] << ", "
-       << x.data[1] << ", "
-       << x.data[2] << "]";
-    return os;
-}
-
-Matrix3d::Matrix3d()
-{
-    // for (int i = 0; i < 3; ++i)
-    //     for (int j = 0; j < 3; ++j)
-    //         this->data[i][j] = 0.0;
-    this->zero();
-}
-Matrix3d::~Matrix3d() {}
-
-void Matrix3d::set_value(int i, int j, double val)
-{
-    assert(i >= 0 && i < 3);
-    assert(j >= 0 && j < 3);
-    this->data[i][j] = val;
-}
-
-double Matrix3d::get_value(int i, int j) const
-{
-    assert(i >= 0 && i < 3);
-    assert(j >= 0 && j < 3);
-    return this->data[i][j];
-}
-
-void Matrix3d::zero()
-{
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            data[i][j] = 0.0;
-        }
-    }
-}
-
-void Matrix3d::identity()
-{
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            data[i][j] = (i == j ? 1.0 : 0.0);
-        }
-    }
-}
-
-std::ostream &operator<<(std::ostream &os, const Matrix3d &A)
-{
-    // os << "[" << x.data[0] << ", "
-    //    << x.data[1] << ", "
-    //    << x.data[2] << "]";
-    os << "[";
-    for (int i = 0; i < 3; ++i)
-    {
-        for (int j = 0; j < 3; ++j)
-        {
-            os << A.data[i][j]
-               << (j < 2 ? ", " : "; ");
-        }
-    }
-    os << "]";
-    return os;
-}
-
-// Compute y = A*x placing the result in y
-void matrix_vector_product(const Matrix3d &A, const Vector3d &x, Vector3d &y)
-{
-    MatrixVectorMult(A.data, x.data, y.data);
-    return;
-}
-
-void matrix_matrix_product(const Matrix3d &A, const Matrix3d &B, Matrix3d &C)
-{
-    MatrixMatrixMult(A.data, B.data, C.data);
-    return;
-}
-
-void vector_add(double a, const Vector3d &x,
-                double b, const Vector3d &y,
-                Vector3d &z)
-{
-    for (int i = 0; i < 3; ++i)
-    {
-        z[i] = a * x[i] + b * y[i];
-    }
-    return;
-}
-
-void vector_add(double a, const Vector3d &x,
-                double b, Vector3d &y)
-{
-    for (int i = 0; i < 3; ++i)
-    {
-        y[i] = a * x[i] + b * y[i];
-    }
-    return;
-}
-
-void vector_max(const Vector3d &x, const Vector3d &y, Vector3d &max)
-{
-    for (int i = 0; i < 3; ++i)
-    {
-        max[i] = fmax(x[i], y[i]);
-    }
-    return;
-}
-
-void vector_min(const Vector3d &x, const Vector3d &y, Vector3d &min)
-{
-    for (int i = 0; i < 3; ++i)
-    {
-        min[i] = fmin(x[i], y[i]);
-    }
-    return;
-}
-
-// Compute standard Euclidean dot product
-double dot_product(const Vector3d &x, const Vector3d &y)
-{
-    return DOT(x.data, y.data);
-}
-
-void cross_product(const Vector3d &u, const Vector3d &v, Vector3d &w)
-{
-    double w0 = u[1] * v[2] - u[2] * v[1];
-    double w1 = u[2] * v[0] - u[0] * v[2];
-    double w2 = u[0] * v[1] - u[1] * v[0];
-    w.set_values(w0, w1, w2);
-    return;
-}
-
-double vector_norm(const Vector3d &x)
-{
-    return sqrt(DOT(x.data, x.data));
-}
-
-void make_unit_vector(Vector3d &x)
-{
-    double mag = vector_norm(x);
-    assert(mag > 0.0);
-    x.scalar_mult(1.0 / mag);
-    // for (int i = 0; i < 3; ++i)
+    // inline void vector_copy(double data[3], const Vector3d &x)
     // {
-    //     x.data[i] /= mag;
+    //     CopyVec3(data, x.data);
+    //     return;
     // }
-    return;
-}
+    // inline void vector_copy(std::vector<double> &dest, const Vector3d &x)
+    // {
+    //     CopyVec3(dest, x.data);
+    //     return;
+    // }
 
-// void transform_to_local(Vector3d &pos_ref,
-//                         Vector3d &cos_ref,
-//                         Vector3d &origin,
-//                         Matrix3d &ref_to_local,
-//                         Vector3d &pos_local,
-//                         Vector3d &cos_local)
-// {
-//     TransformToLocal(pos_ref.data, cos_ref.data,
-//                      origin.data, ref_to_local.data,
-//                      pos_local.data, cos_local.data);
-//     return;
-// }
+    Vector3d::Vector3d()
+    {
+        this->zero();
+        return;
+    }
 
-// void transform_to_reference(Vector3d &pos_local,
-//                             Vector3d &cos_local,
-//                             Vector3d &origin,
-//                             Matrix3d &local_to_ref,
-//                             Vector3d &pos_ref,
-//                             Vector3d &cos_ref)
-// {
-//     TransformToReference(pos_local.data, cos_local.data,
-//                          origin.data, local_to_ref.data,
-//                          pos_ref.data, cos_ref.data);
-//     return;
-// }
+    Vector3d::Vector3d(const double data[3])
+    {
+        for (int i = 0; i < 3; ++i)
+            this->data[i] = data[i];
+        return;
+    }
+    Vector3d::Vector3d(double x, double y, double z)
+    {
+        this->data[0] = x;
+        this->data[1] = y;
+        this->data[2] = z;
+        return;
+    }
+    Vector3d::~Vector3d()
+    {
+        return;
+    }
 
-void compute_transform_matrices(Vector3d &euler,
-                                Matrix3d &ref_to_local,
-                                Matrix3d &local_to_ref)
-{
-    CalculateTransformMatrices(euler.data,
-                               ref_to_local.data,
-                               local_to_ref.data);
-    return;
-}
+    void Vector3d::zero()
+    {
+        for (int i = 0; i < 3; ++i)
+            this->data[i] = 0.0;
+        return;
+    }
+
+    void Vector3d::set_values(double x, double y, double z)
+    {
+        this->data[0] = x;
+        this->data[1] = y;
+        this->data[2] = z;
+        return;
+    }
+
+    void Vector3d::scalar_mult(double alpha)
+    {
+        for (int i = 0; i < 3; ++i)
+            this->data[i] *= alpha;
+        return;
+    }
+
+    void Vector3d::make_unit()
+    {
+        make_unit_vector(*this);
+        return;
+    }
+
+    double Vector3d::norm() const
+    {
+        return vector_norm(*this);
+    }
+
+    const double &Vector3d::operator[](int idx) const
+    {
+        assert(idx >= 0 && idx < 3);
+        return this->data[idx];
+    }
+
+    double &Vector3d::operator[](int idx)
+    {
+        assert(idx >= 0 && idx < 3);
+        return this->data[idx];
+    }
+
+    std::ostream &operator<<(std::ostream &os, const Vector3d &x)
+    {
+        os << "[" << x.data[0] << ", "
+           << x.data[1] << ", "
+           << x.data[2] << "]";
+        return os;
+    }
+
+    Matrix3d::Matrix3d()
+    {
+        // for (int i = 0; i < 3; ++i)
+        //     for (int j = 0; j < 3; ++j)
+        //         this->data[i][j] = 0.0;
+        this->zero();
+    }
+    Matrix3d::~Matrix3d() {}
+
+    void Matrix3d::set_value(int i, int j, double val)
+    {
+        assert(i >= 0 && i < 3);
+        assert(j >= 0 && j < 3);
+        this->data[i][j] = val;
+    }
+
+    double Matrix3d::get_value(int i, int j) const
+    {
+        assert(i >= 0 && i < 3);
+        assert(j >= 0 && j < 3);
+        return this->data[i][j];
+    }
+
+    void Matrix3d::zero()
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            for (int j = 0; j < 3; ++j)
+            {
+                data[i][j] = 0.0;
+            }
+        }
+    }
+
+    void Matrix3d::identity()
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            for (int j = 0; j < 3; ++j)
+            {
+                data[i][j] = (i == j ? 1.0 : 0.0);
+            }
+        }
+    }
+
+    std::ostream &operator<<(std::ostream &os, const Matrix3d &A)
+    {
+        // os << "[" << x.data[0] << ", "
+        //    << x.data[1] << ", "
+        //    << x.data[2] << "]";
+        os << "[";
+        for (int i = 0; i < 3; ++i)
+        {
+            for (int j = 0; j < 3; ++j)
+            {
+                os << A.data[i][j];
+                if (j < 2)
+                {
+                    os << ", ";
+                }
+            }
+            if (i < 2)
+            {
+                os << "; ";
+            }
+        }
+        os << "]";
+        return os;
+    }
+
+    // Compute y = A*x placing the result in y
+    void matrix_vector_product(const Matrix3d &A, const Vector3d &x, Vector3d &y)
+    {
+        MatrixVectorMult(A.data, x.data, y.data);
+        return;
+    }
+
+    void matrix_matrix_product(const Matrix3d &A, const Matrix3d &B, Matrix3d &C)
+    {
+        MatrixMatrixMult(A.data, B.data, C.data);
+        return;
+    }
+
+    void vector_add(double a, const Vector3d &x,
+                    double b, const Vector3d &y,
+                    Vector3d &z)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            z[i] = a * x[i] + b * y[i];
+        }
+        return;
+    }
+
+    void vector_add(double a, const Vector3d &x,
+                    double b, Vector3d &y)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            y[i] = a * x[i] + b * y[i];
+        }
+        return;
+    }
+
+    void vector_max(const Vector3d &x, const Vector3d &y, Vector3d &max)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            max[i] = fmax(x[i], y[i]);
+        }
+        return;
+    }
+
+    void vector_min(const Vector3d &x, const Vector3d &y, Vector3d &min)
+    {
+        for (int i = 0; i < 3; ++i)
+        {
+            min[i] = fmin(x[i], y[i]);
+        }
+        return;
+    }
+
+    // Compute standard Euclidean dot product
+    double dot_product(const Vector3d &x, const Vector3d &y)
+    {
+        return DOT(x.data, y.data);
+    }
+
+    void cross_product(const Vector3d &u, const Vector3d &v, Vector3d &w)
+    {
+        double w0 = u[1] * v[2] - u[2] * v[1];
+        double w1 = u[2] * v[0] - u[0] * v[2];
+        double w2 = u[0] * v[1] - u[1] * v[0];
+        w.set_values(w0, w1, w2);
+        return;
+    }
+
+    double error(const Vector3d &u, const Vector3d &v)
+    {
+        double err = 0.0;
+        double dx;
+        for (int i = 0; i < 3; ++i)
+        {
+            dx = u[i] - v[i];
+            err += dx * dx;
+        }
+        return sqrt(err);
+    }
+
+    double error_inf(const Vector3d &u, const Vector3d &v)
+    {
+        double err = 0.0;
+        for (int i = 0; i < 3; ++i)
+        {
+            err = std::max(err, fabs(u[i] - v[i]));
+        }
+        return err;
+    }
+
+    double vector_norm(const Vector3d &x)
+    {
+        return sqrt(DOT(x.data, x.data));
+    }
+
+    void make_unit_vector(Vector3d &x)
+    {
+        double mag = vector_norm(x);
+        assert(mag > 0.0);
+        x.scalar_mult(1.0 / mag);
+        // for (int i = 0; i < 3; ++i)
+        // {
+        //     x.data[i] /= mag;
+        // }
+        return;
+    }
+
+    // void transform_to_local(Vector3d &pos_ref,
+    //                         Vector3d &cos_ref,
+    //                         Vector3d &origin,
+    //                         Matrix3d &ref_to_local,
+    //                         Vector3d &pos_local,
+    //                         Vector3d &cos_local)
+    // {
+    //     TransformToLocal(pos_ref.data, cos_ref.data,
+    //                      origin.data, ref_to_local.data,
+    //                      pos_local.data, cos_local.data);
+    //     return;
+    // }
+
+    // void transform_to_reference(Vector3d &pos_local,
+    //                             Vector3d &cos_local,
+    //                             Vector3d &origin,
+    //                             Matrix3d &local_to_ref,
+    //                             Vector3d &pos_ref,
+    //                             Vector3d &cos_ref)
+    // {
+    //     TransformToReference(pos_local.data, cos_local.data,
+    //                          origin.data, local_to_ref.data,
+    //                          pos_ref.data, cos_ref.data);
+    //     return;
+    // }
+
+    void compute_transform_matrices(Vector3d &euler,
+                                    Matrix3d &ref_to_local,
+                                    Matrix3d &local_to_ref)
+    {
+        CalculateTransformMatrices(euler.data,
+                                   ref_to_local.data,
+                                   local_to_ref.data);
+        return;
+    }
 
 } // namespace SolTrace::Data

--- a/coretrace/simulation_data/vector3d.hpp
+++ b/coretrace/simulation_data/vector3d.hpp
@@ -212,6 +212,9 @@ double dot_product(const Vector3d &x, const Vector3d &y);
  */
 void cross_product(const Vector3d &u, const Vector3d &v, Vector3d &w);
 
+double error(const Vector3d &u, const Vector3d &v);
+double error_inf(const Vector3d &u, const Vector3d &v);
+
 /**
  * @brief Compute Euclidean norm (length) of vector
  * @param x Input vector

--- a/coretrace/simulation_data/virtual_element.cpp
+++ b/coretrace/simulation_data/virtual_element.cpp
@@ -5,7 +5,7 @@ namespace SolTrace::Data {
 
 void VirtualElement::set_virtual_optics(OpticalProperties &op)
 {
-    op.my_type = REFRACTION;
+    op.my_type = InteractionType::REFRACTION;
     op.reflectivity = 0.0;
     op.slope_error = 0.0;
     op.specularity_error = 0.0;

--- a/coretrace/simulation_results/simulation_result.cpp
+++ b/coretrace/simulation_results/simulation_result.cpp
@@ -1,5 +1,7 @@
 #include "simulation_result.hpp"
 
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -156,24 +158,45 @@ namespace SolTrace::Result
         return;
     }
 
-    void SimulationResult::write_csv_file(std::string csv_name)
+    void SimulationResult::write_csv_file(std::string csv_name,
+                                          int precision)
     {
-        return this->write_csv_file(csv_name.c_str());
+        return this->write_csv_file(csv_name.c_str(), precision);
     }
 
-    void SimulationResult::write_csv_file(const char *csv_name)
+    void SimulationResult::write_csv_file(const char *csv_name,
+                                          int precision)
     {
-        // TODO: Implement this
+        std::ofstream csv(csv_name);
+        csv.precision(precision);
+        csv << "Ray Number,Pos X,Pos Y,Pos Z,"
+            << "Cos X,Cos Y,Cos Z,Element,Event\n";
+        for (auto srit : this->ray_history)
+        {
+            for (auto cit : srit->interactions)
+            {
+                csv << srit->id << ","
+                    << cit->location[0] << ","
+                    << cit->location[1] << ","
+                    << cit->location[2] << ","
+                    << cit->direction[0] << ","
+                    << cit->direction[1] << ","
+                    << cit->direction[2] << ","
+                    << cit->element << ","
+                    << ray_event_string(cit->event) << "\n";
+            }
+        }
+        csv.close();
         return;
     }
 
     const ray_record_ptr &SimulationResult::operator[](int_fast64_t idx) const
     {
-       if (idx < 0 || idx >= this->ray_history.size())
+        if (idx < 0 || idx >= this->ray_history.size())
         {
             std::stringstream ss;
             ss << "SimulationResult: Index " << idx
-               << " is out of bounds [0, " << this->ray_history.size()
+               << " is out of bounds [0, " << this->ray_history.size() - 1
                << "].";
             throw std::invalid_argument(ss.str());
         }

--- a/coretrace/simulation_results/simulation_result.hpp
+++ b/coretrace/simulation_results/simulation_result.hpp
@@ -12,7 +12,6 @@
 
 namespace SolTrace::Result
 {
-
     using ray_id = int_fast64_t;
 
     enum class RayEvent
@@ -135,8 +134,8 @@ namespace SolTrace::Result
             return citer == this->ray_history.cend();
         }
 
-        void write_csv_file(std::string csv_name);
-        void write_csv_file(const char *csv_name);
+        void write_csv_file(std::string csv_name, int precision=12);
+        void write_csv_file(const char *csv_name, int precision=12);
 
         // Legacy stuff -- TODO:
         // void results_to_legacy_csv(std::string csv_name,

--- a/coretrace/simulation_results/simulation_result.hpp
+++ b/coretrace/simulation_results/simulation_result.hpp
@@ -30,8 +30,9 @@ namespace SolTrace::Result
         {RayEvent::ABSORB, "ABSORB"},
         {RayEvent::REFLECT, "REFLECT"},
         {RayEvent::TRANSMIT, "TRANSMIT"},
+        {RayEvent::VIRTUAL, "VIRTUAL"},
         {RayEvent::EXIT, "EXIT"},
-        {RayEvent::UNKNOWN, "UNKNONWN"}};
+        {RayEvent::UNKNOWN, "UNKNOWN"}};
 
     const std::string &ray_event_string(RayEvent rev);
 

--- a/coretrace/simulation_runner/native_runner/calculator_factory.cpp
+++ b/coretrace/simulation_runner/native_runner/calculator_factory.cpp
@@ -40,11 +40,11 @@ calculator_ptr CalculatorFactory::make_calculator(
 
     if (st == SurfaceType::PARABOLA)
     {
-        calc = std::make_shared<ParabolaCalculator>(surf);
+        calc = std::make_shared<ParabolaCalculator>(surf, ap);
     }
     else if (st == SurfaceType::FLAT)
     {
-        calc = std::make_shared<FlatCalculator>(surf);
+        calc = std::make_shared<FlatCalculator>(surf, ap);
     }
     else if (st == SurfaceType::CYLINDER)
     {
@@ -52,7 +52,7 @@ calculator_ptr CalculatorFactory::make_calculator(
     }
     else if (st == SurfaceType::SPHERE)
     {
-        calc = std::make_shared<SphereCalculator>(surf);
+        calc = std::make_shared<SphereCalculator>(surf, ap);
     }
     else
     {

--- a/coretrace/simulation_runner/native_runner/cylinder_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/cylinder_calculator.cpp
@@ -11,189 +11,201 @@
 #include "simulation_data_export.hpp"
 #include "surface.hpp"
 
-namespace SolTrace::NativeRunner {
-
-CylinderCalculator::CylinderCalculator(surface_ptr surf, aperture_ptr ap)
+namespace SolTrace::NativeRunner
 {
-    if (surf == nullptr)
+
+    CylinderCalculator::CylinderCalculator(surface_ptr surf, aperture_ptr ap)
+        : SurfaceIntersectionCalculator(),
+          aper(ap)
     {
-        throw std::invalid_argument("CylinderCalculator: Surface pointer cannot be null");
-    }
-
-    if (ap == nullptr)
-    {
-        throw std::invalid_argument("CylinderCalculator: Aperture pointer cannot be null");
-    }
-
-    auto cylinder = std::dynamic_pointer_cast<Cylinder>(surf);
-    if (cylinder == nullptr)
-    {
-        throw std::invalid_argument("CylinderCalculator: Surface must be of type Cylinder");
-    }
-
-    auto rect = std::dynamic_pointer_cast<Rectangle>(ap);
-    if (rect == nullptr)
-    {
-        throw std::invalid_argument("CylinderCalculator: Aperture must be of type Rectangle");
-    }
-
-    // Validate cylinder radius
-    if (cylinder->radius <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "CylinderCalculator: Cylinder radius must be positive, got: " << cylinder->radius;
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (std::isnan(cylinder->radius) || std::isinf(cylinder->radius))
-    {
-        throw std::invalid_argument("CylinderCalculator: Cylinder radius cannot be NaN or infinite");
-    }
-
-    // Validate rectangle dimensions
-    if (rect->x_length <= 0.0 || rect->y_length <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "CylinderCalculator: Rectangle dimensions must be positive, got: ("
-           << rect->x_length << ", " << rect->y_length << ")";
-        throw std::invalid_argument(ss.str());
-    }
-
-    // Validate that rectangle x_length matches cylinder diameter
-    double expected_x_length = 2.0 * cylinder->radius;
-    if (fabs(expected_x_length - rect->x_length) > 1e-8)
-    {
-        std::stringstream ss;
-        ss << "CylinderCalculator: Rectangle x_length (" << rect->x_length
-           << ") must equal cylinder diameter (" << expected_x_length << ")";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->radius = cylinder->radius;
-    this->length_y = rect->y_length;
-    // this->length_x = rect->x_length;
-    // this->length_x = 2.0 * this->radius;
-
-    // std::cout << "radius: " << radius
-    // << "  length y: " << length_y
-    // << "\naperture: (" << rect->x_coord << ", " << rect->y_coord << ") -- ("
-    // << rect->x_length << ", " << rect->y_length << ")"
-    // << std::endl;
-
-    return;
-}
-
-CylinderCalculator::~CylinderCalculator()
-{
-}
-
-int CylinderCalculator::intersect(const double PosLoc[3],
-                                  const double CosLoc[3],
-                                  double PosXYZ[3],
-                                  double CosKLM[3],
-                                  double DFXYZ[3],
-                                  double *PathLength)
-{
-    // std::cout << "Computing cylinder intersection" << std::endl;
-
-    int sts = 0;
-
-    double x0 = PosLoc[0], y0 = PosLoc[1], z0 = PosLoc[2];
-    double mx = CosLoc[0], my = CosLoc[1], mz = CosLoc[2];
-    double r = this->radius;
-    double yu = 0.5 * this->length_y;
-    double yl = -yu;
-    double t1, t2;
-    double a, b, c;
-    double y1, y2;
-
-    // c = x0 * x0 + z0 * z0 - r * r;
-    c = x0 * x0 + z0 * z0 - 2.0 * z0 * r;
-    // b = 2.0 * (x0 * mx + z0 * mz);
-    b = 2.0 * (x0 * mx + (z0 - r) * mz);
-    a = mx * mx + mz * mz;
-
-    ZeroVec3(PosXYZ);
-    ZeroVec3(CosKLM);
-    ZeroVec3(DFXYZ);
-
-    if (fabs(a) < 1e-12)
-    {
-        // Ray is parallel to the cylinder -- no solution
-        sts = 1;
-        *PathLength = 0.0;
-    }
-    else
-    {
-        double scratch = b * b - 4.0 * a * c;
-        if (scratch < 0.0)
+        if (surf == nullptr)
         {
-            // Only imaginary solutions to quadratic equation -- no solution
+            throw std::invalid_argument("CylinderCalculator: Surface pointer cannot be null");
+        }
+
+        if (ap == nullptr)
+        {
+            throw std::invalid_argument("CylinderCalculator: Aperture pointer cannot be null");
+        }
+
+        auto cylinder = std::dynamic_pointer_cast<Cylinder>(surf);
+        if (cylinder == nullptr)
+        {
+            throw std::invalid_argument("CylinderCalculator: Surface must be of type Cylinder");
+        }
+
+        auto rect = std::dynamic_pointer_cast<Rectangle>(ap);
+        if (rect == nullptr)
+        {
+            throw std::invalid_argument("CylinderCalculator: Aperture must be of type Rectangle");
+        }
+
+        // Validate cylinder radius
+        if (cylinder->radius <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "CylinderCalculator: Cylinder radius must be positive, got: " << cylinder->radius;
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (std::isnan(cylinder->radius) || std::isinf(cylinder->radius))
+        {
+            throw std::invalid_argument("CylinderCalculator: Cylinder radius cannot be NaN or infinite");
+        }
+
+        // Validate rectangle dimensions
+        if (rect->x_length <= 0.0 || rect->y_length <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "CylinderCalculator: Rectangle dimensions must be positive, got: ("
+               << rect->x_length << ", " << rect->y_length << ")";
+            throw std::invalid_argument(ss.str());
+        }
+
+        // Validate that rectangle x_length matches cylinder diameter
+        double expected_x_length = 2.0 * cylinder->radius;
+        if (fabs(expected_x_length - rect->x_length) > 1e-8)
+        {
+            std::stringstream ss;
+            ss << "CylinderCalculator: Rectangle x_length (" << rect->x_length
+               << ") must equal cylinder diameter (" << expected_x_length << ")";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->radius = cylinder->radius;
+        // this->length_y = rect->y_length;
+        // this->length_x = rect->x_length;
+        // this->length_x = 2.0 * this->radius;
+
+        // std::cout << "radius: " << radius
+        // << "  length y: " << length_y
+        // << "\naperture: (" << rect->x_coord << ", " << rect->y_coord << ") -- ("
+        // << rect->x_length << ", " << rect->y_length << ")"
+        // << std::endl;
+
+        return;
+    }
+
+    CylinderCalculator::~CylinderCalculator()
+    {
+    }
+
+    int CylinderCalculator::intersect(const double PosLoc[3],
+                                      const double CosLoc[3],
+                                      double PosXYZ[3],
+                                      double CosKLM[3],
+                                      double DFXYZ[3],
+                                      double *PathLength)
+    {
+        // std::cout << "Computing cylinder intersection" << std::endl;
+
+        int sts = 0;
+
+        double x0 = PosLoc[0], y0 = PosLoc[1], z0 = PosLoc[2];
+        double mx = CosLoc[0], my = CosLoc[1], mz = CosLoc[2];
+        double r = this->radius;
+        // double yu = 0.5 * this->length_y;
+        // double yl = -yu;
+        double t1, t2;
+        double a, b, c;
+        // double y1, y2;
+
+        Vector3d p1, p2;
+
+        c = x0 * x0 + z0 * z0 - 2.0 * z0 * r;
+        b = 2.0 * (x0 * mx + (z0 - r) * mz);
+        a = mx * mx + mz * mz;
+
+        ZeroVec3(PosXYZ);
+        ZeroVec3(CosKLM);
+        ZeroVec3(DFXYZ);
+
+        if (fabs(a) < 1e-12)
+        {
+            // Ray is parallel to the cylinder -- no solution
             sts = 1;
             *PathLength = 0.0;
         }
         else
         {
-            scratch = sqrt(scratch);
-            // Negative root
-            t1 = -0.5 * (b + scratch) / a;
-            // Positive root
-            t2 = -0.5 * (b - scratch) / a;
-
-            y1 = y0 + t1 * my;
-            y2 = y0 + t2 * my;
-
-            if (t1 > 0.0 && yl <= y1 && y1 <= yu)
+            double scratch = b * b - 4.0 * a * c;
+            if (scratch < 0.0)
             {
-                // First intersection point is on the surface of
-                // the finite length cylinder
-                *PathLength = t1;
-                SetVec3(PosXYZ, x0 + t1 * mx, y1, z0 + t1 * mz);
-                this->surface_normal(PosXYZ, DFXYZ);
-            }
-            else if (t2 > 0.0 && yl <= y2 && y2 <= yu)
-            {
-                // First intersection point is outside of surface of finite
-                // length cylinder. Second intersection point is on the
-                // surface of finite cylinder.
-                *PathLength = t2;
-                SetVec3(PosXYZ, x0 + t2 * mx, y2, z0 + t2 * mz);
-                this->surface_normal(PosXYZ, DFXYZ);
-            }
-            else
-            {
-                // Both intersection points are not on the surface of the
-                // finite length cylinder.
+                // Only imaginary solutions to quadratic equation -- no solution
                 sts = 1;
                 *PathLength = 0.0;
             }
+            else
+            {
+                scratch = sqrt(scratch);
+                // Negative root
+                t1 = -0.5 * (b + scratch) / a;
+                // Positive root
+                t2 = -0.5 * (b - scratch) / a;
+
+                // y1 = y0 + t1 * my;
+                // y2 = y0 + t2 * my;
+                AddVec3(1.0, PosLoc, t1, CosLoc, p1.data);
+                AddVec3(1.0, PosLoc, t2, CosLoc, p2.data);
+
+                if (t1 > 0.0 && this->aper->is_in(p1[0], p1[1]))
+                {
+                    // First intersection point is on the surface of
+                    // the finite length cylinder
+                    *PathLength = t1;
+                    // SetVec3(PosXYZ, x0 + t1 * mx, y1, z0 + t1 * mz);
+                    // AddVec3(1.0, PosLoc, t1, CosLoc, PosXYZ);
+                    // this->surface_normal(PosXYZ, DFXYZ);
+                    CopyVec3(PosXYZ, p1.data);
+                }
+                else if (t2 > 0.0 && this->aper->is_in(p2[0], p2[1]))
+                {
+                    // First intersection point is outside of surface of finite
+                    // length cylinder. Second intersection point is on the
+                    // surface of finite cylinder.
+                    *PathLength = t2;
+                    // SetVec3(PosXYZ, x0 + t2 * mx, y2, z0 + t2 * mz);
+                    // AddVec3(1.0, PosLoc, t2, CosLoc, PosXYZ);
+                    // this->surface_normal(PosXYZ, DFXYZ);
+                    CopyVec3(PosXYZ, p2.data);
+                }
+                else
+                {
+                    // Both intersection points are not on the surface of the
+                    // finite length cylinder.
+                    sts = 1;
+                    *PathLength = 0.0;
+                }
+            }
         }
+
+        if (sts == 0)
+        {
+            CopyVec3(CosKLM, CosLoc);
+            this->surface_normal(PosXYZ, DFXYZ);
+        }
+
+        // std::cout << "Exiting with status: " << sts << std::endl;
+
+        return sts;
     }
 
-    if (sts == 0)
-        CopyVec3(CosKLM, CosLoc);
+    void CylinderCalculator::surface_normal(const double PosXYZ[3],
+                                            double DFXYZ[3])
+    {
+        // TODO: Need to default to returning the surface normal of
+        // whatever is the "front". Is that the inside of the cylinder
+        // (which is used currently) or the outside?
+        DFXYZ[0] = 2.0 * PosXYZ[0];
+        DFXYZ[1] = 0.0;
+        DFXYZ[2] = 2.0 * (PosXYZ[2] - this->radius);
+        return;
+    }
 
-    // std::cout << "Exiting with status: " << sts << std::endl;
-
-    return sts;
-}
-
-void CylinderCalculator::surface_normal(const double PosXYZ[3],
-                                        double DFXYZ[3])
-{
-    // TODO: Need to default to returning the surface normal of
-    // whatever is the "front". Is that the inside of the parabola
-    // (which is used currently) or the outside?
-    DFXYZ[0] = 2.0 * PosXYZ[0];
-    DFXYZ[1] = 0.0;
-    DFXYZ[2] = 2.0 * PosXYZ[2];
-    return;
-}
-
-double CylinderCalculator::compute_z_aperture(aperture_ptr ap)
-{
-    double zmax = 2.0 * this->radius;
-    return zmax;
-}
+    double CylinderCalculator::compute_z_aperture(aperture_ptr ap)
+    {
+        double zmax = 2.0 * this->radius;
+        return zmax;
+    }
 
 } // namespace SolTrace::NativeRunner

--- a/coretrace/simulation_runner/native_runner/cylinder_calculator.hpp
+++ b/coretrace/simulation_runner/native_runner/cylinder_calculator.hpp
@@ -27,7 +27,9 @@ public:
 private:
     double radius;
     // double length_x;
-    double length_y;
+    // double length_y;
+
+    SolTrace::Data::aperture_ptr aper;
 };
 
 } // namespace SolTrace::NativeRunner

--- a/coretrace/simulation_runner/native_runner/determine_element_intersection_new.cpp
+++ b/coretrace/simulation_runner/native_runner/determine_element_intersection_new.cpp
@@ -16,7 +16,7 @@ void DetermineElementIntersectionNew(
     int *Intercept,
     int *BacksideFlag)
 {
-    double x, y;
+    // double x, y;
 
     *ErrorFlag = 0;
 
@@ -43,36 +43,39 @@ void DetermineElementIntersectionNew(
         return;
     }
 
-    x = PosRayOut[0];
-    y = PosRayOut[1];
+    // x = PosRayOut[0];
+    // y = PosRayOut[1];
 
-    // std::cout << "x: " << x << "  y: " << y
-    //           << "\nis in: " << Element->aperture->is_in(x, y)
-    //           << "\nz: " << PosRayOut[2]
-    //           << "\nZAp: " << Element->ZAperture
-    //           << std::endl;
+    // // std::cout << "x: " << x << "  y: " << y
+    // //           << "\nis in: " << Element->aperture->is_in(x, y)
+    // //           << "\nz: " << PosRayOut[2]
+    // //           << "\nZAp: " << Element->ZAperture
+    // //           << std::endl;
 
-    if (Element->aperture->is_in(x, y))
-    {
-        *BacksideFlag = DOT(CosRayIn, DFXYZ) < 0 ? 0 : 1;
-        *Intercept = 1;
-    }
-    else
-    {
-        *Intercept = 0;
-        PosRayOut[0] = 0.0;
-        PosRayOut[1] = 0.0;
-        PosRayOut[2] = 0.0;
-        CosRayOut[0] = 0.0;
-        CosRayOut[1] = 0.0;
-        CosRayOut[2] = 0.0;
-        DFXYZ[0] = 0.0;
-        DFXYZ[1] = 0.0;
-        DFXYZ[2] = 0.0;
-        *PathLength = 0.0;
-        *ErrorFlag = 0;
-        *BacksideFlag = 0;
-    }
+    // if (Element->aperture->is_in(x, y))
+    // {
+    //     *BacksideFlag = DOT(CosRayIn, DFXYZ) < 0 ? 0 : 1;
+    //     *Intercept = 1;
+    // }
+    // else
+    // {
+    //     *Intercept = 0;
+    //     PosRayOut[0] = 0.0;
+    //     PosRayOut[1] = 0.0;
+    //     PosRayOut[2] = 0.0;
+    //     CosRayOut[0] = 0.0;
+    //     CosRayOut[1] = 0.0;
+    //     CosRayOut[2] = 0.0;
+    //     DFXYZ[0] = 0.0;
+    //     DFXYZ[1] = 0.0;
+    //     DFXYZ[2] = 0.0;
+    //     *PathLength = 0.0;
+    //     *ErrorFlag = 0;
+    //     *BacksideFlag = 0;
+    // }
+
+    *BacksideFlag = DOT(CosRayIn, DFXYZ) < 0.0 ? 0 : 1;
+    *Intercept = 1;
 
     // if hit on backside of element then slope of surface is reversed
     if (*BacksideFlag)
@@ -85,6 +88,4 @@ void DetermineElementIntersectionNew(
     return;
 }
 
-// #undef sign
-// #undef sqr
 } // namespace SolTrace::NativeRunner

--- a/coretrace/simulation_runner/native_runner/find_element_hit.cpp
+++ b/coretrace/simulation_runner/native_runner/find_element_hit.cpp
@@ -5,141 +5,142 @@
 #include "find_element_hit.hpp"
 #include "native_runner_types.hpp"
 
-namespace SolTrace::NativeRunner {
-
-void FindElementHit(
-	// stage info
-	const int i,
-	const tstage_ptr Stage,
-	const bool PT_override,
-	const bool AsPowerTower,
-	// element info
-	const int nintelements,
-	const std::vector<void *> &sunint_elements,
-	const std::vector<void *> &reflint_elements,
-	// ray info
-	const int RayNumber,
-	const bool in_multi_hit_loop,
-	double (&PosRayStage)[3],
-	double (&CosRayStage)[3],
-	// outputs
-	double (&LastPosRaySurfElement)[3],
-	double (&LastCosRaySurfElement)[3],
-	double (&LastDFXYZ)[3],
-	uint_fast64_t &LastElementNumber,
-	uint_fast64_t &LastRayNumber,
-	double (&LastPosRaySurfStage)[3],
-	double (&LastCosRaySurfStage)[3],
-	int &ErrorFlag,
-	int &LastHitBackSide,
-	bool &StageHit)
+namespace SolTrace::NativeRunner
 {
-	// Initialize Variables
-	double LastPathLength = 1e99;
-	int HitBackSide = 0;
-	int InterceptFlag = 0;
-	double DFXYZ[3] = {0.0, 0.0, 0.0};
-	double PosRayElement[3] = {0.0, 0.0, 0.0};
-	double CosRayElement[3] = {0.0, 0.0, 0.0};
-	double PosRaySurfStage[3] = {0.0, 0.0, 0.0};
-	double CosRaySurfStage[3] = {0.0, 0.0, 0.0};
-	double PosRaySurfElement[3] = {0.0, 0.0, 0.0};
-	double CosRaySurfElement[3] = {0.0, 0.0, 0.0};
-	StageHit = false;
 
-	for (uint_fast64_t j = 0; j < nintelements; j++)
+	void FindElementHit(
+		// stage info
+		const int i,
+		const tstage_ptr Stage,
+		const bool PT_override,
+		const bool AsPowerTower,
+		// element info
+		const int nintelements,
+		const std::vector<void *> &sunint_elements,
+		const std::vector<void *> &reflint_elements,
+		// ray info
+		const int RayNumber,
+		const bool in_multi_hit_loop,
+		double (&PosRayStage)[3],
+		double (&CosRayStage)[3],
+		// outputs
+		double (&LastPosRaySurfElement)[3],
+		double (&LastCosRaySurfElement)[3],
+		double (&LastDFXYZ)[3],
+		uint_fast64_t &LastElementNumber,
+		uint_fast64_t &LastRayNumber,
+		double (&LastPosRaySurfStage)[3],
+		double (&LastCosRaySurfStage)[3],
+		int &ErrorFlag,
+		int &LastHitBackSide,
+		bool &StageHit)
 	{
-		TElement *Element; // = Stage->ElementList[j];
-		if (i == 0 && !PT_override)
+		// Initialize Variables
+		double LastPathLength = 1e99;
+		int HitBackSide = 0;
+		int InterceptFlag = 0;
+		double DFXYZ[3] = {0.0, 0.0, 0.0};
+		double PosRayElement[3] = {0.0, 0.0, 0.0};
+		double CosRayElement[3] = {0.0, 0.0, 0.0};
+		double PosRaySurfStage[3] = {0.0, 0.0, 0.0};
+		double CosRaySurfStage[3] = {0.0, 0.0, 0.0};
+		double PosRaySurfElement[3] = {0.0, 0.0, 0.0};
+		double CosRaySurfElement[3] = {0.0, 0.0, 0.0};
+		StageHit = false;
+
+		for (uint_fast64_t j = 0; j < nintelements; j++)
 		{
-			if (in_multi_hit_loop)
+			TElement *Element; // = Stage->ElementList[j];
+			if (i == 0 && !PT_override)
 			{
-				if (AsPowerTower)
+				if (in_multi_hit_loop)
 				{
-					Element = (TElement *)reflint_elements.at(j);
+					if (AsPowerTower)
+					{
+						Element = (TElement *)reflint_elements.at(j);
+					}
+					else
+					{
+						Element = Stage->ElementList[j].get();
+					}
 				}
 				else
 				{
-					Element = Stage->ElementList[j].get();
+					Element = (TElement *)sunint_elements.at(j);
 				}
 			}
 			else
 			{
-				Element = (TElement *)sunint_elements.at(j);
+				Element = Stage->ElementList[j].get();
 			}
-		}
-		else
-		{
-			Element = Stage->ElementList[j].get();
-		}
 
-		// if (!Element->Enabled)
-		// 	continue;
+			// if (!Element->Enabled)
+			// 	continue;
 
-		//  {Transform ray to element[j] coord system of Stage[i]}
-		TransformToLocal(PosRayStage, CosRayStage,
-						 Element->Origin, Element->RRefToLoc,
-						 PosRayElement, CosRayElement);
+			//  {Transform ray to element[j] coord system of Stage[i]}
+			TransformToLocal(PosRayStage, CosRayStage,
+							 Element->Origin, Element->RRefToLoc,
+							 PosRayElement, CosRayElement);
 
-		ErrorFlag = 0;
-		HitBackSide = 0;
-		InterceptFlag = 0;
-		double PathLength = 0;
+			ErrorFlag = 0;
+			HitBackSide = 0;
+			InterceptFlag = 0;
+			double PathLength = 0;
 
-		// increment position by tiny amount to get off the element
-		// if tracing to the same element
-		PosRayElement[0] = PosRayElement[0] + 1.0e-5 * CosRayElement[0];
-		PosRayElement[1] = PosRayElement[1] + 1.0e-5 * CosRayElement[1];
-		PosRayElement[2] = PosRayElement[2] + 1.0e-5 * CosRayElement[2];
+			// increment position by tiny amount to get off the element
+			// if tracing to the same element
+			PosRayElement[0] = PosRayElement[0] + 1.0e-5 * CosRayElement[0];
+			PosRayElement[1] = PosRayElement[1] + 1.0e-5 * CosRayElement[1];
+			PosRayElement[2] = PosRayElement[2] + 1.0e-5 * CosRayElement[2];
 
-		// {Determine if ray intersects element[j]; if so, Find intersection
-		// point with surface of element[j] }
-		DetermineElementIntersectionNew(Element,
-										PosRayElement,
-										CosRayElement,
-										PosRaySurfElement,
-										CosRaySurfElement,
-										DFXYZ,
-										&PathLength,
-										&ErrorFlag,
-										&InterceptFlag,
-										&HitBackSide);
+			// {Determine if ray intersects element[j]; if so, Find intersection
+			// point with surface of element[j] }
+			DetermineElementIntersectionNew(Element,
+											PosRayElement,
+											CosRayElement,
+											PosRaySurfElement,
+											CosRaySurfElement,
+											DFXYZ,
+											&PathLength,
+											&ErrorFlag,
+											&InterceptFlag,
+											&HitBackSide);
 
-		if (InterceptFlag)
-		{
-			// {If hit multiple elements, this loop determines which one hit
-			// first. Also makes sure that correct part of closed surface is
-			// hit. Also, handles wavy, but close to flat zernikes and
-			// polynomials correctly.}
-			if (PathLength < LastPathLength)
+			if (InterceptFlag)
 			{
-				// if (PosRaySurfElement[2] <= Element->ZAperture ||
-				// 	Element->SurfaceIndex == 'm' ||
-				// 	Element->SurfaceIndex == 'M' ||
-				// 	Element->SurfaceIndex == 'r' ||
-				// 	Element->SurfaceIndex == 'R')
-				// TODO: Is this the correct thing to do?
-				if (PosRaySurfElement[2] <= Element->ZAperture)
+				// {If hit multiple elements, this loop determines which one hit
+				// first. Also makes sure that correct part of closed surface is
+				// hit. Also, handles wavy, but close to flat zernikes and
+				// polynomials correctly.}
+				if (PathLength < LastPathLength)
 				{
-					StageHit = true;
-					LastPathLength = PathLength;
-					CopyVec3(LastPosRaySurfElement, PosRaySurfElement);
-					CopyVec3(LastCosRaySurfElement, CosRaySurfElement);
-					CopyVec3(LastDFXYZ, DFXYZ);
-					// LastElementNumber = ((i == 0 && !PT_override) ? Element->element_number : j + 1); // mjw change from j index to element id
-					LastElementNumber = Element->element_number;
-					LastRayNumber = RayNumber;
-					TransformToReference(PosRaySurfElement, CosRaySurfElement,
-										 Element->Origin, Element->RLocToRef,
-										 PosRaySurfStage, CosRaySurfStage);
+					// if (PosRaySurfElement[2] <= Element->ZAperture ||
+					// 	Element->SurfaceIndex == 'm' ||
+					// 	Element->SurfaceIndex == 'M' ||
+					// 	Element->SurfaceIndex == 'r' ||
+					// 	Element->SurfaceIndex == 'R')
+					// TODO: Is this the correct thing to do?
+					if (PosRaySurfElement[2] <= Element->ZAperture)
+					{
+						StageHit = true;
+						LastPathLength = PathLength;
+						CopyVec3(LastPosRaySurfElement, PosRaySurfElement);
+						CopyVec3(LastCosRaySurfElement, CosRaySurfElement);
+						CopyVec3(LastDFXYZ, DFXYZ);
+						// LastElementNumber = ((i == 0 && !PT_override) ? Element->element_number : j + 1); // mjw change from j index to element id
+						LastElementNumber = Element->element_number;
+						LastRayNumber = RayNumber;
+						TransformToReference(PosRaySurfElement, CosRaySurfElement,
+											 Element->Origin, Element->RLocToRef,
+											 PosRaySurfStage, CosRaySurfStage);
 
-					CopyVec3(LastPosRaySurfStage, PosRaySurfStage);
-					CopyVec3(LastCosRaySurfStage, CosRaySurfStage);
-					LastHitBackSide = HitBackSide;
+						CopyVec3(LastPosRaySurfStage, PosRaySurfStage);
+						CopyVec3(LastCosRaySurfStage, CosRaySurfStage);
+						LastHitBackSide = HitBackSide;
+					}
 				}
 			}
 		}
 	}
-}
 
 } // namespace SolTrace::NativeRunner

--- a/coretrace/simulation_runner/native_runner/flat_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/flat_calculator.cpp
@@ -10,86 +10,95 @@
 #include "simulation_data_export.hpp"
 #include "surface.hpp"
 
-namespace SolTrace::NativeRunner {
-
-FlatCalculator::FlatCalculator(surface_ptr surf)
-    : SurfaceIntersectionCalculator()
+namespace SolTrace::NativeRunner
 {
-    if (surf == nullptr)
+
+    FlatCalculator::FlatCalculator(surface_ptr surf, aperture_ptr ap)
+        : SurfaceIntersectionCalculator(),
+          aper(ap)
     {
-        throw std::invalid_argument("FlatCalculator: Surface pointer cannot be null");
-    }
-
-    auto flat = std::dynamic_pointer_cast<Flat>(surf);
-    if (flat == nullptr)
-    {
-        throw std::invalid_argument("FlatCalculator: Surface must be of type Flat");
-    }
-}
-
-FlatCalculator::~FlatCalculator() {}
-
-int FlatCalculator::intersect(const double PosLoc[3],
-                              const double CosLoc[3],
-                              double PosXYZ[3],
-                              double CosKLM[3],
-                              double DFXYZ[3],
-                              double *PathLength)
-{
-    int sts = 0;
-    // TODO: Make sure that intersection should be computed
-    // in local coordinate frame.
-    double x0 = PosLoc[0];
-    double y0 = PosLoc[1];
-    double z0 = PosLoc[2];
-    double mx = CosLoc[0];
-    double my = CosLoc[1];
-    double mz = CosLoc[2];
-    double t;
-
-    ZeroVec3(PosXYZ);
-    ZeroVec3(DFXYZ);
-    ZeroVec3(CosKLM);
-
-    if (fabs(mz) < 1e-12)
-    {
-        // Ray is parallel to the flat plane.
-        // It does not intersect.
-        sts = 1;
-        *PathLength = 0.0;
-    }
-    else
-    {
-        t = -z0 / mz;
-
-        if (t > 0.0)
+        if (surf == nullptr)
         {
-            CopyVec3(CosKLM, CosLoc);
-
-            PosXYZ[0] = x0 + t * mx;
-            PosXYZ[1] = y0 + t * my;
-            PosXYZ[2] = 0.0;
-
-            DFXYZ[0] = DFXYZ[1] = 0.0;
-            DFXYZ[2] = 1.0;
-
-            assert(fabs(z0 + t * mz) < 1e-12);
-
-            *PathLength = t;
+            throw std::invalid_argument("FlatCalculator: Surface pointer cannot be null");
         }
-        else
+
+        auto flat = std::dynamic_pointer_cast<Flat>(surf);
+        if (flat == nullptr)
         {
+            throw std::invalid_argument("FlatCalculator: Surface must be of type Flat");
+        }
+
+        if (ap == nullptr)
+        {
+            throw std::invalid_argument("FlatCalculator: Aperture pointer cannot be null");
+        }
+    }
+
+    FlatCalculator::~FlatCalculator() {}
+
+    int FlatCalculator::intersect(const double PosLoc[3],
+                                  const double CosLoc[3],
+                                  double PosXYZ[3],
+                                  double CosKLM[3],
+                                  double DFXYZ[3],
+                                  double *PathLength)
+    {
+        int sts = 0;
+        // TODO: Make sure that intersection should be computed
+        // in local coordinate frame.
+        double x0 = PosLoc[0];
+        double y0 = PosLoc[1];
+        double z0 = PosLoc[2];
+        double mx = CosLoc[0];
+        double my = CosLoc[1];
+        double mz = CosLoc[2];
+        double t;
+
+        ZeroVec3(PosXYZ);
+        ZeroVec3(DFXYZ);
+        ZeroVec3(CosKLM);
+
+        if (fabs(mz) < 1e-12)
+        {
+            // Ray is parallel to the flat plane.
+            // It does not intersect.
             sts = 1;
             *PathLength = 0.0;
         }
+        else
+        {
+            t = -z0 / mz;
+            x0 += t * mx;
+            y0 += t * my;
+
+            if (t > 0.0 && this->aper->is_in(x0, y0))
+            {
+                CopyVec3(CosKLM, CosLoc);
+
+                PosXYZ[0] = x0;
+                PosXYZ[1] = y0;
+                PosXYZ[2] = 0.0;
+
+                DFXYZ[0] = DFXYZ[1] = 0.0;
+                DFXYZ[2] = 1.0;
+
+                assert(fabs(z0 + t * mz) < 1e-12);
+
+                *PathLength = t;
+            }
+            else
+            {
+                sts = 1;
+                *PathLength = 0.0;
+            }
+        }
+
+        return sts;
     }
 
-    return sts;
-}
-
-double FlatCalculator::compute_z_aperture(aperture_ptr ap)
-{
-    return 0.0;
-}
+    double FlatCalculator::compute_z_aperture(aperture_ptr ap)
+    {
+        return 0.0;
+    }
 
 } // namespace SolTrace::NativeRunner

--- a/coretrace/simulation_runner/native_runner/flat_calculator.hpp
+++ b/coretrace/simulation_runner/native_runner/flat_calculator.hpp
@@ -5,22 +5,27 @@
 #include "surface.hpp"
 #include "surface_intersection_calculator.hpp"
 
-namespace SolTrace::NativeRunner {
-
-class FlatCalculator : public SurfaceIntersectionCalculator
+namespace SolTrace::NativeRunner
 {
-public:
-    FlatCalculator(SolTrace::Data::surface_ptr surf);
-    virtual ~FlatCalculator();
-    virtual int intersect(const double PosLoc[3],
-                          const double CosLoc[3],
-                          double PosXYZ[3],
-                          double CosKLM[3],
-                          double DFXYZ[3],
-                          double *PathLength);
 
-    virtual double compute_z_aperture(SolTrace::Data::aperture_ptr ap);
-};
+    class FlatCalculator : public SurfaceIntersectionCalculator
+    {
+    public:
+        FlatCalculator(SolTrace::Data::surface_ptr surf,
+                       SolTrace::Data::aperture_ptr ap);
+        virtual ~FlatCalculator();
+        virtual int intersect(const double PosLoc[3],
+                              const double CosLoc[3],
+                              double PosXYZ[3],
+                              double CosKLM[3],
+                              double DFXYZ[3],
+                              double *PathLength);
+
+        virtual double compute_z_aperture(SolTrace::Data::aperture_ptr ap);
+
+    private:
+        SolTrace::Data::aperture_ptr aper;
+    };
 
 } // namespace SolTrace::NativeRunner
 

--- a/coretrace/simulation_runner/native_runner/native_runner_types.cpp
+++ b/coretrace/simulation_runner/native_runner/native_runner_types.cpp
@@ -521,6 +521,11 @@ namespace SolTrace::NativeRunner
                                int_fast64_t el_num,
                                const ElementParameters &eparams)
     {
+        // std::cout << "Name: " << el->get_name()
+        //           << "\nSDID: " << el->get_id()
+        //           << "\nNum: " << el_num
+        //           << std::endl;
+
         telement_ptr telem = std::make_shared<TElement>();
         vector_copy(telem->Origin, el->get_origin_stage());
         vector_copy(telem->AimPoint, el->get_aim_vector_stage());
@@ -572,8 +577,8 @@ namespace SolTrace::NativeRunner
 
         // TODO: What to do with these fields?
         my_stage->MultiHitsPerRay = true;
-        my_stage->Virtual = false;
-        my_stage->TraceThrough = false;
+        my_stage->Virtual = stage_el->is_virtual();
+        my_stage->TraceThrough = true;
         my_stage->stage_id = stage_el->get_stage();
 
         // Add coordinate stuff

--- a/coretrace/simulation_runner/native_runner/native_runner_types.hpp
+++ b/coretrace/simulation_runner/native_runner/native_runner_types.hpp
@@ -229,7 +229,8 @@ namespace SolTrace::NativeRunner
 			double cos[3];
 			int element;
 			int stage;
-			unsigned int raynum;
+			// unsigned int raynum;
+			SolTrace::Result::ray_id raynum;
 			SolTrace::Result::RayEvent event;
 		};
 

--- a/coretrace/simulation_runner/native_runner/newton_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/newton_calculator.cpp
@@ -5,79 +5,84 @@
 #include <cstdint>
 
 #include "simulation_data_export.hpp"
-#include "vector3d.hpp"
+// #include "vector3d.hpp"
 
-namespace SolTrace::NativeRunner {
-
-NewtonCalculator::NewtonCalculator(double tol, uint_fast64_t max_iters)
-    : SurfaceIntersectionCalculator(),
-      tolerance(tol),
-      max_iters(max_iters)
+namespace SolTrace::NativeRunner
 {
-}
 
-int NewtonCalculator::intersect(const double PosLoc[3],
-                                const double CosLoc[3],
-                                double PosXYZ[3],
-                                double CosKLM[3],
-                                double DFXYZ[3],
-                                double *PathLength)
-{
-    int sts = 1;
-    uint_fast64_t count = 0;
-
-    // double x0 = PosLoc[0], y0 = PosLoc[1], z0 = PosLoc[2];
-    // double mx = CosLoc[0], my = CosLoc[1], mz = CosLoc[2];
-    Vector3d u0(PosLoc);
-    Vector3d dt(CosLoc);
-
-    double t0 = 0.0;
-    double delta = 0.0;
-    // double res;
-    double fvalue;
-    double fprime;
-    Vector3d v0(PosLoc);
-    Vector3d dv;
-
-    *PathLength = 0.0;
-    ZeroVec3(PosXYZ);
-    ZeroVec3(CosKLM);
-    ZeroVec3(DFXYZ);
-
-    // this->set_zstart(v0.data);
-    this->surface_and_jacobian(v0.data, &fvalue, dv.data);
-    fprime = dot_product(dv, dt);
-
-    // std::cout << "Tolerance: " << this->tolerance << std::endl;
-
-    while (fabs(fvalue) > this->tolerance && count <= this->max_iters)
+    NewtonCalculator::NewtonCalculator(aperture_ptr ap,
+                                       double tol,
+                                       uint_fast64_t max_iters)
+        : SurfaceIntersectionCalculator(),
+          aper(ap),
+          tolerance(tol),
+          max_iters(max_iters)
     {
-        // std::cout << "**** ITER: " << count << " ****"
-        //           << "\nt = " << t0
-        //           << "\ndelta = " << delta
-        //           << "\nf(t) = " << fvalue
-        //           << "\nf'(t) = " << fprime
-        //           << "\nu0 = " << v0
-        //           << std::endl;
-        delta = fvalue / fprime;
-        t0 -= delta;
-        // Updates v0 to (x0, y0, z0) + t0 * (mx, my, mz)
-        vector_add(1.0, u0, t0, dt, v0);
+    }
+
+    int NewtonCalculator::intersect(const double PosLoc[3],
+                                    const double CosLoc[3],
+                                    double PosXYZ[3],
+                                    double CosKLM[3],
+                                    double DFXYZ[3],
+                                    double *PathLength)
+    {
+        int sts = 1;
+        uint_fast64_t count = 0;
+
+        // double x0 = PosLoc[0], y0 = PosLoc[1], z0 = PosLoc[2];
+        // double mx = CosLoc[0], my = CosLoc[1], mz = CosLoc[2];
+        Vector3d u0(PosLoc);
+        Vector3d dt(CosLoc);
+
+        double t0 = 0.0;
+        double delta = 0.0;
+        // double res;
+        double fvalue;
+        double fprime;
+        Vector3d v0(PosLoc);
+        Vector3d dv;
+
+        *PathLength = 0.0;
+        ZeroVec3(PosXYZ);
+        ZeroVec3(CosKLM);
+        ZeroVec3(DFXYZ);
+
+        // this->set_zstart(v0.data);
         this->surface_and_jacobian(v0.data, &fvalue, dv.data);
         fprime = dot_product(dv, dt);
-        ++count;
-    }
 
-    if (fabs(fvalue) <= this->tolerance)
-    {
-        sts = 0;
-        *PathLength = t0;
-        CopyVec3(CosKLM, CosLoc);
-        CopyVec3(PosXYZ, v0.data);
-        CopyVec3(DFXYZ, dv.data);
-    }
+        // std::cout << "Tolerance: " << this->tolerance << std::endl;
 
-    return sts;
-}
+        while (fabs(fvalue) > this->tolerance && count <= this->max_iters)
+        {
+            // std::cout << "**** ITER: " << count << " ****"
+            //           << "\nt = " << t0
+            //           << "\ndelta = " << delta
+            //           << "\nf(t) = " << fvalue
+            //           << "\nf'(t) = " << fprime
+            //           << "\nu0 = " << v0
+            //           << std::endl;
+            delta = fvalue / fprime;
+            t0 -= delta;
+            // Updates v0 to (x0, y0, z0) + t0 * (mx, my, mz)
+            vector_add(1.0, u0, t0, dt, v0);
+            this->surface_and_jacobian(v0.data, &fvalue, dv.data);
+            fprime = dot_product(dv, dt);
+            ++count;
+        }
+
+        if (fabs(fvalue) <= this->tolerance &&
+            this->aper->is_in(v0[0], v0[1]))
+        {
+            sts = 0;
+            *PathLength = t0;
+            CopyVec3(CosKLM, CosLoc);
+            CopyVec3(PosXYZ, v0.data);
+            CopyVec3(DFXYZ, dv.data);
+        }
+
+        return sts;
+    }
 
 } // namespace SolTrace::NativeRunner

--- a/coretrace/simulation_runner/native_runner/newton_calculator.hpp
+++ b/coretrace/simulation_runner/native_runner/newton_calculator.hpp
@@ -3,45 +3,50 @@
 
 #include <cstdint>
 
+#include "aperture.hpp"
 #include "surface_intersection_calculator.hpp"
 
 // #include "surface.hpp"
 
-namespace SolTrace::NativeRunner {
-
-class NewtonCalculator : public SurfaceIntersectionCalculator
+namespace SolTrace::NativeRunner
 {
-public:
-    NewtonCalculator(double tol=1e-6, uint_fast64_t max_iters=20);
-    virtual ~NewtonCalculator() {}
 
-    virtual int intersect(const double PosLoc[3],
-                          const double CosLoc[3],
-                          double PosXYZ[3],
-                          double CosKLM[3],
-                          double DFXYZ[3],
-                          double *PathLength);
-
-    // For x = PosXYZ[0], y = PosXYZ[1], make a guess at
-    // value of z and place in PosXYZ[2].
-    virtual void set_zstart(double PosXYZ[3]) = 0;
-    virtual void surface_and_jacobian(const double PosXYZ[3],
-                                      double *F,
-                                      double DFXYZ[3]) = 0;
-
-    inline double get_tolerance() const
+    class NewtonCalculator : public SurfaceIntersectionCalculator
     {
-        return this->tolerance;
-    }
-    inline uint_fast64_t get_max_iters() const
-    {
-        return this->max_iters;
-    }
+    public:
+        NewtonCalculator(SolTrace::Data::aperture_ptr ap,
+                         double tol = 1e-6,
+                         uint_fast64_t max_iters = 20);
+        virtual ~NewtonCalculator() {}
 
-private:
-    double tolerance;
-    uint_fast64_t max_iters;
-};
+        virtual int intersect(const double PosLoc[3],
+                              const double CosLoc[3],
+                              double PosXYZ[3],
+                              double CosKLM[3],
+                              double DFXYZ[3],
+                              double *PathLength);
+
+        // For x = PosXYZ[0], y = PosXYZ[1], make a guess at
+        // value of z and place in PosXYZ[2].
+        virtual void set_zstart(double PosXYZ[3]) = 0;
+        virtual void surface_and_jacobian(const double PosXYZ[3],
+                                          double *F,
+                                          double DFXYZ[3]) = 0;
+
+        inline double get_tolerance() const
+        {
+            return this->tolerance;
+        }
+        inline uint_fast64_t get_max_iters() const
+        {
+            return this->max_iters;
+        }
+
+    private:
+        SolTrace::Data::aperture_ptr aper;
+        double tolerance;
+        uint_fast64_t max_iters;
+    };
 
 } // namespace SolTrace::NativeRunner
 

--- a/coretrace/simulation_runner/native_runner/parabola_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/parabola_calculator.cpp
@@ -15,7 +15,8 @@
 namespace SolTrace::NativeRunner
 {
 
-    ParabolaCalculator::ParabolaCalculator(surface_ptr surf)
+    ParabolaCalculator::ParabolaCalculator(surface_ptr surf, aperture_ptr ap)
+        : aper(ap)
     {
         if (surf == nullptr)
         {
@@ -40,9 +41,15 @@ namespace SolTrace::NativeRunner
         {
             throw std::invalid_argument("ParabolaCalculator: Focal lengths cannot be NaN");
         }
+
         if (std::isinf(fx) && std::isinf(fy))
         {
             throw std::invalid_argument("ParabolaCalculator: Both focal lengths cannot be infinite");
+        }
+
+        if (ap == nullptr)
+        {
+            throw std::invalid_argument("ParabolaCalculator: Aperture pointer cannot be null");
         }
 
         this->cx = fabs(fx) < 1e-12 ? 0.0 : 0.5 / fx;
@@ -75,6 +82,7 @@ namespace SolTrace::NativeRunner
         double cx = this->cx, cy = this->cy;
         double t1, t2;
         double a, b, c;
+        Vector3d p1, p2;
 
         c = 0.5 * (cx * x0 * x0 + cy * y0 * y0) - z0;
         b = (x0 * cx * mx + y0 * cy * my - mz);
@@ -84,21 +92,30 @@ namespace SolTrace::NativeRunner
         ZeroVec3(CosKLM);
         ZeroVec3(DFXYZ);
 
+        // std::cout << "a: " << a
+        //           << " b: " << b
+        //           << " c: " << c
+        //           << std::endl;
+
         if (fabs(a) < 1e-12)
         {
             // This should only happen if mx == my == 0.0
             t1 = -c / b;
-            if (t1 <= 0.0)
+            AddVec3(1.0, PosLoc, t1, CosLoc, p1.data);
+
+            if (t1 > 0.0 && this->aper->is_in(p1[0], p1[1]))
+            {
+                *PathLength = t1;
+                // SetVec3(PosXYZ, x0 + t1 * mx, y0 + t1 * my, z0 + t1 * mz);
+                // AddVec3(1.0, PosLoc, t1, CosLoc, PosXYZ);
+                CopyVec3(PosXYZ, p1.data);
+            }
+            else
             {
                 // Intersection is behind the ray -- same as
                 // no solution.
                 sts = 1;
                 *PathLength = 0.0;
-            }
-            else
-            {
-                *PathLength = t1;
-                SetVec3(PosXYZ, x0 + t1 * mx, y0 + t1 * my, z0 + t1 * mz);
             }
         }
         else
@@ -123,15 +140,26 @@ namespace SolTrace::NativeRunner
                 // Positive root
                 t2 = -0.5 * (b - scratch) / a;
 
-                if (t1 > 0.0)
+                AddVec3(1.0, PosLoc, t1, CosLoc, p1.data);
+                AddVec3(1.0, PosLoc, t2, CosLoc, p2.data);
+
+                // std::cout << "P1: " << p1
+                //           << "\nP2: " << p2
+                //           << std::endl;
+
+                if (t1 > 0.0 && this->aper->is_in(p1[0], p1[1]))
                 {
                     *PathLength = t1;
-                    SetVec3(PosXYZ, x0 + t1 * mx, y0 + t1 * my, z0 + t1 * mz);
+                    // SetVec3(PosXYZ, x0 + t1 * mx, y0 + t1 * my, z0 + t1 * mz);
+                    // AddVec3(1.0, PosLoc, t1, CosLoc, PosXYZ);
+                    CopyVec3(PosXYZ, p1.data);
                 }
-                else if (t2 > 0.0)
+                else if (t2 > 0.0 && this->aper->is_in(p2[0], p2[1]))
                 {
                     *PathLength = t2;
-                    SetVec3(PosXYZ, x0 + t2 * mx, y0 + t2 * my, z0 + t2 * mz);
+                    // SetVec3(PosXYZ, x0 + t2 * mx, y0 + t2 * my, z0 + t2 * mz);
+                    // AddVec3(1.0, PosLoc, t2, CosLoc, PosXYZ);
+                    CopyVec3(PosXYZ, p2.data);
                 }
                 else
                 {

--- a/coretrace/simulation_runner/native_runner/parabola_calculator.hpp
+++ b/coretrace/simulation_runner/native_runner/parabola_calculator.hpp
@@ -6,28 +6,32 @@
 #include "aperture.hpp"
 #include "surface.hpp"
 
-namespace SolTrace::NativeRunner {
-
-class ParabolaCalculator : public SurfaceIntersectionCalculator
+namespace SolTrace::NativeRunner
 {
-public:
-    ParabolaCalculator(SolTrace::Data::surface_ptr surf);
-    virtual ~ParabolaCalculator();
-    virtual int intersect(const double PosLoc[3],
-                          const double CosLoc[3],
-                          double PosXYZ[3],
-                          double CosKLM[3],
-                          double DFXYZ[3],
-                          double *PathLength);
 
-    void surface_normal(const double PosXYZ[3], double DFXYZ[3]);
+    class ParabolaCalculator : public SurfaceIntersectionCalculator
+    {
+    public:
+        ParabolaCalculator(SolTrace::Data::surface_ptr surf,
+                           SolTrace::Data::aperture_ptr ap);
+        virtual ~ParabolaCalculator();
+        virtual int intersect(const double PosLoc[3],
+                              const double CosLoc[3],
+                              double PosXYZ[3],
+                              double CosKLM[3],
+                              double DFXYZ[3],
+                              double *PathLength);
 
-    virtual double compute_z_aperture(SolTrace::Data::aperture_ptr ap);
+        void surface_normal(const double PosXYZ[3], double DFXYZ[3]);
 
-private:
-    double cx;
-    double cy;
-};
+        virtual double compute_z_aperture(SolTrace::Data::aperture_ptr ap);
+
+    private:
+        double cx;
+        double cy;
+
+        SolTrace::Data::aperture_ptr aper;
+    };
 
 } // namespace SolTrace::NativeRunner
 

--- a/coretrace/simulation_runner/native_runner/sphere_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/sphere_calculator.cpp
@@ -16,7 +16,8 @@
 namespace SolTrace::NativeRunner
 {
 
-    SphereCalculator::SphereCalculator(surface_ptr surf)
+    SphereCalculator::SphereCalculator(surface_ptr surf, aperture_ptr ap)
+        : aper(ap)
     {
         if (surf == nullptr)
         {
@@ -42,6 +43,11 @@ namespace SolTrace::NativeRunner
             throw std::invalid_argument("SphereCalculator: Vertex curvature cannot be NaN or infinite");
         }
 
+        if (ap == nullptr)
+        {
+            throw std::invalid_argument("SphereCalculator: Aperture pointer cannot be null");
+        }
+
         this->curvature = sph->vertex_curv;
         this->radius = 1.0 / this->curvature;
 
@@ -59,14 +65,19 @@ namespace SolTrace::NativeRunner
                                     double DFXYZ[3],
                                     double *PathLength)
     {
+        // std::cout << "SphereCalculator" << std::endl;
+
         int sts = 0;
 
         double x0 = PosLoc[0], y0 = PosLoc[1], z0 = PosLoc[2];
         double alpha = CosLoc[0], beta = CosLoc[1], gamma = CosLoc[2];
         double r = this->radius;
         double t1, t2;
+        // double x1, y1, z1, x2, y2, z2;
         double a, b, c;
         double scratch;
+
+        Vector3d p1, p2;
 
         c = x0 * x0 + y0 * y0 + z0 * z0 - 2.0 * r * z0;
         b = 2.0 * (alpha * x0 + beta * y0 + gamma * (z0 - r));
@@ -77,6 +88,8 @@ namespace SolTrace::NativeRunner
         ZeroVec3(DFXYZ);
 
         scratch = b * b - 4.0 * a * c;
+
+        // std::cout << "Scratch: " << scratch << std::endl;
 
         if (scratch < 0.0)
         {
@@ -90,17 +103,27 @@ namespace SolTrace::NativeRunner
             t1 = -0.5 * (b + scratch) / a;
             t2 = 0.5 * (scratch - b) / a;
 
-            double z1 = z0 + gamma * t1;
-            double z2 = z0 + gamma * t2;
+            // z1 = z0 + gamma * t1;
+            // z2 = z0 + gamma * t2;
+            AddVec3(1.0, PosLoc, t1, CosLoc, p1.data);
+            AddVec3(1.0, PosLoc, t2, CosLoc, p2.data);
 
-            if (t1 > 0.0 && z1 <= r)
+            // std::cout << "P1: " << p1
+            //           << "\nP2: " << p2
+            //           << std::endl;
+
+            if (t1 > 0.0 && p1[2] <= r && this->aper->is_in(p1[0], p1[1]))
             {
-                SetVec3(PosXYZ, x0 + t1 * alpha, y0 + t1 * beta, z1);
+                // SetVec3(PosXYZ, x0 + t1 * alpha, y0 + t1 * beta, z1);
+                // AddVec3(1.0, PosLoc, t1, CosLoc, PosXYZ);
+                CopyVec3(PosXYZ, p1.data);
                 *PathLength = t1;
             }
-            else if (t2 > 0.0 && z2 <= r)
+            else if (t2 > 0.0 && p2[2] <= r && this->aper->is_in(p2[0], p2[1]))
             {
-                SetVec3(PosXYZ, x0 + t2 * alpha, y0 + t2 * beta, z2);
+                // SetVec3(PosXYZ, x0 + t2 * alpha, y0 + t2 * beta, z2);
+                // AddVec3(1.0, PosLoc, t2, CosLoc, PosXYZ);
+                CopyVec3(PosXYZ, p2.data);
                 *PathLength = t2;
             }
             else

--- a/coretrace/simulation_runner/native_runner/sphere_calculator.hpp
+++ b/coretrace/simulation_runner/native_runner/sphere_calculator.hpp
@@ -6,28 +6,32 @@
 #include "aperture.hpp"
 #include "surface.hpp"
 
-namespace SolTrace::NativeRunner {
-
-class SphereCalculator : public SurfaceIntersectionCalculator
+namespace SolTrace::NativeRunner
 {
-public:
-    SphereCalculator(SolTrace::Data::surface_ptr surf);
-    virtual ~SphereCalculator() {}
-    virtual int intersect(const double PosLoc[3],
-                          const double CosLoc[3],
-                          double PosXYZ[3],
-                          double CosKLM[3],
-                          double DFXYZ[3],
-                          double *PathLength);
 
-    void surface_normal(const double PosXYZ[3], double DFXYZ[3]);
+    class SphereCalculator : public SurfaceIntersectionCalculator
+    {
+    public:
+        SphereCalculator(SolTrace::Data::surface_ptr surf,
+                         SolTrace::Data::aperture_ptr ap);
+        virtual ~SphereCalculator() {}
+        virtual int intersect(const double PosLoc[3],
+                              const double CosLoc[3],
+                              double PosXYZ[3],
+                              double CosKLM[3],
+                              double DFXYZ[3],
+                              double *PathLength);
 
-    virtual double compute_z_aperture(SolTrace::Data::aperture_ptr ap);
+        void surface_normal(const double PosXYZ[3], double DFXYZ[3]);
 
-private:
-    double radius;
-    double curvature;
-};
+        virtual double compute_z_aperture(SolTrace::Data::aperture_ptr ap);
+
+    private:
+        double radius;
+        double curvature;
+
+        SolTrace::Data::aperture_ptr aper;
+    };
 
 } // namespace SolTrace::NativeRunner
 

--- a/coretrace/simulation_runner/native_runner/trace.cpp
+++ b/coretrace/simulation_runner/native_runner/trace.cpp
@@ -373,7 +373,27 @@ namespace SolTrace::NativeRunner
 
 						// Apply MonteCarlo probability of absorption. Limited
 						// for now, but can make more complex later on if desired
-						if (TestValue <= myrng())
+						// if (TestValue <= myrng())
+						double flip = myrng();
+						// if (RayNumber == 36)
+						// {
+						// 	std::cout << "RAY NUMBER 36!" << std::endl;
+						// }
+						// if (i > 0)
+						// {
+						// 	std::cout << "Ray Number: " << RayNumber
+						// 			  << "\nStage: " << i + 1
+						// 			  << "\nMultiHit: " << Stage->MultiHitsPerRay
+						// 			  << "\nmyrng_counter: " << myrng_counter
+						// 			  << "\nTestValue: " << TestValue
+						// 			  << "\nflip: " << flip
+						// 			  << "\nRayIsAbsorbed: " << (TestValue < flip)
+						// 			  << "\nPosRayGlob: " << Vector3d(PosRayGlob)
+						// 			  << "\nCosRayGlob: " << Vector3d(CosRayGlob)
+						// 			  << "\nDFXYZ: " << Vector3d(LastDFXYZ)
+						// 			  << std::endl;
+						// }
+						if (TestValue <= flip)
 						{
 							myrng_counter++;
 							// ray was fully absorbed

--- a/google-tests/regression-tests/native_runner_performance_test.cpp
+++ b/google-tests/regression-tests/native_runner_performance_test.cpp
@@ -24,8 +24,6 @@ using SolTrace::NativeRunner::TSystem;
 
 TEST(NativeRunner, PerformanceTest)
 {
-    // TODO: Add timing component to test
-
     const uint_fast64_t NRAYS = 100000;
     const Vector3d zero(0.0, 0.0, 0.0);
     const Vector3d khat(0.0, 0.0, 1.0);
@@ -173,123 +171,123 @@ TEST(NativeRunner, PerformanceTest)
     // sys->AllRayData.Print();
 }
 
-TEST(NativeRunner, LargePerformanceTest)
-{
-    // Pulling in path variable from CMake and creating path to .stinput sample file
-    std::string sample_path = std::string(PROJECT_DIR) +
-                              std::string("/Power-tower-surround_singlefacet.stinput");
+// TEST(NativeRunner, LargePerformanceTest)
+// {
+//     // Pulling in path variable from CMake and creating path to .stinput sample file
+//     std::string sample_path = std::string(PROJECT_DIR) +
+//                               std::string("/Power-tower-surround_singlefacet.stinput");
 
-    // Path to .csv exported from Soltrace as ground truth
-    std::string ground_csv_path = PROJECT_DIR +
-                                  std::string("/powertower_example_raydata.csv");
+//     // Path to .csv exported from Soltrace as ground truth
+//     std::string ground_csv_path = PROJECT_DIR +
+//                                   std::string("/powertower_example_raydata.csv");
 
-    // std::ifstream csv_file(ground_csv_path);
-    // std::vector<std::vector<std::string>> ground_raydata = split_csv(
-    //     ground_csv_path);
+//     // std::ifstream csv_file(ground_csv_path);
+//     // std::vector<std::vector<std::string>> ground_raydata = split_csv(
+//     //     ground_csv_path);
 
-    // const char *file = sample_path.data();
+//     // const char *file = sample_path.data();
 
-    // // Soltrace case parameters
-    // int nrays = 50000;
-    // int maxrays = 5000000;
-    // int seed = 1; // Any positive integer will produce the same results each time, -1 will be a random seed
-    // int sunshape = 0;
-    // int errors = 0;
-    // int powertower = 0; // Toggles optimizations for power tower cases
+//     // // Soltrace case parameters
+//     // int nrays = 50000;
+//     // int maxrays = 5000000;
+//     // int seed = 1; // Any positive integer will produce the same results each time, -1 will be a random seed
+//     // int sunshape = 0;
+//     // int errors = 0;
+//     // int powertower = 0; // Toggles optimizations for power tower cases
 
-    // Create Simuluation Data
-    SimulationData sd;
+//     // Create Simuluation Data
+//     SimulationData sd;
 
-    // Constants
-    const uint_fast64_t NRAYS = 50000;
-    const double TOL = 1e-4;
+//     // Constants
+//     const uint_fast64_t NRAYS = 50000;
+//     const double TOL = 1e-4;
 
-    // Read Input File
-    bool success = sd.import_from_file(sample_path);
-    EXPECT_TRUE(success);
-    EXPECT_TRUE(sd.get_number_of_elements() > 0);
-    EXPECT_TRUE(sd.get_number_of_ray_sources() > 0);
+//     // Read Input File
+//     bool success = sd.import_from_file(sample_path);
+//     EXPECT_TRUE(success);
+//     EXPECT_TRUE(sd.get_number_of_elements() > 0);
+//     EXPECT_TRUE(sd.get_number_of_ray_sources() > 0);
 
-    std::cout << "Num Elements: " << sd.get_number_of_elements() << std::endl;
+//     std::cout << "Num Elements: " << sd.get_number_of_elements() << std::endl;
 
-    // Parameters
-    SimulationParameters &params = sd.get_simulation_parameters();
-    params.include_optical_errors = false;
-    params.include_sun_shape_errors = false;
-    params.max_number_of_rays = NRAYS * 100;
-    params.number_of_rays = NRAYS;
-    params.seed = 1;
+//     // Parameters
+//     SimulationParameters &params = sd.get_simulation_parameters();
+//     params.include_optical_errors = false;
+//     params.include_sun_shape_errors = false;
+//     params.max_number_of_rays = NRAYS * 100;
+//     params.number_of_rays = NRAYS;
+//     params.seed = 1;
 
-    // Run Ray Trace
-    NativeRunner runner;
-    runner.disable_point_focus();
-    runner.disable_power_tower();
-    RunnerStatus sts;
-    sts = runner.initialize();
-    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
-    sts = runner.setup_simulation(&sd);
-    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+//     // Run Ray Trace
+//     NativeRunner runner;
+//     runner.disable_point_focus();
+//     runner.disable_power_tower();
+//     RunnerStatus sts;
+//     sts = runner.initialize();
+//     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+//     sts = runner.setup_simulation(&sd);
+//     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
-    auto t0 = std::chrono::high_resolution_clock::now();
-    sts = runner.run_simulation();
-    auto t1 = std::chrono::high_resolution_clock::now();
-    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+//     auto t0 = std::chrono::high_resolution_clock::now();
+//     sts = runner.run_simulation();
+//     auto t1 = std::chrono::high_resolution_clock::now();
+//     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
-    std::chrono::duration<double, std::milli> dur = t1 - t0;
-    EXPECT_TRUE(dur.count() < 60000.0);
+//     std::chrono::duration<double, std::milli> dur = t1 - t0;
+//     EXPECT_TRUE(dur.count() < 60000.0);
 
-    const TSystem *sys = runner.get_system();
-    // sys->RayData.Print();
-    const TRayData *ray_data = &(sys->RayData);
-    size_t n = ray_data->Count();
-    uint_fast64_t num_absorbed = count_absorbed_native(ray_data);
+//     const TSystem *sys = runner.get_system();
+//     // sys->RayData.Print();
+//     const TRayData *ray_data = &(sys->RayData);
+//     size_t n = ray_data->Count();
+//     uint_fast64_t num_absorbed = count_absorbed_native(ray_data);
 
-    std::cout << "Time: " << dur.count() << " ms" << std::endl;
-    std::cout << "Number Absorbed: " << num_absorbed << std::endl;
-    std::cout << "Number Interactions: " << n << std::endl;
+//     std::cout << "Time: " << dur.count() << " ms" << std::endl;
+//     std::cout << "Number Absorbed: " << num_absorbed << std::endl;
+//     std::cout << "Number Interactions: " << n << std::endl;
 
-    EXPECT_TRUE(n >= NRAYS);
-    EXPECT_TRUE(num_absorbed > 0);
+//     EXPECT_TRUE(n >= NRAYS);
+//     EXPECT_TRUE(num_absorbed > 0);
 
-    // const TSystem *sys = runner.get_system();
-    // const TRayData *ray_data = &(sys->AllRayData);
-    // size_t nrdata = ray_data->Count();
+//     // const TSystem *sys = runner.get_system();
+//     // const TRayData *ray_data = &(sys->AllRayData);
+//     // size_t nrdata = ray_data->Count();
 
-    // Vector3d point, cosines;
-    // int element;
-    // int stage;
-    // unsigned int raynum;
+//     // Vector3d point, cosines;
+//     // int element;
+//     // int stage;
+//     // unsigned int raynum;
 
-    // // Retrieving data from Runner
-    // for (size_t i = 0; i < nrdata; i++)
-    // {
-    //     EXPECT_TRUE(ray_data->Query(i, point.data, cosines.data,
-    //                                 &element, &stage, &raynum));
+//     // // Retrieving data from Runner
+//     // for (size_t i = 0; i < nrdata; i++)
+//     // {
+//     //     EXPECT_TRUE(ray_data->Query(i, point.data, cosines.data,
+//     //                                 &element, &stage, &raynum));
 
-    //     EXPECT_EQ(element, stoi(ground_raydata[6][i + 1]));
-    //     EXPECT_EQ(stage, stoi(ground_raydata[7][i + 1]));
-    //     EXPECT_EQ(raynum, stoul(ground_raydata[8][i + 1]));
+//     //     EXPECT_EQ(element, stoi(ground_raydata[6][i + 1]));
+//     //     EXPECT_EQ(stage, stoi(ground_raydata[7][i + 1]));
+//     //     EXPECT_EQ(raynum, stoul(ground_raydata[8][i + 1]));
 
-    //     if (element == stoi(ground_raydata[6][i + 1]) &&
-    //         stage == stoi(ground_raydata[7][i + 1]) &&
-    //         raynum == stoul(ground_raydata[8][i + 1]))
-    //     {
-    //         EXPECT_NEAR(point[0], stod(ground_raydata[0][i + 1]), TOL);
-    //         EXPECT_NEAR(point[1], stod(ground_raydata[1][i + 1]), TOL);
-    //         EXPECT_NEAR(point[2], stod(ground_raydata[2][i + 1]), TOL);
+//     //     if (element == stoi(ground_raydata[6][i + 1]) &&
+//     //         stage == stoi(ground_raydata[7][i + 1]) &&
+//     //         raynum == stoul(ground_raydata[8][i + 1]))
+//     //     {
+//     //         EXPECT_NEAR(point[0], stod(ground_raydata[0][i + 1]), TOL);
+//     //         EXPECT_NEAR(point[1], stod(ground_raydata[1][i + 1]), TOL);
+//     //         EXPECT_NEAR(point[2], stod(ground_raydata[2][i + 1]), TOL);
 
-    //         EXPECT_NEAR(cosines[0], stod(ground_raydata[3][i + 1]), TOL);
-    //         EXPECT_NEAR(cosines[1], stod(ground_raydata[4][i + 1]), TOL);
-    //         EXPECT_NEAR(cosines[2], stod(ground_raydata[5][i + 1]), TOL);
-    //     }
-    //     else
-    //     {
-    //         std::cout << "Line: " << i
-    //                   << "\nElement: " << element
-    //                   << "\nStage: " << stage
-    //                   << "\nRay Number: " << raynum
-    //                   << std::endl;
-    //         break;
-    //     }
-    // }
-}
+//     //         EXPECT_NEAR(cosines[0], stod(ground_raydata[3][i + 1]), TOL);
+//     //         EXPECT_NEAR(cosines[1], stod(ground_raydata[4][i + 1]), TOL);
+//     //         EXPECT_NEAR(cosines[2], stod(ground_raydata[5][i + 1]), TOL);
+//     //     }
+//     //     else
+//     //     {
+//     //         std::cout << "Line: " << i
+//     //                   << "\nElement: " << element
+//     //                   << "\nStage: " << stage
+//     //                   << "\nRay Number: " << raynum
+//     //                   << std::endl;
+//     //         break;
+//     //     }
+//     // }
+// }

--- a/google-tests/regression-tests/native_runner_validation_test.cpp
+++ b/google-tests/regression-tests/native_runner_validation_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <sstream>
 
 #include <native_runner.hpp>
@@ -56,7 +57,31 @@ bool get_runner_element_and_stage(const NativeRunner *runner,
     return found;
 }
 
-TEST(NativeRunner, ValidationTest)
+int_fast64_t count_element_event(const SimulationResult &res, element_id el, RayEvent rev)
+{
+    int_fast64_t count = 0;
+
+    for (auto ray_idx = 0;
+         ray_idx < res.get_number_of_records();
+         ++ray_idx)
+    {
+        auto rr = res[ray_idx];
+        for (auto event_idx = 0;
+             event_idx < rr->get_number_of_interactions();
+             ++event_idx)
+        {
+            if (rr->get_event(event_idx) == rev &&
+                rr->get_element(event_idx) == el)
+            {
+                ++count;
+            }
+        }
+    }
+
+    return count;
+}
+
+TEST(NativeRunner, ValidationTest1)
 {
     // Pulling in path variable from CMake and creating path to .stinput sample file
     string sample_path = string(PROJECT_DIR) + string("/High Flux Solar Furnace.stinput");
@@ -259,6 +284,365 @@ TEST(NativeRunner, ValidationTest)
         EXPECT_NEAR(dir_stage[0], stod(ground_raydata[3][i]), TOL);
         EXPECT_NEAR(dir_stage[1], stod(ground_raydata[4][i]), TOL);
         EXPECT_NEAR(dir_stage[2], stod(ground_raydata[5][i]), TOL);
+
+        // if (fabs(pos_stage[0] - stod(ground_raydata[0][i]) > TOL))
+        // {
+        //     Vector3d pos_csv(stod(ground_raydata[0][i]),
+        //                      stod(ground_raydata[1][i]),
+        //                      stod(ground_raydata[2][i]));
+        //     Vector3d dir_csv(stod(ground_raydata[3][i]),
+        //                      stod(ground_raydata[4][i]),
+        //                      stod(ground_raydata[5][i]));
+
+        //     Vector3d pos_loc;
+        //     Vector3d dir_loc;
+
+        //     Vector3d csv_glob;
+        //     el->convert_stage_to_local(temp, pos_csv);
+        //     el->convert_local_to_global(csv_glob, temp);
+
+        //     el->convert_global_to_local(pos_loc, point);
+        //     el->convert_vector_global_to_local(dir_loc, cosines);
+
+        //     std::cout << "CSV Line: " << i + 1
+        //               << "\nRay Number: " << rayidx + 1
+        //               << "\nElement: " << rr->get_element(iidx)
+        //               << " CSV Element: " << element
+        //               << " Runner Element: " << run_element
+        //               << "\nCSV Stage: " << stage
+        //               << " Runner Stage: " << run_stage
+        //               << std::endl;
+
+        //     std::cout << "CSV Pos: " << pos_csv
+        //               << "\nCSV Global: " << csv_glob
+        //               << "\nPos Global: " << point
+        //               << "\nPos Stage: " << pos_stage
+        //               << "\nPos Local: " << pos_loc
+        //               << "\nCSV Dir: " << dir_csv
+        //               << "\nDir Global: " << cosines
+        //               << "\nDir Stage: " << dir_stage
+        //               << "\nDir Local: " << dir_loc
+        //               << std::endl;
+
+        //     std::cout << "Ray Record: "
+        //               << *rr
+        //               << std::endl;
+
+        //     std::cout << "Element Global Origin: " << el->get_origin_global()
+        //               << "\nElement Local to Global: " << el->get_local_to_global()
+        //               << "\nElement Ref to Local: " << el->get_local_to_reference()
+        //               << std::endl;
+
+        //     break;
+        // }
+    }
+}
+
+TEST(NativeRunner, ValidationTest2)
+{
+    // Pulling in path variable from CMake and creating path to .stinput sample file
+    string sample_path = string(PROJECT_DIR) + string("/Power-tower-surround_singlefacet.stinput");
+
+    // Path to .csv exported from Soltrace as ground truth
+    string ground_csv_path = PROJECT_DIR + string("/powertower_example_raydata.csv");
+
+    std::ifstream csv_file(ground_csv_path);
+    vector<vector<string>> ground_raydata = split_csv(ground_csv_path);
+
+    // Create Simuluation Data
+    SimulationData sd;
+
+    // Constants
+    const uint_fast64_t NRAYS = 50000;
+    const double TOL = 1e-4;
+
+    // Read Input File
+    bool success = sd.import_from_file(sample_path);
+    EXPECT_TRUE(success);
+    EXPECT_TRUE(sd.get_number_of_elements() > 0);
+    EXPECT_TRUE(sd.get_number_of_ray_sources() > 0);
+
+    std::cout << "Num Elements: " << sd.get_number_of_elements() << std::endl;
+
+    // Parameters
+    SimulationParameters &params = sd.get_simulation_parameters();
+    params.include_optical_errors = false;
+    params.include_sun_shape_errors = false;
+    params.max_number_of_rays = NRAYS * 100;
+    params.number_of_rays = NRAYS;
+    params.seed = 1;
+
+    // for (auto cit = sd.get_const_iterator();
+    //      !sd.is_at_end(cit);
+    //      ++cit)
+    // {
+    //     auto elem = cit->second;
+    //     if (elem->is_stage())
+    //     {
+    //         stage_ptr st = dynamic_pointer_cast<StageElement>(elem);
+    //         assert(st != nullptr);
+    //         std::cout << "Stage: " << st->get_stage()
+    //                   << "\nNumber of elements: "
+    //                   << st->get_number_of_elements()
+    //                   << std::endl;
+    //         if (st->get_stage() == 1)
+    //         {
+    //             auto el = st->get_const_iterator()->second;
+
+    //             auto surf = dynamic_pointer_cast<Cylinder>(el->get_surface());
+    //             assert(surf != nullptr);
+    //             auto ap = dynamic_pointer_cast<Rectangle>(el->get_aperture());
+    //             assert(ap != nullptr);
+
+    //             std::cout << "------------\n"
+    //                       << "Element ID: " << el->get_id()
+    //                       << "\nElement name: " << el->get_name()
+    //                       << "\nIs Stage: " << el->is_stage()
+    //                       << "\nIs Composite: " << el->is_composite()
+    //                       << "\nIs Single: " << el->is_single()
+    //                       << "\nOrigin (ref): " << el->get_origin_ref()
+    //                       << "\nOrigin (stage): " << el->get_origin_stage()
+    //                       << "\nOrigin (global): " << el->get_origin_global()
+    //                       << "\nAim (ref): " << el->get_aim_vector_ref()
+    //                       << "\nAim (stage): " << el->get_aim_vector_stage()
+    //                       << "\nAim (global): " << el->get_aim_vector_global()
+    //                       << "\nRefToLoc: " << el->get_reference_to_local()
+    //                       << "\nCylinder Radius: " << surf->radius
+    //                       << "\nAperture Dimension: " << ap->x_length << " x " << ap->y_length
+    //                       << " at (" << ap->x_coord << ", " << ap->y_coord << ")"
+    //                       << "\n** Front Optical Properties **\n"
+    //                       << *(el->get_front_optical_properties())
+    //                       << "\n** Back Optical Properties **\n"
+    //                       << *(el->get_back_optical_properties())
+    //                       << "\n------------"
+    //                       << std::endl;
+    //         }
+    //     }
+    // }
+
+    // return;
+
+    // Run Ray Trace
+    NativeRunner runner;
+    runner.disable_point_focus();
+    runner.disable_power_tower();
+    RunnerStatus sts;
+    sts = runner.initialize();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(&sd);
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // auto stage_list = runner.get_system()->StageList;
+    // stage_list[1]->MultiHitsPerRay = false;
+    // tstage_ptr tstage = nullptr;
+    // for (auto iter = stage_list.begin();
+    //      iter != stage_list.end();
+    //      ++iter)
+    // {
+    //     tstage = *iter;
+    //     tstage->MultiHitsPerRay = false;
+    //     tstage->TraceThrough = false;
+    // }
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+    sts = runner.run_simulation();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+
+    std::chrono::duration<double, std::milli> dur = t1 - t0;
+    EXPECT_TRUE(dur.count() < 60000.0);
+
+    std::cout << "Time: " << dur.count() << " ms" << std::endl;
+
+    // const TSystem *sys = runner.get_system();
+    // const TRayData *ray_data = &(runner.get_system()->RayData);
+    // size_t nrdata = ray_data->Count();
+
+    // ray_data->Print();
+
+    SimulationResult result;
+    sts = runner.report_simulation(&result, 0);
+    EXPECT_EQ(sts, RunnerStatus::SUCCESS);
+    EXPECT_EQ(result.get_number_of_records(), NRAYS);
+
+    element_id absorber_id = 6285;
+    int_fast64_t nabsorbed = count_element_event(result, absorber_id, RayEvent::ABSORB);
+    int_fast64_t nreflect = count_element_event(result, absorber_id, RayEvent::REFLECT);
+    int_fast64_t nevents = nabsorbed + nreflect;
+
+    std::cout << "Total: " << nevents
+              << "\nAbsorb: " << nabsorbed << " ("
+              << static_cast<double>(nabsorbed) / nevents << ")"
+              << "\nReflect: " << nreflect << " ("
+              << static_cast<double>(nreflect) / nevents << ")"
+              << std::endl;
+
+    result.write_csv_file("native_runner_result_dump.csv");
+
+    Vector3d point, cosines;
+    Vector3d pos_stage, dir_stage;
+    Vector3d temp;
+    int_fast64_t element;
+    int_fast64_t stage;
+    uint_fast64_t rayidx;
+    uint_fast64_t iidx;
+    element_ptr el = nullptr;
+    int_fast64_t run_element, run_stage;
+    double RTOL = 0.0;
+
+    // size_t total_lines = ground_raydata[0].size();
+    size_t total_lines = std::numeric_limits<size_t>::max();
+    size_t i;
+    for (i = 0; i < 9; ++i)
+    {
+        total_lines = std::min(total_lines, ground_raydata[i].size());
+    }
+
+    // Compare saved CSV values to runner values
+    for (i = 1; i < total_lines; ++i)
+    {
+        element = stoi(ground_raydata[6][i]);
+        stage = stoi(ground_raydata[7][i]);
+        // Legacy SolTrace and CSV file had 1-based ray IDs. SimulationResult
+        // has 0-based ray ID's so subtract 1 here.
+        rayidx = stoul(ground_raydata[8][i]) - 1;
+
+        const ray_record_ptr rr = result[rayidx];
+        if (element > 0)
+        {
+            bool found = false;
+            for (uint_fast64_t idx = 0; idx < rr->get_number_of_interactions(); ++idx)
+            {
+                run_element = -1;
+                run_stage = -1;
+                bool sts = get_runner_element_and_stage(&runner,
+                                                        rr->get_element(idx),
+                                                        run_element,
+                                                        run_stage);
+                if (sts && element == run_element && stage == run_stage)
+                {
+                    iidx = idx;
+                    found = true;
+                    break;
+                }
+            }
+
+            // assert(found);
+            EXPECT_TRUE(found);
+
+            if (found)
+            {
+                EXPECT_NE(rr->get_event(iidx), RayEvent::CREATE);
+                EXPECT_NE(rr->get_event(iidx), RayEvent::ABSORB);
+                EXPECT_NE(rr->get_event(iidx), RayEvent::EXIT);
+            }
+
+            if (!found ||
+                rr->get_event(iidx) == RayEvent::CREATE ||
+                rr->get_event(iidx) == RayEvent::ABSORB ||
+                rr->get_event(iidx) == RayEvent::EXIT)
+            {
+                std::cout << "CSV Line: " << i + 1
+                          << "\nRay Record: " << *rr
+                          << std::endl;
+                break;
+            }
+
+            rr->get_position(iidx, point);
+            // Legacy SolTrace stored the incoming ray direction whereas
+            // NativeRunner/SimulationResult stores the exit direction so
+            // we take the direction for the previous ray event.
+            rr->get_direction(iidx - 1, cosines);
+        }
+        else
+        {
+            iidx = rr->get_number_of_interactions() - 1;
+            if (element == 0)
+            {
+                // Ray miss -- check only that it was noted
+                EXPECT_EQ(rr->get_event(iidx), RayEvent::EXIT);
+                continue;
+            }
+            else
+            {
+                EXPECT_EQ(rr->get_event(iidx), RayEvent::ABSORB);
+
+                get_runner_element_and_stage(&runner,
+                                             rr->get_element(iidx),
+                                             run_element,
+                                             run_stage);
+                EXPECT_EQ(run_element, abs(element));
+                EXPECT_EQ(run_stage, stage);
+
+                if (run_element != abs(element) || run_stage != stage)
+                {
+                    std::cout << "CSV Line: " << i + 1
+                              << "\nRay Number: " << rayidx + 1
+                              << "\nElement: " << rr->get_element(iidx)
+                              << " CSV Element: " << element
+                              << " Runner Element: " << run_element
+                              << "\nCSV Stage: " << stage
+                              << " Runner Stage: " << run_stage
+                              << "\nRay Record: " << *rr
+                              << std::endl;
+                    break;
+                }
+
+                rr->get_position(iidx, point);
+                // Legacy SolTrace stored the incoming ray direction whereas
+                // NativeRunner/SimulationResult stores the exit direction so
+                // we take the direction for the previous ray event.
+                rr->get_direction(iidx - 1, cosines);
+            }
+        }
+
+        el = sd.get_element(rr->get_element(iidx));
+        EXPECT_NE(el, nullptr);
+
+        if (el == nullptr)
+        {
+            std::cout << "CSV Line: " << i + 1
+                      << "\nRay Number: " << rayidx + 1
+                      << "\nElement: " << rr->get_element(iidx)
+                      << " CSV Element: " << element
+                      << " Runner Element: " << run_element
+                      << "\nCSV Stage: " << stage
+                      << " Runner Stage: " << run_stage
+                      << "\nRay Record: " << *rr
+                      << std::endl;
+            break;
+        }
+
+        // Runner and SimulationResult store everything in global
+        // coordinate whereas the CSV file is in stage coordinates
+        // as per legacy SolTrace
+        el->convert_global_to_reference(pos_stage, point);
+
+        // See previous comment about coordinates
+        el->convert_vector_global_to_reference(dir_stage, cosines);
+
+        RTOL = vector_norm(pos_stage) * TOL;
+        EXPECT_NEAR(pos_stage[0], stod(ground_raydata[0][i]), RTOL);
+        EXPECT_NEAR(pos_stage[1], stod(ground_raydata[1][i]), RTOL);
+        EXPECT_NEAR(pos_stage[2], stod(ground_raydata[2][i]), RTOL);
+
+        EXPECT_NEAR(dir_stage[0], stod(ground_raydata[3][i]), TOL);
+        EXPECT_NEAR(dir_stage[1], stod(ground_raydata[4][i]), TOL);
+        EXPECT_NEAR(dir_stage[2], stod(ground_raydata[5][i]), TOL);
+
+        if (fabs(pos_stage[0] - stod(ground_raydata[0][i])) > RTOL)
+        {
+            std::cout << "CSV Line: " << i + 1
+                      << "\nRay Number: " << rayidx + 1
+                      << "\nElement: " << rr->get_element(iidx)
+                      << " CSV Element: " << element
+                      << " Runner Element: " << run_element
+                      << "\nCSV Stage: " << stage
+                      << " Runner Stage: " << run_stage
+                      << "\nRay Record: " << *rr
+                      << std::endl;
+            break;
+        }
 
         // if (fabs(pos_stage[0] - stod(ground_raydata[0][i]) > TOL))
         // {

--- a/google-tests/unit-tests/common/common.hpp
+++ b/google-tests/unit-tests/common/common.hpp
@@ -20,4 +20,49 @@ bool is_identical(const SolTrace::Data::Matrix3d &A,
 // care about the specifics of the element.
 SolTrace::Data::element_ptr make_configured_element();
 
+// Helper functions to create surfaces
+inline std::shared_ptr<Cylinder> create_cylinder_surface(double radius = 1.0)
+{
+    auto cylinder = std::make_shared<Cylinder>(radius);
+    return cylinder;
+}
+
+inline std::shared_ptr<Flat> create_flat_surface()
+{
+    auto flat = std::make_shared<Flat>();
+    return flat;
+}
+
+inline std::shared_ptr<Parabola> create_parabola_surface(double focal_length = 1.0)
+{
+    auto parabola = std::make_shared<Parabola>(focal_length, focal_length);
+    return parabola;
+}
+
+inline std::shared_ptr<Sphere> create_sphere_surface(double vertex_curvature = 0.1)
+{
+    auto sphere = std::make_shared<Sphere>(vertex_curvature);
+    return sphere;
+}
+
+// Helper functions to create apertures
+inline std::shared_ptr<Circle> create_circle_aperture(double radius = 1.0)
+{
+    auto circle = std::make_shared<Circle>(2.0 * radius);
+    return circle;
+}
+
+// inline std::shared_ptr<Rectangle> create_rect_aperture(double a = 1.0, double b = 1.0)
+// {
+//     auto rect = std::make_shared<Rectangle>(a, b);
+//     return rect;
+// }
+
+inline std::shared_ptr<Rectangle> create_rectangle_aperture(double x_length = 2.0,
+                                                            double y_length = 2.0)
+{
+    auto rect = std::make_shared<Rectangle>(x_length, y_length);
+    return rect;
+}
+
 #endif

--- a/google-tests/unit-tests/simulation_data/cst-templates/linear_fresnel_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/linear_fresnel_test.cpp
@@ -3,6 +3,7 @@
 #include <native_runner.hpp>
 #include <native_runner_types.hpp>
 #include <simulation_data.hpp>
+#include <simulation_result_export.hpp>
 #include <sun.hpp>
 
 #include <cst_templates/arclength.hpp>
@@ -201,8 +202,8 @@ TEST(LinearFresnel, Tracing)
     SimulationParameters &params = my_sim.get_simulation_parameters();
     params.number_of_rays = NRAYS;
     params.max_number_of_rays = params.number_of_rays * 1000;
-    params.include_optical_errors = true;
-    params.include_sun_shape_errors = true;
+    params.include_optical_errors = false;
+    params.include_sun_shape_errors = false;
     params.seed = 123;
 
     NativeRunner my_runner;
@@ -221,7 +222,8 @@ TEST(LinearFresnel, Tracing)
 
     OpticalProperties envelop_out;
     envelop_out.set_ideal_transmission();
-    envelop_out.refraction_index_front = 1.46;
+    // envelop_out.refraction_index_front = 1.46;
+    envelop_out.refraction_index_front = 1.0;
     envelop_out.refraction_index_back = 1.0;
     envelop_out.slope_error = 1e-4;
     envelop_out.specularity_error = 1e-4;
@@ -229,7 +231,8 @@ TEST(LinearFresnel, Tracing)
     OpticalProperties envelop_in;
     envelop_in.set_ideal_transmission();
     envelop_in.refraction_index_front = 1.0;
-    envelop_in.refraction_index_back = 1.46;
+    // envelop_in.refraction_index_back = 1.46;
+    envelop_in.refraction_index_back = 1.0;
     envelop_in.slope_error = 1e-4;
     envelop_in.specularity_error = 1e-4;
 
@@ -322,6 +325,13 @@ TEST(LinearFresnel, Tracing)
 
     EXPECT_TRUE(n >= NRAYS);
     EXPECT_TRUE(num_absorbed > N_ABSORBED_THRESH);
+
+    // SimulationResult my_res;
+    // my_runner.report_simulation(&my_res, 0);
+
+    // std::cout << my_res << std::endl;
+
+    // my_res.write_csv_file("linear_fresnel_test.csv", 12);
 }
 
 TEST(LinearFresnel, UpdateGeometry)
@@ -390,9 +400,9 @@ TEST(LinearFresnel, UpdateGeometry)
     lf->set_focused_panels(true);
     lf->set_receiver_height(2.0);
     lf->set_receiver_dimensions(0.07, 0.115, 0.003);
-    lf->set_angles(0.0, 15.0);
+    lf->set_angles(0.0, 40.0);
     // lf->set_angles(0.0, 0.0);
-    lf->set_tracking_limits(10.0, 170.0);
+    lf->set_tracking_limits(-90.0, 90.0);
     lf->create_geometry();
     lf->set_name("LinearFresnel");
     lf->update_geometry(sun_az, sun_el);
@@ -465,6 +475,10 @@ TEST(LinearFresnel, UpdateGeometry)
 
     EXPECT_TRUE(n >= NRAYS);
     EXPECT_TRUE(num_absorbed > N_ABSORBED_THRESH);
+
+    // SimulationResult my_res;
+    // my_runner.report_simulation(&my_res, 0);
+    // std::cout << my_res << std::endl;
 }
 
 TEST(LinearFresnel, UpdateGeometry_TrackingLimits)

--- a/google-tests/unit-tests/simulation_data/element_test.cpp
+++ b/google-tests/unit-tests/simulation_data/element_test.cpp
@@ -1,11 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <constants.hpp>
-#include <element.hpp>
-#include <single_element.hpp>
-#include <stage_element.hpp>
-#include <virtual_element.hpp>
-#include <vector3d.hpp>
+#include <simulation_data_export.hpp>
 
 #include "common.hpp"
 
@@ -39,6 +34,12 @@ TEST(Element, SingleElementAccessors)
     EXPECT_FALSE(ref.is_composite());
     EXPECT_FALSE(ref.is_virtual());
     EXPECT_TRUE(ref.is_single());
+
+    EXPECT_FALSE(ref.is_virtual());
+    ref.mark_virtual();
+    EXPECT_TRUE(ref.is_virtual());
+    ref.unmark_virtual();
+    EXPECT_FALSE(ref.is_virtual());
 
     auto pos = Vector3d(2.0, 1.0, -3.0);
     ref.set_origin(pos);
@@ -80,7 +81,8 @@ TEST(Element, SingleElementAccessors)
     EXPECT_EQ(opf->slope_error, opb->slope_error);
     EXPECT_EQ(opf->specularity_error, opb->specularity_error);
 
-    OpticalProperties op(SolTrace::Data::REFLECTION, SolTrace::Data::GAUSSIAN,
+    OpticalProperties op(InteractionType::REFLECTION,
+                         DistributionType::GAUSSIAN,
                          0.75, 0.25, 0.1, 0.001, 1.0, 1.0);
     ref.set_front_optical_properties(op);
     // EXPECT_EQ(*opf, op);
@@ -96,79 +98,81 @@ TEST(Element, SingleElementAccessors)
     EXPECT_EQ(opb->specularity_error, op.specularity_error);
 }
 
-// TEST(Element, VirtualElement)
-// {
-//     VirtualElement ve;
+TEST(Element, VirtualElement)
+{
+    VirtualElement ve;
 
-//     EXPECT_TRUE(ve.is_virtual());
+    EXPECT_TRUE(ve.is_virtual());
 
-//     const double LX = 1.0;
-//     const double LY = 2.0;
-//     ve.set_aperture(make_aperture<Rectangle>(LX, LY));
-//     auto aptr = ve.get_aperture();
-//     EXPECT_EQ(aptr->get_type(), RECTANGLE);
-//     auto rptr = std::dynamic_pointer_cast<Rectangle>(aptr);
-//     EXPECT_NE(rptr, nullptr);
-//     if (rptr != nullptr)
-//     {
-//         EXPECT_EQ(rptr->x_length, LX);
-//         EXPECT_EQ(rptr->y_length, LY);
-//     }
+    const double LX = 1.0;
+    const double LY = 2.0;
+    ve.set_aperture(make_aperture<Rectangle>(LX, LY));
+    auto aptr = ve.get_aperture();
+    EXPECT_EQ(aptr->get_type(), ApertureType::RECTANGLE);
+    auto rptr = std::dynamic_pointer_cast<Rectangle>(aptr);
+    EXPECT_NE(rptr, nullptr);
+    if (rptr != nullptr)
+    {
+        EXPECT_EQ(rptr->x_length, LX);
+        EXPECT_EQ(rptr->y_length, LY);
+    }
 
-//     ve.set_surface(make_surface<Flat>());
-//     auto sptr = ve.get_surface();
-//     EXPECT_EQ(sptr->get_type(), FLAT);
-//     auto fptr = std::dynamic_pointer_cast<Flat>(sptr);
-//     EXPECT_NE(fptr, nullptr);
+    ve.set_surface(make_surface<Flat>());
+    auto sptr = ve.get_surface();
+    EXPECT_EQ(sptr->get_type(), SurfaceType::FLAT);
+    auto fptr = std::dynamic_pointer_cast<Flat>(sptr);
+    EXPECT_NE(fptr, nullptr);
 
-//     EXPECT_TRUE(ve.is_virtual());
-//     EXPECT_TRUE(ve.is_single());
-//     EXPECT_FALSE(ve.is_composite());
+    EXPECT_TRUE(ve.is_virtual());
+    EXPECT_TRUE(ve.is_single());
+    EXPECT_FALSE(ve.is_composite());
 
-//     // These functions should have no effects
-//     OpticalProperties op(REFLECTION, GAUSSIAN, 0.75, 0.25, 0.1, 0.001, 1.0, 1.0);
-//     ve.set_front_optical_properties(op);
-//     auto opf = ve.get_front_optical_properties();
-//     EXPECT_EQ(opf->reflectivity, 0.0);
-//     EXPECT_EQ(opf->slope_error, 0.0);
-//     EXPECT_EQ(opf->specularity_error, 0.0);
-//     EXPECT_EQ(opf->transmitivity, 1.0);
-//     ve.set_back_optical_properties(op);
-//     auto opb = ve.get_back_optical_properties();
-//     EXPECT_EQ(opb->reflectivity, 0.0);
-//     EXPECT_EQ(opb->slope_error, 0.0);
-//     EXPECT_EQ(opb->specularity_error, 0.0);
-//     EXPECT_EQ(opb->transmitivity, 1.0);
+    // These functions should have no effects
+    OpticalProperties op(InteractionType::REFLECTION,
+                         DistributionType::GAUSSIAN,
+                         0.75, 0.25, 0.1, 0.001, 1.0, 1.0);
+    ve.set_front_optical_properties(op);
+    auto opf = ve.get_front_optical_properties();
+    EXPECT_EQ(opf->reflectivity, 0.0);
+    EXPECT_EQ(opf->slope_error, 0.0);
+    EXPECT_EQ(opf->specularity_error, 0.0);
+    EXPECT_EQ(opf->transmitivity, 1.0);
+    ve.set_back_optical_properties(op);
+    auto opb = ve.get_back_optical_properties();
+    EXPECT_EQ(opb->reflectivity, 0.0);
+    EXPECT_EQ(opb->slope_error, 0.0);
+    EXPECT_EQ(opb->specularity_error, 0.0);
+    EXPECT_EQ(opb->transmitivity, 1.0);
 
-//     return;
-// }
+    return;
+}
 
-// TEST(Element, VirtualPlane)
-// {
-//     const double LX = 5.0;
-//     const double LY = 2.5;
-//     VirtualPlane vp(LX, LY);
+TEST(Element, VirtualPlane)
+{
+    const double LX = 5.0;
+    const double LY = 2.5;
+    VirtualPlane vp(LX, LY);
 
-//     EXPECT_TRUE(vp.is_virtual());
-//     EXPECT_EQ(vp.get_aperture()->get_type(), RECTANGLE);
-//     EXPECT_EQ(vp.get_surface()->get_type(), FLAT);
+    EXPECT_TRUE(vp.is_virtual());
+    EXPECT_EQ(vp.get_aperture()->get_type(), ApertureType::RECTANGLE);
+    EXPECT_EQ(vp.get_surface()->get_type(), SurfaceType::FLAT);
 
-//     auto rptr = std::dynamic_pointer_cast<Rectangle>(vp.get_aperture());
-//     EXPECT_NE(rptr, nullptr);
-//     if (rptr != nullptr)
-//     {
-//         EXPECT_EQ(rptr->x_length, LX);
-//         EXPECT_EQ(rptr->y_length, LY);
-//     }
+    auto rptr = std::dynamic_pointer_cast<Rectangle>(vp.get_aperture());
+    EXPECT_NE(rptr, nullptr);
+    if (rptr != nullptr)
+    {
+        EXPECT_EQ(rptr->x_length, LX);
+        EXPECT_EQ(rptr->y_length, LY);
+    }
 
-//     // These functions should have no effects
-//     vp.set_aperture(make_aperture<Circle>(2.0));
-//     EXPECT_EQ(vp.get_aperture()->get_type(), RECTANGLE);
-//     vp.set_surface(make_surface<Parabola>(1.0, 1.0));
-//     EXPECT_EQ(vp.get_surface()->get_type(), FLAT);
+    // These functions should have no effects
+    vp.set_aperture(make_aperture<Circle>(2.0));
+    EXPECT_EQ(vp.get_aperture()->get_type(), ApertureType::RECTANGLE);
+    vp.set_surface(make_surface<Parabola>(1.0, 1.0));
+    EXPECT_EQ(vp.get_surface()->get_type(), SurfaceType::FLAT);
 
-//     return;
-// }
+    return;
+}
 
 TEST(Element, CompositeElementAccessors)
 {
@@ -202,7 +206,6 @@ TEST(Element, CompositeElementAccessors)
         // EXPECT_EQ(elem->get_stage(), STAGE);
     }
     EXPECT_EQ(cmp->get_number_of_elements(), NUM_ELEMENTS);
-    // EXPECT_EQ(cmp->get_stage(), cmp->get_element(0)->get_stage());
 
     cmp->remove_element(0);
     EXPECT_EQ(cmp->get_number_of_elements(), NUM_ELEMENTS - 1);
@@ -231,6 +234,15 @@ TEST(Element, CompositeElementAccessors)
     EXPECT_TRUE(cmp->is_enabled());
     EXPECT_TRUE(elem2->is_enabled());
 
+    EXPECT_FALSE(elem2->is_virtual());
+    EXPECT_FALSE(cmp->is_virtual());
+    cmp->mark_virtual();
+    EXPECT_TRUE(cmp->is_virtual());
+    EXPECT_TRUE(elem2->is_virtual());
+    cmp->unmark_virtual();
+    EXPECT_FALSE(cmp->is_virtual());
+    EXPECT_FALSE(elem2->is_virtual());
+
     // Check that pass through functions are hooked up correctly
     auto iter = cmp->get_iterator();
     while (!cmp->is_at_end(iter))
@@ -256,7 +268,7 @@ TEST(Element, StageElementAccessors)
     auto el1 = make_configured_element();
     auto cmp1 = SolTrace::Data::make_element<CompositeElement>();
     auto sub1 = make_configured_element();
-    auto sub2 = SolTrace::Data::make_element<SolTrace::Data::VirtualPlane>(10.0, 10.0);
+    auto sub2 = make_configured_element();
     auto sub3 = make_configured_element();
     EXPECT_TRUE(SolTrace::Data::Element::is_success(cmp1->add_element(sub1)));
     EXPECT_TRUE(SolTrace::Data::Element::is_success(cmp1->add_element(sub2)));
@@ -852,7 +864,8 @@ TEST(Element, SingleElementEnforceUserFieldsSet)
     EXPECT_NO_THROW(elem->enforce_user_fields_set());
 
     // Test with optical properties set as well
-    OpticalProperties op(SolTrace::Data::REFLECTION, SolTrace::Data::GAUSSIAN,
+    OpticalProperties op(InteractionType::REFLECTION,
+                         DistributionType::GAUSSIAN,
                          0.75, 0.25, 0.1, 0.001, 1.0, 1.0);
     elem->set_front_optical_properties(op);
     elem->set_back_optical_properties(op);

--- a/google-tests/unit-tests/simulation_data/element_test.cpp
+++ b/google-tests/unit-tests/simulation_data/element_test.cpp
@@ -1,8 +1,20 @@
 #include <gtest/gtest.h>
 
+#include <sstream>
+
 #include <simulation_data_export.hpp>
 
 #include "common.hpp"
+
+TEST(OpticalProperties, OutputOperator)
+{
+    std::stringstream ss;
+
+    OpticalProperties op;
+    op.set_ideal_reflection();
+    ss << op;
+    EXPECT_GE(ss.str().length(), 0);
+}
 
 TEST(Element, ConstructionSmokeTest)
 {

--- a/google-tests/unit-tests/simulation_data/linear_algebra_test.cpp
+++ b/google-tests/unit-tests/simulation_data/linear_algebra_test.cpp
@@ -103,6 +103,11 @@ TEST(LinearAlgebra, VectorBasics)
     EXPECT_NEAR(result[1], 0.0, TOL);
     EXPECT_NEAR(result[2], 0.0, TOL);
     result.zero();
+
+    double l2 = error(ihat, jhat);
+    EXPECT_NEAR(l2, sqrt(2.0), TOL);
+    double linf = error_inf(ihat, jhat);
+    EXPECT_NEAR(linf, 1.0, TOL);
 }
 
 TEST(LinearAlgebra, MatrixVectorProduct)
@@ -209,21 +214,21 @@ TEST(LinearAlgebra, Matrix3dOutputOperator)
 
     std::ostringstream oss;
     oss << A;
-    EXPECT_EQ(oss.str(), "[1, 2, 3; 4, 5, 6; 7, 8, 9; ]");
+    EXPECT_EQ(oss.str(), "[1, 2, 3; 4, 5, 6; 7, 8, 9]");
 
     // Test identity matrix
     Matrix3d I;
     I.identity();
     std::ostringstream oss_identity;
     oss_identity << I;
-    EXPECT_EQ(oss_identity.str(), "[1, 0, 0; 0, 1, 0; 0, 0, 1; ]");
+    EXPECT_EQ(oss_identity.str(), "[1, 0, 0; 0, 1, 0; 0, 0, 1]");
 
     // Test zero matrix
     Matrix3d Z;
     Z.zero();
     std::ostringstream oss_zero;
     oss_zero << Z;
-    EXPECT_EQ(oss_zero.str(), "[0, 0, 0; 0, 0, 0; 0, 0, 0; ]");
+    EXPECT_EQ(oss_zero.str(), "[0, 0, 0; 0, 0, 0; 0, 0, 0]");
 
     // Test with negative values and different precision
     Matrix3d B;
@@ -239,7 +244,7 @@ TEST(LinearAlgebra, Matrix3dOutputOperator)
 
     std::ostringstream oss_negative;
     oss_negative << std::fixed << std::setprecision(2) << B;
-    EXPECT_EQ(oss_negative.str(), "[-1.50, 2.25, -3.75; 0.00, -0.50, 1.00; 10.00, -20.00, 30.00; ]");
+    EXPECT_EQ(oss_negative.str(), "[-1.50, 2.25, -3.75; 0.00, -0.50, 1.00; 10.00, -20.00, 30.00]");
 }
 
 TEST(LinearAlgebra, Matrix3dGetValue)

--- a/google-tests/unit-tests/simulation_results/simulation_result_test.cpp
+++ b/google-tests/unit-tests/simulation_results/simulation_result_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <sstream>
 
 #include <simulation_result.hpp>
@@ -51,6 +52,17 @@ TEST(InteractionRecord, OutputOperator)
     std::stringstream ss;
     ss << ir1;
     EXPECT_TRUE(ss.str().size() > 0);
+}
+
+TEST(InteractionRecord, RayEventToString)
+{
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::CREATE), "CREATE");
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::ABSORB), "ABSORB");
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::REFLECT), "REFLECT");
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::TRANSMIT), "TRANSMIT");
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::VIRTUAL), "VIRTUAL");
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::EXIT), "EXIT");
+    EXPECT_EQ(SolTrace::Result::ray_event_string(RayEvent::UNKNOWN), "UNKNOWN");
 }
 
 TEST(RayRecord, Accessors)
@@ -216,4 +228,84 @@ TEST(SimulationResult, OstreamOperator)
     ss << sr;
 
     EXPECT_TRUE(ss.str().size() > 0);
+}
+
+TEST(SimulationResult, IndexOperator)
+{
+    // Test constants
+    const uint_fast32_t NRAYS = 3;
+    const uint_fast32_t NINTER = 5;
+    const int_fast32_t INDEX = 0;
+    RayEvent my_types[NINTER] = {
+        RayEvent::REFLECT,
+        RayEvent::TRANSMIT,
+        RayEvent::REFLECT,
+        RayEvent::ABSORB,
+        RayEvent::EXIT};
+
+    SimulationResult sr;
+
+    for (uint_fast32_t k = 0; k < NRAYS; ++k)
+    {
+        ray_record_ptr rr = make_ray_record(k);
+        for (uint_fast32_t ell = 0; ell < NINTER; ++ell)
+        {
+            Vector3d loc(1.0 * ell, 2.0 * ell, 3.0 * ell);
+            Vector3d dir(1.0, 2.0, 3.0);
+            RayEvent it = my_types[ell];
+            interaction_ptr ir = make_interaction_record(ell, it, loc, dir);
+            rr->add_interaction_record(ir);
+        }
+        sr.add_ray_record(rr);
+    }
+
+    EXPECT_THROW(sr[-1], std::invalid_argument);
+    EXPECT_THROW(sr[NRAYS + 1], std::invalid_argument);
+
+    ray_record_ptr rr = sr[INDEX];
+    EXPECT_NE(rr, nullptr);
+    EXPECT_THROW((*rr)[-1], std::invalid_argument);
+    EXPECT_THROW((*rr)[NINTER + 1], std::invalid_argument);
+
+    interaction_ptr ir = (*rr)[INDEX];
+    EXPECT_EQ(ir->event, my_types[INDEX]);
+}
+
+TEST(SimulationResult, WriteCSV)
+{
+    // Test constants
+    const uint_fast32_t NRAYS = 3;
+    const uint_fast32_t NINTER = 5;
+    RayEvent my_types[NINTER] = {
+        RayEvent::REFLECT,
+        RayEvent::TRANSMIT,
+        RayEvent::REFLECT,
+        RayEvent::ABSORB,
+        RayEvent::EXIT};
+
+    std::string csv_file("temp_string.csv");
+
+    SimulationResult sr;
+
+    for (uint_fast32_t k = 0; k < NRAYS; ++k)
+    {
+        ray_record_ptr rr = make_ray_record(k);
+        for (uint_fast32_t ell = 0; ell < NINTER; ++ell)
+        {
+            Vector3d loc(1.0 * ell, 2.0 * ell, 3.0 * ell);
+            Vector3d dir(1.0, 2.0, 3.0);
+            RayEvent it = my_types[ell];
+            interaction_ptr ir = make_interaction_record(ell, it, loc, dir);
+            rr->add_interaction_record(ir);
+        }
+        sr.add_ray_record(rr);
+    }
+
+    // Write the CSV files
+    sr.write_csv_file(csv_file);
+    sr.write_csv_file("temp_char.csv");
+
+    // Cleanup
+    std::filesystem::remove(csv_file);
+    std::filesystem::remove("temp_char.csv");
 }

--- a/google-tests/unit-tests/simulation_runner/native_runner/cylinder_calculator_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/cylinder_calculator_test.cpp
@@ -10,30 +10,191 @@
 
 using SolTrace::NativeRunner::CylinderCalculator;
 
-// Helper functions to create surfaces and apertures
-std::shared_ptr<Cylinder> create_cylinder_surface(double radius = 1.0)
+// NOTES: Equation for a cylinder is x^2 + (z - r)^2 = r^2
+// Computing the intersection point comes down to solving
+// quadratic equation for a parameter t given by
+//      at^2 + bt + c = 0
+// The cases here are broken down by cases with regard to
+// this equation. The case is noted at the top.  The coefficients
+// a, b, and c can be determined by subtituting x(t) = x0 + mx*t,
+// y(t) = y0 + my*t, and z(t) = z0 + mz*t into the given equation
+// for a cylinder. In the comments and naming, we use the
+// following terms:
+//    Delta = b^2 - 4ac  -- discrimanant of quadratic equation
+//    t1 = (-b - sqrt(Delta)) / (2a) -- negative root
+//    t2 = (-b + sqrt(Delta)) / (2a) -- positive root
+// From these last two, we always have t1 < t2.
+
+// Intersection case tests
+TEST(CylinderCalculator, Case1)
 {
-    auto cylinder = std::make_shared<Cylinder>(radius);
-    return cylinder;
+    // Case a == 0, no solution
+    const double r = 1.0;
+    const double ymax = 4.0;
+    auto surface = create_cylinder_surface(r);
+    auto aperture = create_rectangle_aperture(2.0 * r, 2.0 * ymax);
+    CylinderCalculator calc(surface, aperture);
+
+    // Ray position and direction
+    Vector3d x0(-1.0, -1.0, -1.0);
+    Vector3d m(0.0, 1.0, 0.0);
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    int result = calc.intersect(x0.data, m.data, xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(result, 1);
+    EXPECT_EQ(t, 0.0);
 }
 
-std::shared_ptr<Rectangle> create_rectangle_aperture(double x_length = 2.0, double y_length = 2.0)
+TEST(CylinderCalculator, Case2)
 {
-    auto rect = std::make_shared<Rectangle>(x_length, y_length);
-    return rect;
+    // Case a != 0, Delta < 0 -- no solution
+    const double r = 1.0;
+    const double ymax = 4.0;
+    auto surface = create_cylinder_surface(r);
+    auto aperture = create_rectangle_aperture(2.0 * r, 2.0 * ymax);
+    CylinderCalculator calc(surface, aperture);
+
+    // Ray position and direction
+    Vector3d x0(5.0, 0.0, 1.0);
+    Vector3d m(-1.0, 1.0, 1.0);
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    int result = calc.intersect(x0.data, m.data, xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(result, 1);
+    EXPECT_EQ(t, 0.0);
 }
 
-std::shared_ptr<Circle> create_circular_aperture(double diameter = 2.0)
+TEST(CylinderCalculator, Case3)
 {
-    auto circ = std::make_shared<Circle>(diameter);
-    return circ;
+    // Case a != 0, Delta > 0, t1 > 0, t2 > 0 -- returns t1
+    const double TOL = 1e-12;
+    const double r = 1.0;
+    const double ymax = 4.0;
+    auto surface = create_cylinder_surface(r);
+    auto aperture = create_rectangle_aperture(2.0 * r, 2.0 * ymax);
+    CylinderCalculator calc(surface, aperture);
+
+    // Ray position and direction
+    Vector3d x0(5.0, -3.0, 1.0);
+    Vector3d m(-1.0, 1.0, 0.0);
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    int result = calc.intersect(x0.data, m.data, xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_NEAR(t, 4.0, TOL);
+    EXPECT_NEAR(xt[0], 1.0, TOL);
+    EXPECT_NEAR(xt[1], 1.0, TOL);
+    EXPECT_NEAR(xt[2], 1.0, TOL);
+    EXPECT_NEAR(mt[0], m[0], TOL);
+    EXPECT_NEAR(mt[1], m[1], TOL);
+    EXPECT_NEAR(mt[2], m[2], TOL);
 }
 
-// Constructor validation tests
+TEST(CylinderCalculator, Case4)
+{
+    // Case a != 0, Delta > 0, t1 > 0, t2 > 0 -- returns t1
+    const double TOL = 1e-12;
+    const double r = 1.0;
+    const double ymax = 4.0;
+    auto surface = create_cylinder_surface(r);
+    auto aperture = create_rectangle_aperture(2.0 * r, 2.0 * ymax);
+    CylinderCalculator calc(surface, aperture);
+
+    // Ray position and direction
+    Vector3d x0(0.0, -1.0, 1.0);
+    Vector3d m(-1.0, 1.0, 0.0);
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    int result = calc.intersect(x0.data, m.data, xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(result, 0);
+    EXPECT_NEAR(t, 1.0, TOL);
+    EXPECT_NEAR(xt[0], -1.0, TOL);
+    EXPECT_NEAR(xt[1], 0.0, TOL);
+    EXPECT_NEAR(xt[2], 1.0, TOL);
+    EXPECT_NEAR(mt[0], m[0], TOL);
+    EXPECT_NEAR(mt[1], m[1], TOL);
+    EXPECT_NEAR(mt[2], m[2], TOL);
+}
+
+TEST(CylinderCalculator, Case5)
+{
+    // Case a != 0, Delta > 0, t1 > 0, t2 > 0, yt1 > ymax, yt2 > ymax -- no solution
+    const double r = 1.0;
+    const double ymax = 4.0;
+    auto surface = create_cylinder_surface(r);
+    auto aperture = create_rectangle_aperture(2.0 * r, 2.0 * ymax);
+    CylinderCalculator calc(surface, aperture);
+
+    // Ray position and direction
+    Vector3d x0(5.0, ymax, 1.0);
+    Vector3d m(-1.0, 1.0, 0.0);
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    int result = calc.intersect(x0.data, m.data, xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(result, 1);
+    EXPECT_EQ(t, 0.0);
+}
+
+TEST(CylinderCalculator, Case6)
+{
+    // Case a != 0, Delta > 0, t1 < 0, t2 < 0
+    const double r = 1.0;
+    const double ymax = 4.0;
+    auto surface = create_cylinder_surface(r);
+    auto aperture = create_rectangle_aperture(2.0 * r, 2.0 * ymax);
+    CylinderCalculator calc(surface, aperture);
+
+    // Ray position and direction
+    Vector3d x0(5.0, ymax, 1.0);
+    Vector3d m(-1.0, 1.0, 0.0);
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    int result = calc.intersect(x0.data, m.data, xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(result, 1);
+    EXPECT_EQ(t, 0.0);
+}
+
+// Constructor validation tests -- includes error tests
 TEST(CylinderCalculator, ConstructorValidConstruction)
 {
     auto surface = create_cylinder_surface();
-    auto aperture = create_rectangle_aperture(); // x_length = 2.0 matches cylinder diameter
+    auto aperture = create_rectangle_aperture();
     EXPECT_NO_THROW({
         CylinderCalculator calc(surface, aperture);
     });
@@ -42,71 +203,55 @@ TEST(CylinderCalculator, ConstructorValidConstruction)
 TEST(CylinderCalculator, ConstructorNullSurfaceThrows)
 {
     auto aperture = create_rectangle_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(nullptr, aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(nullptr, aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorNullApertureThrows)
 {
     auto surface = create_cylinder_surface();
-    EXPECT_THROW({
-        CylinderCalculator calc(surface, nullptr);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(surface, nullptr); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorWrongSurfaceTypeThrows)
 {
     auto flat = std::make_shared<Flat>();
     auto aperture = create_rectangle_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(flat, aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(flat, aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorWrongApertureTypeThrows)
 {
     auto surface = create_cylinder_surface();
-    auto circular_ap = create_circular_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(surface, circular_ap);
-    }, std::invalid_argument);
+    auto circular_ap = create_circle_aperture();
+    EXPECT_THROW({ CylinderCalculator calc(surface, circular_ap); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorZeroRadiusThrows)
 {
     auto zero_radius_surface = create_cylinder_surface(0.0);
     auto aperture = create_rectangle_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(zero_radius_surface, aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(zero_radius_surface, aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorNegativeRadiusThrows)
 {
     auto negative_radius_surface = create_cylinder_surface(-1.0);
     auto aperture = create_rectangle_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(negative_radius_surface, aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(negative_radius_surface, aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorNaNRadiusThrows)
 {
     auto nan_radius_surface = create_cylinder_surface(std::nan(""));
     auto aperture = create_rectangle_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(nan_radius_surface, aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(nan_radius_surface, aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorInfiniteRadiusThrows)
 {
     auto inf_radius_surface = create_cylinder_surface(std::numeric_limits<double>::infinity());
     auto aperture = create_rectangle_aperture();
-    EXPECT_THROW({
-        CylinderCalculator calc(inf_radius_surface, aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(inf_radius_surface, aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorMismatchedApertureDimensionsThrows)
@@ -114,37 +259,33 @@ TEST(CylinderCalculator, ConstructorMismatchedApertureDimensionsThrows)
     auto surface = create_cylinder_surface(1.0); // radius = 1.0, diameter = 2.0
     // Create aperture with x_length != 2 * radius
     auto mismatched_aperture = create_rectangle_aperture(3.0, 2.0); // x_length = 3.0, but cylinder diameter = 2.0
-    EXPECT_THROW({
-        CylinderCalculator calc(surface, mismatched_aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(surface, mismatched_aperture); }, std::invalid_argument);
 }
 
 TEST(CylinderCalculator, ConstructorZeroApertureDimensionsThrows)
 {
     auto surface = create_cylinder_surface();
     auto zero_aperture = create_rectangle_aperture(2.0, 0.0); // y_length = 0
-    EXPECT_THROW({
-        CylinderCalculator calc(surface, zero_aperture);
-    }, std::invalid_argument);
+    EXPECT_THROW({ CylinderCalculator calc(surface, zero_aperture); }, std::invalid_argument);
 }
 
-// Basic intersection test
-TEST(CylinderCalculator, ValidIntersection)
-{
-    auto surface = create_cylinder_surface();
-    auto aperture = create_rectangle_aperture();
-    CylinderCalculator calc(surface, aperture);
-    
-    // Use the array-based intersect method
-    // Ray starting outside cylinder and hitting it
-    double pos_loc[3] = {2.0, 0.0, 0.0}; // Start outside cylinder (radius=1) in x direction
-    double cos_loc[3] = {-1.0, 0.0, 0.0}; // Moving toward center in -x direction
-    double pos_xyz[3], cos_klm[3], df_xyz[3];
-    double path_length;
-    
-    int result = calc.intersect(pos_loc, cos_loc, pos_xyz, cos_klm, df_xyz, &path_length);
-    
-    // Should find intersection (result == 0 means success)
-    EXPECT_EQ(result, 0);
-    EXPECT_GT(path_length, 0.0);
-}
+// // Basic intersection test
+// TEST(CylinderCalculator, ValidIntersection)
+// {
+//     auto surface = create_cylinder_surface();
+//     auto aperture = create_rectangle_aperture();
+//     CylinderCalculator calc(surface, aperture);
+
+//     // Use the array-based intersect method
+//     // Ray starting outside cylinder and hitting it
+//     double pos_loc[3] = {2.0, 0.0, 0.0}; // Start outside cylinder (radius=1) in x direction
+//     double cos_loc[3] = {-1.0, 0.0, 0.0}; // Moving toward center in -x direction
+//     double pos_xyz[3], cos_klm[3], df_xyz[3];
+//     double path_length;
+
+//     int result = calc.intersect(pos_loc, cos_loc, pos_xyz, cos_klm, df_xyz, &path_length);
+
+//     // Should find intersection (result == 0 means success)
+//     EXPECT_EQ(result, 0);
+//     EXPECT_GT(path_length, 0.0);
+// }

--- a/google-tests/unit-tests/simulation_runner/native_runner/flat_calculator_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/flat_calculator_test.cpp
@@ -12,34 +12,31 @@ using SolTrace::NativeRunner::FlatCalculator;
 
 // NOTE: Equation for the plane is always z=0
 
-// Helper function to create flat surface
-std::shared_ptr<Flat> create_flat_surface()
-{
-    auto flat = std::make_shared<Flat>();
-    return flat;
-}
-
 // Constructor validation tests
 TEST(FlatCalculator, ConstructorNullSurfaceThrows)
 {
-    EXPECT_THROW({
-        FlatCalculator calc(nullptr);
-    }, std::invalid_argument);
+    EXPECT_THROW({ FlatCalculator calc(nullptr, nullptr); }, std::invalid_argument);
 }
 
 TEST(FlatCalculator, ConstructorWrongSurfaceTypeThrows)
 {
     auto parabola = std::make_shared<Parabola>(1.0, 1.0);
-    EXPECT_THROW({
-        FlatCalculator calc(parabola);
-    }, std::invalid_argument);
+    auto rect = create_rectangle_aperture();
+    EXPECT_THROW({ FlatCalculator calc(parabola, rect); }, std::invalid_argument);
 }
 
-TEST(FlatCalculator, ConstructorValidSurface)
+TEST(FlatCalculator, ConstructorNullApertureThrows)
 {
     auto valid_surface = create_flat_surface();
+    EXPECT_THROW({ FlatCalculator calc(valid_surface, nullptr); }, std::invalid_argument);
+}
+
+TEST(FlatCalculator, ConstructorValid)
+{
+    auto valid_surface = create_flat_surface();
+    auto rect = create_rectangle_aperture();
     EXPECT_NO_THROW({
-        FlatCalculator calc(valid_surface);
+        FlatCalculator calc(valid_surface, rect);
     });
 }
 
@@ -59,7 +56,7 @@ TEST(FlatCalculator, Case1)
     Vector3d mt;
     Vector3d gradf;
 
-    FlatCalculator fcalc(create_flat_surface());
+    FlatCalculator fcalc(create_flat_surface(), create_rectangle_aperture());
     int sts = fcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
@@ -85,7 +82,7 @@ TEST(FlatCalculator, Case2)
     Vector3d mt;
     Vector3d gradf;
 
-    FlatCalculator fcalc(create_flat_surface());
+    FlatCalculator fcalc(create_flat_surface(), create_rectangle_aperture());
     int sts = fcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
@@ -97,7 +94,7 @@ TEST(FlatCalculator, Case2)
 
 TEST(FlatCalculator, Case3)
 {
-    // Case: t < 0.0 -- returns no solution
+    // Case: t > 0.0 -- returns solution
     Vector3d zero;
     zero.zero();
     // Ray position
@@ -114,7 +111,8 @@ TEST(FlatCalculator, Case3)
     Vector3d mt;
     Vector3d gradf;
 
-    FlatCalculator fcalc(create_flat_surface());
+    FlatCalculator fcalc(create_flat_surface(),
+                         create_rectangle_aperture(10.0, 10.0));
     int sts = fcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 0);
@@ -129,8 +127,39 @@ TEST(FlatCalculator, Case3)
     EXPECT_NEAR(gradf[2], 1.0, TOL);
 }
 
+TEST(FlatCalculator, Case4)
+{
+    // Case: t > 0.0, outside aperture -- returns no solution
+    Vector3d zero;
+    zero.zero();
+    // Ray position
+    Vector3d x0(2.0, 1.0, -3.0);
+    // Ray direction
+    Vector3d m(1.0, 1.0, 2.0);
+    // Solution
+    const double T = 1.5;
+    // const double TOL = 1e-12;
+
+    // Solution values
+    double t;
+    Vector3d xt;
+    Vector3d mt;
+    Vector3d gradf;
+
+    FlatCalculator fcalc(create_flat_surface(),
+                         create_rectangle_aperture(1.0, 1.0));
+    int sts = fcalc.intersect(x0.data, m.data,
+                              xt.data, mt.data, gradf.data, &t);
+
+    EXPECT_EQ(sts, 1);
+    EXPECT_EQ(t, 0.0);
+    EXPECT_TRUE(is_identical(xt, zero));
+    EXPECT_TRUE(is_identical(mt, zero));
+    EXPECT_TRUE(is_identical(gradf, zero));
+}
+
 TEST(FlatCalculator, ZAperture)
 {
-    FlatCalculator fcalc(create_flat_surface());
+    FlatCalculator fcalc(create_flat_surface(), create_rectangle_aperture());
     EXPECT_EQ(fcalc.compute_z_aperture(nullptr), 0.0);
 }

--- a/google-tests/unit-tests/simulation_runner/native_runner/native_runner_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/native_runner_test.cpp
@@ -5,15 +5,8 @@
 #include <mtrand.hpp>
 #include <native_runner.hpp>
 #include <native_runner_types.hpp>
-#include <ray_source.hpp>
-#include <sun.hpp>
-#include <simulation_data.hpp>
 #include <simulation_data_export.hpp>
 #include <simulation_result.hpp>
-#include <single_element.hpp>
-#include <stage_element.hpp>
-#include <vector3d.hpp>
-#include <virtual_element.hpp>
 
 #include "common.hpp"
 #include "count_absorbed_native.h"
@@ -44,14 +37,14 @@ TEST(NativeRunnerTypes, TSun)
     auto sun = SolTrace::Data::make_ray_source<Sun>();
     Vector3d spos(1.0, 2.0, 3.0);
     sun->set_position(spos);
-    sun->set_shape(SolTrace::Data::PILLBOX, -1.0, 1.0);
+    sun->set_shape(DistributionType::PILLBOX, -1.0, 1.0);
     my_sim.add_ray_source(sun);
 
     NativeRunner runner;
     runner.setup_sun(&my_sim);
     auto sys = runner.get_system();
     EXPECT_TRUE(is_identical(sys->Sun.Origin, sun->get_position()));
-    EXPECT_EQ(sys->Sun.ShapeIndex, SolTrace::Data::PILLBOX);
+    EXPECT_EQ(sys->Sun.ShapeIndex, DistributionType::PILLBOX);
 }
 
 TEST(NativeRunnerTypes, TElement)
@@ -210,7 +203,7 @@ TEST(NativeRunner, PowerTowerSmokeTest)
     absorber->set_surface(SolTrace::Data::make_surface<Flat>()); // surface(nullptr)
     absorber->set_aperture(SolTrace::Data::make_aperture<Rectangle>(2.0, 2.0));
     OpticalProperties *foptics = absorber->get_front_optical_properties();
-    foptics->my_type = SolTrace::Data::REFLECTION;
+    foptics->my_type = InteractionType::REFLECTION;
     foptics->reflectivity = 0.0;
 
     // Make stage 1 -- second stage -- these can be added to SimulationData
@@ -370,15 +363,17 @@ TEST(NativeRunner, SingleRayValidationTest)
     sph->set_surface(SolTrace::Data::make_surface<Sphere>(c));
     sph->get_front_optical_properties()->set_ideal_reflection();
     sph->get_back_optical_properties()->set_ideal_reflection();
+    sph->set_name("Sphere");
     sd.add_element(sph);
 
-    auto para = SolTrace::Data::make_element<SolTrace::Data::VirtualElement>();
+    auto para = SolTrace::Data::make_element<SingleElement>();
     origin.set_values(0.0, 0.0, -1.0);
     aim.set_values(0.0, 0.0, 0.0);
     zrot = 0.0;
     para->set_reference_frame_geometry(origin, aim, zrot);
     para->set_aperture(SolTrace::Data::make_aperture<Rectangle>(31.0, 31.0));
     para->set_surface(SolTrace::Data::make_surface<Parabola>(0.5 / 0.03, 0.5 / 0.03));
+    para->set_name("Parabola");
     sd.add_element(para);
 
     NativeRunner runner;
@@ -390,11 +385,11 @@ TEST(NativeRunner, SingleRayValidationTest)
     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
 
     const TSystem *sys = runner.get_system();
-    // sys->AllRayData.Print();
+    sys->RayData.Print();
     const TRayData *ray_data = &(sys->RayData);
     size_t n = ray_data->Count();
 
-    sys->RayData.Print();
+    // sys->RayData.Print();
 
     EXPECT_EQ(n, 3);
 

--- a/google-tests/unit-tests/simulation_runner/native_runner/newton_calculator_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/newton_calculator_test.cpp
@@ -2,17 +2,22 @@
 
 #include <cmath>
 
-#include <common.hpp>
 #include <newton_calculator.hpp>
 #include <vector3d.hpp>
+
+#include <common.hpp>
 
 using SolTrace::NativeRunner::NewtonCalculator;
 
 class ParabolaNewton : public NewtonCalculator
 {
 public:
-    ParabolaNewton(double cx, double cy, double tol, uint_fast64_t max_iters)
-        : NewtonCalculator(tol, max_iters),
+    ParabolaNewton(double cx,
+                   double cy,
+                   aperture_ptr ap,
+                   double tol,
+                   uint_fast64_t max_iters)
+        : NewtonCalculator(ap, tol, max_iters),
           cx(cx),
           cy(cy)
     {
@@ -68,9 +73,11 @@ TEST(NewtonCalculator, Case1)
     Vector3d mt;
     Vector3d gradf;
 
-    ParabolaNewton pnewt(cx, cy, TOL, MAX_ITERS);
+    auto rect = create_rectangle_aperture(20.0, 20.0);
+    ParabolaNewton pnewt(cx, cy, rect, TOL, MAX_ITERS);
     int sts = pnewt.intersect(x0.data, m.data,
-                              xt.data, mt.data, gradf.data, &t);
+                              xt.data, mt.data, 
+                              gradf.data, &t);
     EXPECT_EQ(sts, 0);
     EXPECT_NEAR(t, T, TOL);
     EXPECT_NEAR(xt[0], m[0] * T + x0[0], TOL);
@@ -105,7 +112,8 @@ TEST(NewtonCalculator, Case2)
     Vector3d mt;
     Vector3d gradf;
 
-    ParabolaNewton pnewt(cx, cy, TOL, MAX_ITERS);
+    auto rect = create_rectangle_aperture(20.0, 20.0);
+    ParabolaNewton pnewt(cx, cy, rect, TOL, MAX_ITERS);
     int sts = pnewt.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);

--- a/google-tests/unit-tests/simulation_runner/native_runner/parabola_calculator_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/parabola_calculator_test.cpp
@@ -30,66 +30,64 @@ double focal_length(double c)
     return 0.5 / c;
 }
 
-// Helper function to create parabola surface
-std::shared_ptr<Parabola> create_parabola_surface(double focal_length = 1.0)
-{
-    auto parabola = std::make_shared<Parabola>(focal_length, focal_length);
-    return parabola;
-}
-
 // Constructor validation tests
 TEST(ParabolaCalculator, ConstructorNullSurfaceThrows)
 {
-    EXPECT_THROW({
-        ParabolaCalculator calc(nullptr);
-    }, std::invalid_argument);
+    auto circ = create_circle_aperture();
+    EXPECT_THROW({ ParabolaCalculator calc(nullptr, circ); }, std::invalid_argument);
+}
+
+TEST(ParabolaCalculator, ConstructorNullApertureThrows)
+{
+    auto para = create_parabola_surface(1.0);
+    EXPECT_THROW({ ParabolaCalculator calc(para, nullptr); }, std::invalid_argument);
 }
 
 TEST(ParabolaCalculator, ConstructorWrongSurfaceTypeThrows)
 {
     auto flat = std::make_shared<Flat>();
-    EXPECT_THROW({
-        ParabolaCalculator calc(flat);
-    }, std::invalid_argument);
+    auto circ = create_circle_aperture();
+    EXPECT_THROW({ ParabolaCalculator calc(flat, circ); }, std::invalid_argument);
 }
 
 TEST(ParabolaCalculator, ConstructorZeroFocalLengthAllowed)
 {
     auto zero_focal_surface = create_parabola_surface(0.0);
+    auto circ = create_circle_aperture();
     EXPECT_NO_THROW({
-        ParabolaCalculator calc(zero_focal_surface);
+        ParabolaCalculator calc(zero_focal_surface, circ);
     });
 }
 
 TEST(ParabolaCalculator, ConstructorNegativeFocalLengthAllowed)
 {
     auto negative_focal_surface = create_parabola_surface(-1.0);
+    auto circ = create_circle_aperture();
     EXPECT_NO_THROW({
-        ParabolaCalculator calc(negative_focal_surface);
+        ParabolaCalculator calc(negative_focal_surface, circ);
     });
 }
 
 TEST(ParabolaCalculator, ConstructorNaNFocalLengthThrows)
 {
     auto nan_focal_surface = create_parabola_surface(std::nan(""));
-    EXPECT_THROW({
-        ParabolaCalculator calc(nan_focal_surface);
-    }, std::invalid_argument);
+    auto circ = create_circle_aperture();
+    EXPECT_THROW({ ParabolaCalculator calc(nan_focal_surface, circ); }, std::invalid_argument);
 }
 
 TEST(ParabolaCalculator, ConstructorInfiniteFocalLengthThrows)
 {
     auto inf_focal_surface = create_parabola_surface(std::numeric_limits<double>::infinity());
-    EXPECT_THROW({
-        ParabolaCalculator calc(inf_focal_surface);
-    }, std::invalid_argument);
+    auto circ = create_circle_aperture();
+    EXPECT_THROW({ ParabolaCalculator calc(inf_focal_surface, circ); }, std::invalid_argument);
 }
 
 TEST(ParabolaCalculator, ConstructorValidFocalLength)
 {
     auto valid_surface = create_parabola_surface(1.0);
+    auto circ = create_circle_aperture();
     EXPECT_NO_THROW({
-        ParabolaCalculator calc(valid_surface);
+        ParabolaCalculator calc(valid_surface, circ);
     });
 }
 
@@ -110,7 +108,8 @@ TEST(ParabolaCalculator, Case1)
     Vector3d gradf;
 
     auto parabola = SolTrace::Data::make_surface<Parabola>(0.5, 0.25);
-    ParabolaCalculator pcalc(parabola);
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     int sts = pcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
@@ -142,7 +141,8 @@ TEST(ParabolaCalculator, Case2)
     Vector3d gradf;
 
     auto parabola = SolTrace::Data::make_surface<Parabola>(0.5, 0.25);
-    ParabolaCalculator pcalc(parabola);
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     int sts = pcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 0);
@@ -174,7 +174,8 @@ TEST(ParabolaCalculator, Case3)
     Vector3d gradf;
 
     auto parabola = SolTrace::Data::make_surface<Parabola>(0.5, 0.25);
-    ParabolaCalculator pcalc(parabola);
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     int sts = pcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
@@ -205,8 +206,9 @@ TEST(ParabolaCalculator, Case4)
     Vector3d gradf;
 
     auto parabola = SolTrace::Data::make_surface<Parabola>(focal_length(cx),
-                                           focal_length(cy));
-    ParabolaCalculator pcalc(parabola);
+                                                           focal_length(cy));
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     int sts = pcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 0);
@@ -242,8 +244,9 @@ TEST(ParabolaCalculator, Case5)
     Vector3d gradf;
 
     auto parabola = SolTrace::Data::make_surface<Parabola>(focal_length(cx),
-                                           focal_length(cy));
-    ParabolaCalculator pcalc(parabola);
+                                                           focal_length(cy));
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     int sts = pcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 0);
@@ -281,8 +284,9 @@ TEST(ParabolaCalculator, Case6)
     Vector3d gradf;
 
     auto parabola = SolTrace::Data::make_surface<Parabola>(focal_length(cx),
-                                           focal_length(cy));
-    ParabolaCalculator pcalc(parabola);
+                                                           focal_length(cy));
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     int sts = pcalc.intersect(x0.data, m.data,
                               xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
@@ -301,16 +305,17 @@ TEST(ParabolaCalculator, ZAperture)
     double r = 2.5;
     auto ap = SolTrace::Data::make_aperture<Circle>(2.0 * r);
     auto parabola = SolTrace::Data::make_surface<Parabola>(focal_length(cx),
-                                           focal_length(cy));
-    ParabolaCalculator pcalc(parabola);
+                                                           focal_length(cy));
+    auto circ = create_circle_aperture(10.0);
+    ParabolaCalculator pcalc(parabola, circ);
     double zap = pcalc.compute_z_aperture(ap);
     double zmax = 0.5 * cy * r * r;
     EXPECT_NEAR(zap, zmax, TOL);
 
     // Swap x and y coefficients
     parabola = SolTrace::Data::make_surface<Parabola>(focal_length(cy),
-                                      focal_length(cx));
-    ParabolaCalculator pcalc_swap(parabola);
+                                                      focal_length(cx));
+    ParabolaCalculator pcalc_swap(parabola, circ);
     zap = pcalc.compute_z_aperture(ap);
     EXPECT_NEAR(zap, zmax, TOL);
 }

--- a/google-tests/unit-tests/simulation_runner/native_runner/sphere_calculator_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/sphere_calculator_test.cpp
@@ -5,8 +5,6 @@
 #include <common.hpp>
 #include <sphere_calculator.hpp>
 #include <simulation_data_export.hpp>
-#include <surface.hpp>
-#include <vector3d.hpp>
 
 using SolTrace::NativeRunner::SphereCalculator;
 
@@ -28,66 +26,73 @@ using SolTrace::NativeRunner::SphereCalculator;
 //    z2 = z(t2)
 // From these last two, we always have t1 < t2.
 
-// Helper function to create sphere surface
-std::shared_ptr<Sphere> create_sphere_surface(double vertex_curvature = 0.1)
-{
-    auto sphere = std::make_shared<Sphere>(vertex_curvature);
-    return sphere;
-}
-
 // Constructor validation tests
 TEST(SphereCalculator, ConstructorNullSurfaceThrows)
 {
     EXPECT_THROW({
-        SphereCalculator calc(nullptr);
+        SphereCalculator calc(nullptr, nullptr);
     }, std::invalid_argument);
 }
 
 TEST(SphereCalculator, ConstructorWrongSurfaceTypeThrows)
 {
     auto flat = std::make_shared<Flat>();
+    auto circ = create_circle_aperture();
     EXPECT_THROW({
-        SphereCalculator calc(flat);
+        SphereCalculator calc(flat, circ);
     }, std::invalid_argument);
 }
 
 TEST(SphereCalculator, ConstructorZeroVertexCurvatureThrows)
 {
     auto zero_curvature_surface = create_sphere_surface(0.0);
+    auto circ = create_circle_aperture();
     EXPECT_THROW({
-        SphereCalculator calc(zero_curvature_surface);
+        SphereCalculator calc(zero_curvature_surface, circ);
     }, std::invalid_argument);
 }
 
 TEST(SphereCalculator, ConstructorNegativeVertexCurvatureThrows)
 {
     auto negative_curvature_surface = create_sphere_surface(-0.1);
+    auto circ = create_circle_aperture();
     EXPECT_THROW({
-        SphereCalculator calc(negative_curvature_surface);
+        SphereCalculator calc(negative_curvature_surface, circ);
     }, std::invalid_argument);
 }
 
 TEST(SphereCalculator, ConstructorNaNVertexCurvatureThrows)
 {
     auto nan_curvature_surface = create_sphere_surface(std::nan(""));
+    auto circ = create_circle_aperture();
     EXPECT_THROW({
-        SphereCalculator calc(nan_curvature_surface);
+        SphereCalculator calc(nan_curvature_surface, circ);
     }, std::invalid_argument);
 }
 
 TEST(SphereCalculator, ConstructorInfiniteVertexCurvatureThrows)
 {
     auto inf_curvature_surface = create_sphere_surface(std::numeric_limits<double>::infinity());
+    auto circ = create_circle_aperture();
     EXPECT_THROW({
-        SphereCalculator calc(inf_curvature_surface);
+        SphereCalculator calc(inf_curvature_surface, circ);
     }, std::invalid_argument);
 }
 
-TEST(SphereCalculator, ConstructorValidVertexCurvature)
+TEST(SphereCalculator, ConstructorNullApertureThrows)
 {
     auto valid_surface = create_sphere_surface(0.1);
+    EXPECT_THROW({
+        SphereCalculator calc(valid_surface, nullptr);
+    }, std::invalid_argument);
+}
+
+TEST(SphereCalculator, ConstructorValid)
+{
+    auto valid_surface = create_sphere_surface(0.1);
+    auto circ = create_circle_aperture();
     EXPECT_NO_THROW({
-        SphereCalculator calc(valid_surface);
+        SphereCalculator calc(valid_surface, circ);
     });
 }
 
@@ -109,7 +114,8 @@ TEST(SphereCalculator, Case1)
     Vector3d gradf;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
     EXPECT_EQ(t, 0.0);
@@ -138,7 +144,8 @@ TEST(SphereCalculator, Case2)
     Vector3d r;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
 
     EXPECT_EQ(sts, 0);
@@ -175,7 +182,8 @@ TEST(SphereCalculator, Case3)
     Vector3d r;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
 
     EXPECT_EQ(sts, 0);
@@ -210,7 +218,8 @@ TEST(SphereCalculator, Case4)
     Vector3d gradf;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
     EXPECT_EQ(t, 0.0);
@@ -237,7 +246,8 @@ TEST(SphereCalculator, Case5)
     Vector3d gradf;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
 
     EXPECT_EQ(sts, 0);
@@ -269,7 +279,8 @@ TEST(SphereCalculator, Case6)
     Vector3d gradf;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
     EXPECT_EQ(t, 0.0);
@@ -296,7 +307,8 @@ TEST(SphereCalculator, Case7)
     Vector3d gradf;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
     EXPECT_EQ(sts, 1);
     EXPECT_EQ(t, 0.0);
@@ -323,7 +335,8 @@ TEST(SphereCalculator, Case8)
     Vector3d gradf;
     
     surface_ptr sph = make_surface<Sphere>(1.0 / radius);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(radius);
+    SphereCalculator scalc(sph, circ);
     sts = scalc.intersect(r0.data, rd.data, xt.data, mt.data, gradf.data, &t);
 
     EXPECT_EQ(sts, 0);
@@ -343,7 +356,8 @@ TEST(SphereCalculator, ZAperture)
 
     double r = 1.0;
     surface_ptr sph = make_surface<Sphere>(1.0 / r);
-    SphereCalculator scalc(sph);
+    auto circ = create_circle_aperture(r);
+    SphereCalculator scalc(sph, circ);
 
     double XLEN = 1.0;
     double YLEN = 1.0;

--- a/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/tower_demo.cpp
@@ -38,7 +38,7 @@ TEST(TowerDemo, NativeRunnerWithStages)
     absorber->set_surface(make_surface<Flat>()); // surface(nullptr)
     absorber->set_aperture(make_aperture<Rectangle>(2.0, 2.0));
     OpticalProperties *foptics = absorber->get_front_optical_properties();
-    foptics->my_type = SolTrace::Data::REFLECTION;
+    foptics->my_type = InteractionType::REFLECTION;
     foptics->reflectivity = 0.0;
     absorber->set_name("Absorber");
 


### PR DESCRIPTION
Moves the check that the ray is in the aperture into the native runner surface intersection calculator instead of in the determine intersection new function. Fixes the missed parabola case.

Implements tests for cylinder calculator and fixes several bugs with cylinder ray tracing.