### PR TITLE
Add ASAN to root CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ option(FULL_FIELD_VALIDATION_TEST "Include full field validation tests" OFF)
 
 if(SOLTRACE_ENABLE_ASAN)
 	if(MSVC)
-		message(WARNING "SOLTRACE_ENABLE_ASAN is not supported with MSVC")
-	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+		message(WARNING "SOLTRACE_ENABLE_ASAN is not yet supported with MSVC or GCC")
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang")
 		message(STATUS "Enabling address sanitizer")
 		add_compile_options(
 			$<$<COMPILE_LANGUAGE:C,CXX>:-fsanitize=address>
@@ -32,7 +32,7 @@ if(SOLTRACE_ENABLE_ASAN)
 		)
 		add_link_options(-fsanitize=address)
 	else()
-		message(WARNING "SOLTRACE_ENABLE_ASAN is only supported with Clang and GCC")
+		message(WARNING "SOLTRACE_ENABLE_ASAN is only supported with Clang")
 	endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ if(SOLTRACE_ENABLE_ASAN)
 	if(MSVC)
 		message(WARNING "SOLTRACE_ENABLE_ASAN is not supported with MSVC")
 	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+		message(STATUS "Enabling address sanitizer")
 		add_compile_options(
 			$<$<COMPILE_LANGUAGE:C,CXX>:-fsanitize=address>
 			$<$<COMPILE_LANGUAGE:C,CXX>:-fno-omit-frame-pointer>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,23 @@ option(SOLTRACE_BUILD_EMBREE_SUPPORT "Build Embree support for ray tracing" OFF)
 option(SOLTRACE_BUILD_OPTIX_SUPPORT "Build the OptiX support for ray tracing" OFF)
 
 option(SOLTRACE_BUILD_PERF_TEST "Build performance tests (not built for debug)" OFF)
+option(SOLTRACE_ENABLE_ASAN "Enable AddressSanitizer for supported builds" OFF)
 
 option(FULL_FIELD_VALIDATION_TEST "Include full field validation tests" OFF)
+
+if(SOLTRACE_ENABLE_ASAN)
+	if(MSVC)
+		message(WARNING "SOLTRACE_ENABLE_ASAN is not supported with MSVC")
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+		add_compile_options(
+			$<$<COMPILE_LANGUAGE:C,CXX>:-fsanitize=address>
+			$<$<COMPILE_LANGUAGE:C,CXX>:-fno-omit-frame-pointer>
+		)
+		add_link_options(-fsanitize=address)
+	else()
+		message(WARNING "SOLTRACE_ENABLE_ASAN is only supported with Clang and GCC")
+	endif()
+endif()
 
 
 enable_testing()
@@ -29,4 +44,3 @@ add_subdirectory(google-tests)
 if(SOLTRACE_BUILD_GUI)
 	add_subdirectory(app)
 endif()
-


### PR DESCRIPTION
AddressSanitizer is a great feature that helps catch memory safety issues early (heap/stack buffer overflows, use-after-free, etc.), and makes debugging crashes far easier during development.

This PR adds an opt-in AddressSanitizer build configuration controlled by a new CMake option:

* `SOLTRACE_ENABLE_ASAN` (by default, this is `OFF`)

When enabled and the project is built with Clang or GCC, the build will compile and link with `-fsanitize=address`. Note that this is not supported on MSVC; in this case, CMake will skip the flags. This is added to the root CMake so that all code (including third-party) can be covered. ASan is not added to the CI matrix in this PR, but can be, later on.

To enable ASan at configure time:

```sh
cmake -S . -B build-asan -DSOLTRACE_ENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build-asan
ctest --test-dir build-asan
```

Note that this will inflate execution time as it adds additional instrumentation to the code.