### PR TITLE
116 support all geometries   gpu runner

### DIFF
--- a/coretrace/CMakeLists.txt
+++ b/coretrace/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 add_subdirectory(simulation_data)
 add_subdirectory(simulation_results)
 add_subdirectory(simulation_runner)
+add_subdirectory(simdriver)
 
 #####################################################################################################################
 #

--- a/coretrace/simdriver/CMakeLists.txt
+++ b/coretrace/simdriver/CMakeLists.txt
@@ -1,0 +1,45 @@
+project(simdriver)
+
+cmake_minimum_required(VERSION 3.19)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+include_directories(
+    .
+    ../simulation_data
+    ../simulation_results
+    ../simulation_runner/native_runner
+)
+
+add_executable(simdriver main.cpp)
+
+if(SOLTRACE_BUILD_EMBREE_SUPPORT)
+    target_include_directories(simdriver PRIVATE
+        ../simulation_runner/embree_runner
+    )
+    target_compile_definitions(simdriver PRIVATE SOLTRACE_EMBREE_SUPPORT)
+    target_link_libraries(simdriver PRIVATE embree_runner)
+endif()
+
+if(SOLTRACE_BUILD_OPTIX_SUPPORT)
+    target_include_directories(simdriver PRIVATE
+        ../simulation_runner/optix_runner
+    )
+    target_compile_definitions(simdriver PRIVATE SOLTRACE_OPTIX_SUPPORT)
+    target_link_libraries(simdriver PRIVATE optix_runner)
+endif()
+
+target_link_libraries(simdriver PRIVATE
+    simdata
+    simresult
+    native_runner
+)
+
+if(UNIX)
+    target_link_libraries(simdriver PRIVATE pthread)
+endif()
+
+install(TARGETS simdriver
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/coretrace/simdriver/main.cpp
+++ b/coretrace/simdriver/main.cpp
@@ -1,0 +1,319 @@
+/**
+ * @file main.cpp
+ * @brief Command-line driver for SolTrace ray tracing.
+ *
+ * Reads a JSON file to configure SimulationData, runs the ray tracer,
+ * and writes the ray interaction records to a CSV file.
+ *
+ * Usage:
+ *   simdriver <input.json> <output.csv> [options]
+ *
+ * Options:
+ *   --threads <n>   Number of parallel threads (default: 1)
+ *   --rays <n>      Override the number of rays from the JSON file
+ *   --embree        Use the Embree runner (only available if built with
+ *                   SOLTRACE_BUILD_EMBREE_SUPPORT=ON; falls back to native
+ *                   runner with a warning if Embree support is absent)
+ *   --optix         Use the OptiX runner (only available if built with
+ *                   SOLTRACE_BUILD_OPTIX_SUPPORT=ON; falls back to native
+ *                   runner with a warning if OptiX support is absent)
+ */
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "native_runner.hpp"
+#include "simulation_data_export.hpp"
+#include "simulation_result_export.hpp"
+
+#ifdef SOLTRACE_EMBREE_SUPPORT
+#include "embree_runner.hpp"
+#endif
+
+#ifdef SOLTRACE_OPTIX_SUPPORT
+#include "optix_runner.hpp"
+#endif
+
+// using SolTrace::Data::SimulationData;
+// using SolTrace::Data::SimulationParameters;
+using SolTrace::NativeRunner::NativeRunner;
+using SolTrace::Result::SimulationResult;
+using SolTrace::Runner::RunnerStatus;
+
+static void print_usage(const char *prog)
+{
+    std::cerr
+        << "Usage: " << prog << " <input.json> <output.csv> [options]\n"
+        << "\n"
+        << "Options:\n"
+        << "  --threads <n>   Number of threads (default: 1)\n"
+        << "  --rays <n>      Override number of rays specified in the JSON file\n"
+#ifdef SOLTRACE_EMBREE_SUPPORT
+        << "  --embree        Use Embree runner instead of the native runner\n"
+        << "                  (requires SOLTRACE_BUILD_EMBREE_SUPPORT=ON at build time)\n"
+#endif
+#ifdef SOLTRACE_OPTIX_SUPPORT
+        << "  --optix         Use OptiX runner instead of the native runner\n"
+        << "                  (requires SOLTRACE_BUILD_OPTIX_SUPPORT=ON at build time)\n"
+#endif
+        ;
+}
+
+int main(int argc, char *argv[])
+{
+    if (argc < 3)
+    {
+        print_usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    const std::string input_file = argv[1];
+    const std::string output_file = argv[2];
+
+    int num_threads = 1;
+    long long num_rays_override = -1; // -1 means use what the JSON specifies
+    bool use_embree = false;
+    bool use_optix = false;
+
+    for (int i = 3; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (arg == "--threads")
+        {
+            if (i + 1 >= argc)
+            {
+                std::cerr << "Error: --threads requires an argument\n";
+                return EXIT_FAILURE;
+            }
+            try
+            {
+                num_threads = std::stoi(argv[++i]);
+            }
+            catch (...)
+            {
+                std::cerr << "Error: invalid thread count '" << argv[i] << "'\n";
+                return EXIT_FAILURE;
+            }
+            if (num_threads < 1)
+            {
+                std::cerr << "Error: thread count must be >= 1\n";
+                return EXIT_FAILURE;
+            }
+        }
+        else if (arg == "--rays")
+        {
+            if (i + 1 >= argc)
+            {
+                std::cerr << "Error: --rays requires an argument\n";
+                return EXIT_FAILURE;
+            }
+            try
+            {
+                num_rays_override = std::stoll(argv[++i]);
+            }
+            catch (...)
+            {
+                std::cerr << "Error: invalid ray count '" << argv[i] << "'\n";
+                return EXIT_FAILURE;
+            }
+            if (num_rays_override < 1)
+            {
+                std::cerr << "Error: ray count must be >= 1\n";
+                return EXIT_FAILURE;
+            }
+        }
+        else if (arg == "--embree")
+        {
+            use_embree = true;
+        }
+        else if (arg == "--optix")
+        {
+            use_optix = true;
+        }
+        else
+        {
+            std::cerr << "Error: unknown option '" << arg << "'\n";
+            print_usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Load simulation data from JSON
+    // -------------------------------------------------------------------------
+    SimulationData simData;
+    try
+    {
+        std::cout << "Loading simulation data from: " << input_file << "\n";
+        simData.import_json_file(input_file);
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "Error loading JSON file: " << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    // Override ray count if the user requested it
+    if (num_rays_override > 0)
+    {
+        SimulationParameters &params = simData.get_simulation_parameters();
+        params.number_of_rays = static_cast<uint_fast64_t>(num_rays_override);
+        params.max_number_of_rays = params.number_of_rays * 100;
+        std::cout << "Overriding ray count to " << params.number_of_rays << "\n";
+    }
+
+    // -------------------------------------------------------------------------
+    // Set up and run the simulation
+    // -------------------------------------------------------------------------
+    RunnerStatus sts;
+    SimulationResult result;
+
+#ifdef SOLTRACE_EMBREE_SUPPORT
+    if (use_embree)
+    {
+        SolTrace::EmbreeRunner::EmbreeRunner runner;
+
+        sts = runner.initialize();
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: failed to initialize Embree runner\n";
+            return EXIT_FAILURE;
+        }
+
+        runner.set_number_of_threads(static_cast<uint_fast64_t>(num_threads));
+        std::cout << "Using Embree runner with " << num_threads << " thread(s)\n";
+
+        sts = runner.setup_simulation(&simData);
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: Embree runner setup failed\n";
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Running simulation...\n";
+        sts = runner.run_simulation();
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: simulation failed\n";
+            return EXIT_FAILURE;
+        }
+
+        sts = runner.report_simulation(&result, 0);
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: failed to collect simulation results\n";
+            return EXIT_FAILURE;
+        }
+    }
+    else
+#endif
+#ifdef SOLTRACE_OPTIX_SUPPORT
+    if (use_optix)
+    {
+        OptixRunner runner;
+
+        sts = runner.initialize();
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: failed to initialize OptiX runner\n";
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Using OptiX runner\n";
+
+        sts = runner.setup_simulation(&simData);
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: OptiX runner setup failed\n";
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Running simulation...\n";
+        sts = runner.run_simulation();
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: simulation failed\n";
+            return EXIT_FAILURE;
+        }
+
+        sts = runner.report_simulation(&result, 0);
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: failed to collect simulation results\n";
+            return EXIT_FAILURE;
+        }
+    }
+    else
+#endif
+    {
+#ifndef SOLTRACE_EMBREE_SUPPORT
+        if (use_embree)
+        {
+            std::cerr << "Warning: this build does not include Embree support. "
+                         "Falling back to the native runner.\n";
+        }
+#endif
+#ifndef SOLTRACE_OPTIX_SUPPORT
+        if (use_optix)
+        {
+            std::cerr << "Warning: this build does not include OptiX support. "
+                         "Falling back to the native runner.\n";
+        }
+#endif
+
+        NativeRunner runner;
+
+        sts = runner.initialize();
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: failed to initialize native runner\n";
+            return EXIT_FAILURE;
+        }
+
+        runner.set_number_of_threads(static_cast<uint_fast64_t>(num_threads));
+        std::cout << "Using native runner with " << num_threads << " thread(s)\n";
+
+        sts = runner.setup_simulation(&simData);
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: native runner setup failed\n";
+            return EXIT_FAILURE;
+        }
+
+        std::cout << "Running simulation...\n";
+        sts = runner.run_simulation();
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: simulation failed\n";
+            return EXIT_FAILURE;
+        }
+
+        sts = runner.report_simulation(&result, 0);
+        if (sts != RunnerStatus::SUCCESS)
+        {
+            std::cerr << "Error: failed to collect simulation results\n";
+            return EXIT_FAILURE;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Write results to CSV
+    // -------------------------------------------------------------------------
+    std::cout << "Writing " << result.get_number_of_records()
+              << " ray records to: " << output_file << "\n";
+    try
+    {
+        result.write_csv_file(output_file);
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "Error writing CSV file: " << e.what() << "\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Done.\n";
+    return EXIT_SUCCESS;
+}

--- a/coretrace/simdriver/main.cpp
+++ b/coretrace/simdriver/main.cpp
@@ -23,6 +23,7 @@
 #include <exception>
 #include <iostream>
 #include <stdexcept>
+#include <chrono>
 #include <string>
 
 #include "native_runner.hpp"
@@ -147,8 +148,13 @@ int main(int argc, char *argv[])
     SimulationData simData;
     try
     {
-        std::cout << "Loading simulation data from: " << input_file << "\n";
+        std::cout << "Loading simulation data from: " << input_file << "...\n";
+        auto t_load_start = std::chrono::steady_clock::now();
         simData.import_json_file(input_file);
+        auto t_load_end = std::chrono::steady_clock::now();
+        std::cout << "  Loaded in "
+                  << std::chrono::duration<double>(t_load_end - t_load_start).count()
+                  << " s\n";
     }
     catch (const std::exception &e)
     {
@@ -186,27 +192,44 @@ int main(int argc, char *argv[])
         runner.set_number_of_threads(static_cast<uint_fast64_t>(num_threads));
         std::cout << "Using Embree runner with " << num_threads << " thread(s)\n";
 
+        std::cout << "Setting up simulation...\n";
+        auto t_setup_start = std::chrono::steady_clock::now();
         sts = runner.setup_simulation(&simData);
+        auto t_setup_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: Embree runner setup failed\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Setup in "
+                  << std::chrono::duration<double>(t_setup_end - t_setup_start).count()
+                  << " s\n";
 
         std::cout << "Running simulation...\n";
+        auto t_run_start = std::chrono::steady_clock::now();
         sts = runner.run_simulation();
+        auto t_run_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: simulation failed\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Completed in "
+                  << std::chrono::duration<double>(t_run_end - t_run_start).count()
+                  << " s\n";
 
+        std::cout << "Retrieving results...\n";
+        auto t_report_start = std::chrono::steady_clock::now();
         sts = runner.report_simulation(&result, 0);
+        auto t_report_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: failed to collect simulation results\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Retrieved in "
+                  << std::chrono::duration<double>(t_report_end - t_report_start).count()
+                  << " s\n";
     }
     else
 #endif
@@ -224,27 +247,44 @@ int main(int argc, char *argv[])
 
         std::cout << "Using OptiX runner\n";
 
+        std::cout << "Setting up simulation...\n";
+        auto t_setup_start = std::chrono::steady_clock::now();
         sts = runner.setup_simulation(&simData);
+        auto t_setup_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: OptiX runner setup failed\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Setup in "
+                  << std::chrono::duration<double>(t_setup_end - t_setup_start).count()
+                  << " s\n";
 
         std::cout << "Running simulation...\n";
+        auto t_run_start = std::chrono::steady_clock::now();
         sts = runner.run_simulation();
+        auto t_run_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: simulation failed\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Completed in "
+                  << std::chrono::duration<double>(t_run_end - t_run_start).count()
+                  << " s\n";
 
+        std::cout << "Retrieving results...\n";
+        auto t_report_start = std::chrono::steady_clock::now();
         sts = runner.report_simulation(&result, 0);
+        auto t_report_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: failed to collect simulation results\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Retrieved in "
+                  << std::chrono::duration<double>(t_report_end - t_report_start).count()
+                  << " s\n";
     }
     else
 #endif
@@ -276,37 +316,59 @@ int main(int argc, char *argv[])
         runner.set_number_of_threads(static_cast<uint_fast64_t>(num_threads));
         std::cout << "Using native runner with " << num_threads << " thread(s)\n";
 
+        std::cout << "Setting up simulation...\n";
+        auto t_setup_start = std::chrono::steady_clock::now();
         sts = runner.setup_simulation(&simData);
+        auto t_setup_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: native runner setup failed\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Setup in "
+                  << std::chrono::duration<double>(t_setup_end - t_setup_start).count()
+                  << " s\n";
 
         std::cout << "Running simulation...\n";
+        auto t_run_start = std::chrono::steady_clock::now();
         sts = runner.run_simulation();
+        auto t_run_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: simulation failed\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Completed in "
+                  << std::chrono::duration<double>(t_run_end - t_run_start).count()
+                  << " s\n";
 
+        std::cout << "Retrieving results...\n";
+        auto t_report_start = std::chrono::steady_clock::now();
         sts = runner.report_simulation(&result, 0);
+        auto t_report_end = std::chrono::steady_clock::now();
         if (sts != RunnerStatus::SUCCESS)
         {
             std::cerr << "Error: failed to collect simulation results\n";
             return EXIT_FAILURE;
         }
+        std::cout << "  Retrieved in "
+                  << std::chrono::duration<double>(t_report_end - t_report_start).count()
+                  << " s\n";
     }
 
     // -------------------------------------------------------------------------
     // Write results to CSV
     // -------------------------------------------------------------------------
     std::cout << "Writing " << result.get_number_of_records()
-              << " ray records to: " << output_file << "\n";
+              << " ray records to: " << output_file << "...\n";
     try
     {
+        auto t_write_start = std::chrono::steady_clock::now();
         result.write_csv_file(output_file);
+        auto t_write_end = std::chrono::steady_clock::now();
+        std::cout << "  Written in "
+                  << std::chrono::duration<double>(t_write_end - t_write_start).count()
+                  << " s\n";
     }
     catch (const std::exception &e)
     {

--- a/coretrace/simulation_data/aperture.cpp
+++ b/coretrace/simulation_data/aperture.cpp
@@ -40,7 +40,7 @@ namespace SolTrace::Data
         case ApertureType::EQUILATERAL_TRIANGLE:
             if (args.size() < 1)
                 break;
-            return make_aperture<EqualateralTriangle>(args[0]);
+            return make_aperture<EquilateralTriangle>(args[0]);
         case ApertureType::SINGLE_AXIS_CURVATURE_SECTION:
             if (args.size() < 3)
                 break;
@@ -90,7 +90,7 @@ namespace SolTrace::Data
         case ApertureType::RECTANGLE:
             return make_aperture<Rectangle>(jnode);
         case ApertureType::EQUILATERAL_TRIANGLE:
-            return make_aperture<EqualateralTriangle>(jnode);
+            return make_aperture<EquilateralTriangle>(jnode);
         case ApertureType::IRREGULAR_TRIANGLE:
             return make_aperture<IrregularTriangle>(jnode);
         case ApertureType::IRREGULAR_QUADRILATERAL:
@@ -349,24 +349,24 @@ namespace SolTrace::Data
         return std::make_tuple(verts, indices);
     }
 
-    EqualateralTriangle::EqualateralTriangle(const nlohmann::ordered_json &jnode)
+    EquilateralTriangle::EquilateralTriangle(const nlohmann::ordered_json &jnode)
         : Aperture(ApertureType::EQUILATERAL_TRIANGLE)
     {
         this->circumscribe_diameter = jnode.at("circumscribe_diameter");
     }
 
-    double EqualateralTriangle::aperture_area() const
+    double EquilateralTriangle::aperture_area() const
     {
         double r = 0.5 * this->circumscribe_diameter;
         return 0.75 * sqrt(3) * r * r;
     }
 
-    double EqualateralTriangle::diameter_circumscribed_circle() const
+    double EquilateralTriangle::diameter_circumscribed_circle() const
     {
         return this->circumscribe_diameter;
     }
 
-    void EqualateralTriangle::bounding_box(double &xmin,
+    void EquilateralTriangle::bounding_box(double &xmin,
                                            double &xmax,
                                            double &ymin,
                                            double &ymax) const
@@ -381,7 +381,7 @@ namespace SolTrace::Data
         return;
     }
 
-    bool EqualateralTriangle::is_in(double x, double y) const
+    bool EquilateralTriangle::is_in(double x, double y) const
     {
         double r = sqrt(x * x + y * y);
         double ro = this->radius_circumscribed_circle();
@@ -411,7 +411,7 @@ namespace SolTrace::Data
     }
 
     std::tuple<std::vector<double>, std::vector<int>>
-    EqualateralTriangle::triangulation() const
+    EquilateralTriangle::triangulation() const
     {
         double r = circumscribe_diameter / 2.0;
         Triangle tri(Point(0, r),
@@ -420,13 +420,13 @@ namespace SolTrace::Data
         return indexed_triangles(subdivide(tri, 3));
     }
 
-    aperture_ptr EqualateralTriangle::make_copy() const
+    aperture_ptr EquilateralTriangle::make_copy() const
     {
         // Invokes the implicit copy constructor
-        return make_aperture<EqualateralTriangle>(*this);
+        return make_aperture<EquilateralTriangle>(*this);
     }
 
-    void EqualateralTriangle::write_json(nlohmann::ordered_json &jnode) const
+    void EquilateralTriangle::write_json(nlohmann::ordered_json &jnode) const
     {
         ApertureType type = ApertureType::EQUILATERAL_TRIANGLE;
         jnode["aperture_type"] = ApertureTypeMap.at(type);

--- a/coretrace/simulation_data/aperture.hpp
+++ b/coretrace/simulation_data/aperture.hpp
@@ -381,10 +381,10 @@ namespace SolTrace::Data
         triangulation() const override;
     };
 
-    struct EqualateralTriangle : public Aperture
+    struct EquilateralTriangle : public Aperture
     {
         double circumscribe_diameter;
-        // EqualateralTriangle() : Aperture(EQUILATERAL_TRIANGLE),
+        // EquilateralTriangle() : Aperture(EQUILATERAL_TRIANGLE),
         //                         circumscribe_diameter(0.0)
         // {
         // }
@@ -393,7 +393,7 @@ namespace SolTrace::Data
          * @brief Constructor for equilateral triangle aperture
          * @param cd Diameter of circumscribed circle
          */
-        EqualateralTriangle(double cd)
+        EquilateralTriangle(double cd)
             : Aperture(ApertureType::EQUILATERAL_TRIANGLE),
               circumscribe_diameter(cd)
         {
@@ -403,9 +403,9 @@ namespace SolTrace::Data
          * @brief Json-based constructor for equilateral triangle aperture
          * @param jnode contains diameter of circumscribed circle
          */
-        EqualateralTriangle(const nlohmann::ordered_json &jnode);
+        EquilateralTriangle(const nlohmann::ordered_json &jnode);
 
-        virtual ~EqualateralTriangle() {}
+        virtual ~EquilateralTriangle() {}
 
         /**
          * @brief Calculate equilateral triangle aperture area

--- a/coretrace/simulation_data/cst_templates/linear_fresnel.cpp
+++ b/coretrace/simulation_data/cst_templates/linear_fresnel.cpp
@@ -390,8 +390,9 @@ namespace SolTrace::Data
         // TODO: Single element at the moment. Break up into multiple tubes.
         auto abs = make_element<SingleElement>();
         abs->set_name("Absorber");
-        origin.set_values(0.0, 0.0,
-                          this->receiver_height - 0.5 * this->abs_diameter);
+        // origin.set_values(0.0, 0.0,
+        //                   this->receiver_height - 0.5 * this->abs_diameter);
+        origin.set_values(0.0, 0.0, this->receiver_height);
         aim.set_values(0.0, 0.0, 1.0);
         vector_add(1.0, origin, 1.0, aim);
         abs->set_reference_frame_geometry(origin, aim, 0.0);
@@ -413,8 +414,9 @@ namespace SolTrace::Data
         // Envelope -- Outer
         auto envout = make_element<SingleElement>();
         envout->set_name("EnvelopeOuter");
-        origin.set_values(0.0, 0.0,
-                          this->receiver_height - 0.5 * this->env_diameter);
+        // origin.set_values(0.0, 0.0,
+        //                   this->receiver_height - 0.5 * this->env_diameter);
+        origin.set_values(0.0, 0.0, this->receiver_height);
         aim.set_values(0.0, 0.0, 1.0);
         vector_add(1.0, origin, 1.0, aim);
         envout->set_reference_frame_geometry(origin, aim, 0.0);
@@ -435,9 +437,11 @@ namespace SolTrace::Data
         // Envelope -- Inner
         auto envin = make_element<SingleElement>();
         envin->set_name("EnvelopeInner");
+        // origin.set_values(0.0, 0.0,
+        //                   this->receiver_height -
+        //                       0.5 * this->env_diameter + this->env_thickness);
         origin.set_values(0.0, 0.0,
-                          this->receiver_height -
-                              0.5 * this->env_diameter + this->env_thickness);
+                          this->receiver_height + this->env_thickness);
         aim.set_values(0.0, 0.0, 1.0);
         vector_add(1.0, origin, 1.0, aim);
         envin->set_reference_frame_geometry(origin, aim, 0.0);

--- a/coretrace/simulation_data/cst_templates/parabolic_trough.cpp
+++ b/coretrace/simulation_data/cst_templates/parabolic_trough.cpp
@@ -13,571 +13,568 @@
 #include "utilities.hpp"
 #include "surface.hpp"
 
-namespace SolTrace::Data {
-
-ParabolicTrough::ParabolicTrough()
-    : initialized(false),
-      //   ready_to_add_self(false),
-      azimuth(-1.0),
-      tilt(-1.0),
-      aperture_size_x(-1.0),
-      aperture_size_y(-1.0),
-      focal_length(-1.0),
-      gap_x(-1.0),
-      gap_y(-1.0),
-      gap_center(-1.0),
-      num_panels_x(-1),
-      num_panels_y(-1),
-      absorber_diameter(-1.0),
-      envelope_diameter(-1.0),
-      envelope_thickness(-1.0),
-      tracking_angle(0.0),
-      tracking_limit_lower(-180.0),
-      tracking_limit_upper(180.0)
+namespace SolTrace::Data
 {
-    this->tracking_origin.set_values(1.0, 0.0, 0.0);
-    this->rotation_axis.set_values(0.0, 1.0, 0.0);
-    this->neutral_normal.set_values(0.0, 0.0, 1.0);
-    return;
-}
 
-ParabolicTrough::~ParabolicTrough()
-{
-    absorbers.clear();
-    envelopes.clear();
-    mirrors.clear();
-    return;
-}
-
-void ParabolicTrough::create_geometry()
-{
-    // TODO: Check that gap values are consistent with number of panels
-
-    if (initialized)
+    ParabolicTrough::ParabolicTrough()
+        : initialized(false),
+          //   ready_to_add_self(false),
+          azimuth(-1.0),
+          tilt(-1.0),
+          aperture_size_x(-1.0),
+          aperture_size_y(-1.0),
+          focal_length(-1.0),
+          gap_x(-1.0),
+          gap_y(-1.0),
+          gap_center(-1.0),
+          num_panels_x(-1),
+          num_panels_y(-1),
+          absorber_diameter(-1.0),
+          envelope_diameter(-1.0),
+          envelope_thickness(-1.0),
+          tracking_angle(0.0),
+          tracking_limit_lower(-180.0),
+          tracking_limit_upper(180.0)
+    {
+        this->tracking_origin.set_values(1.0, 0.0, 0.0);
+        this->rotation_axis.set_values(0.0, 1.0, 0.0);
+        this->neutral_normal.set_values(0.0, 0.0, 1.0);
         return;
+    }
 
-    this->enforce_user_fields_set();
-
-    this->absorbers.clear();
-    this->mirrors.clear();
-    this->envelopes.clear();
-    this->clear();
-
-    // Mirrors
-    aperture_ptr ap = nullptr;
-    single_element_ptr panel = nullptr;
-    surface_ptr surf = nullptr;
-    Vector3d origin;
-    Vector3d aim;
-    double xstop;
-    double gap;
-    double ystart, ycoord;
-
-    // double ystart = -0.5 * this->aperture_size_y;
-    double panel_length_y = (this->aperture_size_y -
-                             this->gap_y * (this->num_panels_y - 1)) /
-                            this->num_panels_y;
-
-    double hw = 0.5 * this->aperture_size_x;
-    double xstart = -hw;
-    double arc_length = hw * sqrt(hw * this->cx * hw * this->cx + 1) +
-                        asinh(hw * this->cx) / this->cx;
-    double panel_arc_length = arc_length -
-                              this->gap_x * (this->num_panels_x - 1);
-    panel_arc_length -= this->gap_center - this->gap_x;
-    panel_arc_length /= this->num_panels_x;
-
-    // NOTE: Integer (floor) division is intentional here.
-    uint_fast64_t half_n_x = this->num_panels_x / 2;
-
-    for (int i = 0; i < this->num_panels_x; ++i)
+    ParabolicTrough::~ParabolicTrough()
     {
-        xstop = determine_x_coordinate(xstart, panel_arc_length);
-        ystart = -0.5 * this->aperture_size_y;
-        ycoord = ystart + 0.5 * panel_length_y;
+        absorbers.clear();
+        envelopes.clear();
+        mirrors.clear();
+        return;
+    }
 
-        for (int j = 0; j < this->num_panels_y; ++j)
+    void ParabolicTrough::create_geometry()
+    {
+        // TODO: Check that gap values are consistent with number of panels
+
+        if (initialized)
+            return;
+
+        this->enforce_user_fields_set();
+
+        this->absorbers.clear();
+        this->mirrors.clear();
+        this->envelopes.clear();
+        this->clear();
+
+        // Mirrors
+        aperture_ptr ap = nullptr;
+        single_element_ptr panel = nullptr;
+        surface_ptr surf = nullptr;
+        Vector3d origin;
+        Vector3d aim;
+        double xstop;
+        double gap;
+        double ystart, ycoord;
+
+        // double ystart = -0.5 * this->aperture_size_y;
+        double panel_length_y = (this->aperture_size_y -
+                                 this->gap_y * (this->num_panels_y - 1)) /
+                                this->num_panels_y;
+
+        double hw = 0.5 * this->aperture_size_x;
+        double xstart = -hw;
+        double arc_length = hw * sqrt(hw * this->cx * hw * this->cx + 1) +
+                            asinh(hw * this->cx) / this->cx;
+        double panel_arc_length = arc_length -
+                                  this->gap_x * (this->num_panels_x - 1);
+        panel_arc_length -= this->gap_center - this->gap_x;
+        panel_arc_length /= this->num_panels_x;
+
+        // NOTE: Integer (floor) division is intentional here.
+        uint_fast64_t half_n_x = this->num_panels_x / 2;
+
+        for (int i = 0; i < this->num_panels_x; ++i)
         {
-            // std::cout << "**** i = " << i << "  j = " << j << " ****"
-            //           << "\nxstart = " << xstart << "  xstop = " << xstop
-            //           << "\nystart = " << ystart << "  ycoord = " << ycoord
-            //           << "\npanel_len_y = " << panel_length_y
-            //           << "\npanel_arc_len = " << panel_arc_length
-            //           << "\narc_len = " << arc_length
-            //           << std::endl;
-
-            origin.set_values(0.0, ycoord, 0.0);
-            aim.set_values(0.0, ycoord, 1000.0);
-
-            panel = make_element<SingleElement>();
-            panel->set_name("ParabolicMirror");
-            panel->set_reference_frame_geometry(origin, aim, 0.0);
-            ap = make_aperture<Rectangle>(xstop - xstart,
-                                          panel_length_y,
-                                          xstart,
-                                          ystart);
-            panel->set_aperture(ap);
-            surf = make_surface<Parabola>(this->focal_length, 0.0);
-            panel->set_surface(surf);
-            panel->set_front_optical_properties(this->optics_mirror);
-            panel->enable();
-
-            this->mirrors.push_back(panel);
-            this->add_element(panel);
-
-            ystart += panel_length_y + this->gap_y;
+            xstop = determine_x_coordinate(xstart, panel_arc_length);
+            ystart = -0.5 * this->aperture_size_y;
             ycoord = ystart + 0.5 * panel_length_y;
+
+            for (int j = 0; j < this->num_panels_y; ++j)
+            {
+                // std::cout << "**** i = " << i << "  j = " << j << " ****"
+                //           << "\nxstart = " << xstart << "  xstop = " << xstop
+                //           << "\nystart = " << ystart << "  ycoord = " << ycoord
+                //           << "\npanel_len_y = " << panel_length_y
+                //           << "\npanel_arc_len = " << panel_arc_length
+                //           << "\narc_len = " << arc_length
+                //           << std::endl;
+
+                origin.set_values(0.0, ycoord, 0.0);
+                aim.set_values(0.0, ycoord, 1000.0);
+
+                panel = make_element<SingleElement>();
+                panel->set_name("ParabolicMirror");
+                panel->set_reference_frame_geometry(origin, aim, 0.0);
+                ap = make_aperture<Rectangle>(xstop - xstart,
+                                              panel_length_y,
+                                              xstart,
+                                              ystart);
+                panel->set_aperture(ap);
+                surf = make_surface<Parabola>(this->focal_length, 0.0);
+                panel->set_surface(surf);
+                panel->set_front_optical_properties(this->optics_mirror);
+                panel->enable();
+
+                this->mirrors.push_back(panel);
+                this->add_element(panel);
+
+                ystart += panel_length_y + this->gap_y;
+                ycoord = ystart + 0.5 * panel_length_y;
+            }
+            gap = i == this->num_panels_x / 2 - 1 ? this->gap_center : this->gap_x;
+            // std::cout << "Gap: " << gap << std::endl;
+            // std::cout << "this->num_panels_x / 2 = " << this->num_panels_x / 2
+            //           << std::endl;
+            xstart = determine_x_coordinate(xstop, gap);
         }
-        gap = i == this->num_panels_x / 2 - 1 ? this->gap_center : this->gap_x;
-        // std::cout << "Gap: " << gap << std::endl;
-        // std::cout << "this->num_panels_x / 2 = " << this->num_panels_x / 2
-        //           << std::endl;
-        xstart = determine_x_coordinate(xstop, gap);
+
+        // Absorber
+        // TODO: Single element at the moment. Break up into multiple tubes.
+        auto abs = make_element<SingleElement>();
+        abs->set_name("Absorber");
+        abs->set_origin(0.0, 0.0, this->focal_length);
+        abs->set_aim_vector(0.0, 0.0, 1.0);
+        abs->set_zrot(0.0);
+        abs->compute_coordinate_rotations();
+        abs->set_aperture(make_aperture<Rectangle>(this->absorber_diameter,
+                                                   this->aperture_size_y));
+        abs->set_surface(make_surface<Cylinder>(0.5 * this->absorber_diameter));
+        abs->set_front_optical_properties(this->optics_absorber);
+        abs->set_back_optical_properties(this->optics_absorber);
+        abs->enable();
+        this->absorbers.push_back(abs);
+        auto id = this->add_element(abs);
+        if (!Element::is_success(id))
+        {
+            // TODO: Make this more helpful
+            throw std::runtime_error("Failed to add absorber element");
+        }
+
+        // Envelope -- Outer
+        auto envout = make_element<SingleElement>();
+        envout->set_name("EnvelopeOuter");
+        envout->set_origin(0.0, 0.0, this->focal_length);
+        envout->set_aim_vector(0.0, 0.0, 1.0);
+        envout->set_zrot(0.0);
+        envout->compute_coordinate_rotations();
+        envout->set_aperture(make_aperture<Rectangle>(this->envelope_diameter,
+                                                      this->aperture_size_y));
+        envout->set_surface(make_surface<Cylinder>(0.5 * this->envelope_diameter));
+        envout->set_front_optical_properties(this->optics_envelope_outer);
+        envout->set_back_optical_properties(this->optics_envelope_outer);
+        envout->enable();
+        this->envelopes.push_back(envout);
+        id = this->add_element(envout);
+        if (!Element::is_success(id))
+        {
+            throw std::runtime_error("Failed to add outer envelope element");
+        }
+
+        // Envelope -- Inner
+        auto envin = make_element<SingleElement>();
+        envin->set_name("EnvelopeInner");
+        envin->set_origin(0.0, 0.0, this->focal_length + this->envelope_thickness);
+        envin->set_aim_vector(0.0, 0.0, 1.0);
+        envin->set_zrot(0.0);
+        envin->compute_coordinate_rotations();
+        double ap_x = this->envelope_diameter - 2 * this->envelope_thickness;
+        double ap_y = this->aperture_size_y;
+        envin->set_aperture(make_aperture<Rectangle>(ap_x, ap_y));
+        envin->set_surface(make_surface<Cylinder>(0.5 * ap_x));
+        envin->set_front_optical_properties(this->optics_envelope_inner);
+        envin->set_back_optical_properties(this->optics_envelope_inner);
+        envin->enable();
+        this->envelopes.push_back(envin);
+        id = this->add_element(envin);
+        if (!Element::is_success(id))
+        {
+            throw std::runtime_error("Failed to add inner envelope element");
+        }
+
+        this->enable();
+
+        this->rotation_axis.make_unit();
+        this->tracking_origin.make_unit();
+
+        rotate_vector_degrees(this->rotation_axis,
+                              this->tracking_origin,
+                              -this->tracking_limit_lower,
+                              this->vector_lower_limit);
+        this->vector_lower_limit.make_unit();
+
+        rotate_vector_degrees(this->rotation_axis,
+                              this->tracking_origin,
+                              -this->tracking_limit_upper,
+                              this->vector_upper_limit);
+        this->vector_upper_limit.make_unit();
+
+        this->initialized = true;
+
+        return;
     }
 
-    // Absorber
-    // TODO: Single element at the moment. Break up into multiple tubes.
-    auto abs = make_element<SingleElement>();
-    abs->set_name("Absorber");
-    abs->set_origin(0.0, 0.0,
-                    this->focal_length - 0.5 * this->absorber_diameter);
-    abs->set_aim_vector(0.0, 0.0, 1.0);
-    abs->set_zrot(0.0);
-    abs->compute_coordinate_rotations();
-    abs->set_aperture(make_aperture<Rectangle>(this->absorber_diameter,
-                                               this->aperture_size_y));
-    abs->set_surface(make_surface<Cylinder>(0.5 * this->absorber_diameter));
-    abs->set_front_optical_properties(this->optics_absorber);
-    abs->set_back_optical_properties(this->optics_absorber);
-    abs->enable();
-    this->absorbers.push_back(abs);
-    auto id = this->add_element(abs);
-    if (!Element::is_success(id))
+    void ParabolicTrough::update_geometry(double azimuth,
+                                          double elevation)
     {
-        // TODO: Make this more helpful
-        throw std::runtime_error("Failed to add absorber element");
+
+        if (elevation < 0.0 || elevation > 90.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::update_geometry: Invalid elevation ("
+               << elevation << "). Elevation must lie between 0 and 90 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (azimuth < -180.0 || azimuth > 180.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::update_geometry: Invalid azimuth ("
+               << elevation << "). Azimuth must lie between -180 and 180 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (!this->initialized)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::update_geometry: Uninitialized. "
+               << "Call create_geometry() first.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->coordinates_initialized = false;
+
+        Vector3d sun_pos;
+        sun_position_vector_degrees(sun_pos, azimuth, elevation);
+        make_unit_vector(sun_pos);
+
+        // Project into the plane defined by rotation axis as the normal
+        Vector3d sun_proj;
+        project_onto_plane(this->rotation_axis, sun_pos, sun_proj);
+        make_unit_vector(sun_proj);
+
+        assert(dot_product(sun_proj, this->rotation_axis) < 1e-12);
+
+        // double theta = acos(dot_product(sun_proj, this->tracking_origin)) * R2D;
+        double theta = acos(dot_product(sun_proj, this->neutral_normal)) * R2D;
+        if (dot_product(sun_proj, this->tracking_origin) < 0.0)
+            theta = -theta;
+
+        if (theta < this->tracking_limit_lower)
+        {
+            this->tracking_angle = this->tracking_limit_lower;
+            this->convert_global_to_reference(this->aim,
+                                              this->vector_lower_limit);
+        }
+        else if (theta > this->tracking_limit_upper)
+        {
+            this->tracking_angle = this->tracking_limit_upper;
+            this->convert_global_to_reference(this->aim,
+                                              this->vector_upper_limit);
+        }
+        else
+        {
+            this->tracking_angle = theta;
+            this->convert_global_to_reference(this->aim, sun_proj);
+        }
+
+        Vector3d rotation_axis_ref;
+        this->aim.make_unit();
+        double beta = asin(this->aim[1]);
+        this->convert_global_to_reference(rotation_axis_ref,
+                                          this->rotation_axis);
+        double gamma = acos(rotation_axis_ref[1] / cos(beta));
+
+        this->set_zrot_radians(gamma);
+        this->aim.scalar_mult(1000.0);
+        vector_add(1.0, this->origin, 1.0, this->aim);
+
+        this->compute_coordinate_rotations();
+
+        return;
     }
 
-    // Envelope -- Outer
-    auto envout = make_element<SingleElement>();
-    envout->set_name("EnvelopeOuter");
-    envout->set_origin(0.0, 0.0,
-                       this->focal_length - 0.5 * this->envelope_diameter);
-    envout->set_aim_vector(0.0, 0.0, 1.0);
-    envout->set_zrot(0.0);
-    envout->compute_coordinate_rotations();
-    envout->set_aperture(make_aperture<Rectangle>(this->envelope_diameter,
-                                                  this->aperture_size_y));
-    envout->set_surface(make_surface<Cylinder>(0.5 * this->envelope_diameter));
-    envout->set_front_optical_properties(this->optics_envelope_outer);
-    envout->set_back_optical_properties(this->optics_envelope_outer);
-    envout->enable();
-    this->envelopes.push_back(envout);
-    id = this->add_element(envout);
-    if (!Element::is_success(id))
+    double ParabolicTrough::calculate_receiver_power()
     {
-        throw std::runtime_error("Failed to add outer envelope element");
+        // TODO: Implement...
+        return 0.0;
     }
 
-    // Envelope -- Inner
-    auto envin = make_element<SingleElement>();
-    envin->set_name("EnvelopeInner");
-    envin->set_origin(0.0, 0.0,
-                      this->focal_length - 0.5 * this->envelope_diameter +
-                          this->envelope_thickness);
-    envin->set_aim_vector(0.0, 0.0, 1.0);
-    envin->set_zrot(0.0);
-    envin->compute_coordinate_rotations();
-    double ap_x = this->envelope_diameter - 2 * this->envelope_thickness;
-    double ap_y = this->aperture_size_y;
-    envin->set_aperture(make_aperture<Rectangle>(ap_x, ap_y));
-    envin->set_surface(make_surface<Cylinder>(0.5 * ap_x));
-    envin->set_front_optical_properties(this->optics_envelope_inner);
-    envin->set_back_optical_properties(this->optics_envelope_inner);
-    envin->enable();
-    this->envelopes.push_back(envin);
-    id = this->add_element(envin);
-    if (!Element::is_success(id))
+    double ParabolicTrough::get_tracking_angle_degrees() const
     {
-        throw std::runtime_error("Failed to add inner envelope element");
+        return this->tracking_angle;
     }
 
-    this->enable();
-
-    this->rotation_axis.make_unit();
-    this->tracking_origin.make_unit();
-
-    rotate_vector_degrees(this->rotation_axis,
-                          this->tracking_origin,
-                          -this->tracking_limit_lower,
-                          this->vector_lower_limit);
-    this->vector_lower_limit.make_unit();
-
-    rotate_vector_degrees(this->rotation_axis,
-                          this->tracking_origin,
-                          -this->tracking_limit_upper,
-                          this->vector_upper_limit);
-    this->vector_upper_limit.make_unit();
-
-    this->initialized = true;
-
-    return;
-}
-
-void ParabolicTrough::update_geometry(double azimuth,
-                                      double elevation)
-{
-
-    if (elevation < 0.0 || elevation > 90.0)
+    double ParabolicTrough::get_tracking_angle_radians() const
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::update_geometry: Invalid elevation ("
-           << elevation << "). Elevation must lie between 0 and 90 degrees.";
-        throw std::invalid_argument(ss.str());
+        return D2R * this->get_tracking_angle_degrees();
     }
 
-    if (azimuth < -180.0 || azimuth > 180.0)
+    void ParabolicTrough::set_angles(double azimuth, double tilt)
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::update_geometry: Invalid azimuth ("
-           << elevation << "). Azimuth must lie between -180 and 180 degrees.";
-        throw std::invalid_argument(ss.str());
+        if (azimuth < -180.0 || azimuth > 180.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_angles: Invalid azimuth angle ("
+               << azimuth << "). Must be between -180 and 180 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (tilt < 0.0 || tilt > 90.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_angles: Invalid tilt angle ("
+               << tilt << "). Must be between 0 and 90 degrees.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->coordinates_initialized = false;
+        this->azimuth = azimuth;
+        this->tilt = tilt;
+
+        // Convert input angles to spherical coordinate angles
+        double az = azimuth * D2R;
+        double el = tilt * D2R;
+        double pol = 0.5 * PI - az;
+        double inc = 0.5 * PI - el;
+
+        // Convert spherical coordinates to cartesian coordinates
+        // y-axis
+        this->rotation_axis.set_values(sin(inc) * cos(pol),
+                                       sin(inc) * sin(pol),
+                                       cos(inc));
+
+        // z-axis
+        this->neutral_normal.set_values(sin(-el) * cos(pol),
+                                        sin(-el) * sin(pol),
+                                        cos(-el));
+
+        // x-axis
+        cross_product(this->rotation_axis,
+                      this->neutral_normal,
+                      this->tracking_origin);
+
+        return;
     }
 
-    if (!this->initialized)
+    void ParabolicTrough::set_aperture_size(double size_x,
+                                            double size_y)
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::update_geometry: Uninitialized. "
-           << "Call create_geometry() first.";
-        throw std::invalid_argument(ss.str());
+        if (size_x <= 0.0 || size_y <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_aperture_size: Invalid aperture "
+               << "dimensions. size_x (" << size_x << ") and size_y ("
+               << size_y << ") must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->aperture_size_x = size_x;
+        this->aperture_size_y = size_y;
+
+        return;
     }
 
-    this->coordinates_initialized = false;
-
-    Vector3d sun_pos;
-    sun_position_vector_degrees(sun_pos, azimuth, elevation);
-    make_unit_vector(sun_pos);
-
-    // Project into the plane defined by rotation axis as the normal
-    Vector3d sun_proj;
-    project_onto_plane(this->rotation_axis, sun_pos, sun_proj);
-    make_unit_vector(sun_proj);
-
-    assert(dot_product(sun_proj, this->rotation_axis) < 1e-12);
-
-    // double theta = acos(dot_product(sun_proj, this->tracking_origin)) * R2D;
-    double theta = acos(dot_product(sun_proj, this->neutral_normal)) * R2D;
-    if (dot_product(sun_proj, this->tracking_origin) < 0.0)
-        theta = -theta;
-
-    if (theta < this->tracking_limit_lower)
+    void ParabolicTrough::set_focal_length(double flen)
     {
-        this->tracking_angle = this->tracking_limit_lower;
-        this->convert_global_to_reference(this->aim,
-                                          this->vector_lower_limit);
+        if (flen <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_focal_length: Invalid focal length ("
+               << flen << "). Must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->focal_length = flen;
+        this->cx = 0.5 / this->focal_length;
+
+        return;
     }
-    else if (theta > this->tracking_limit_upper)
+
+    void ParabolicTrough::set_gaps(double gap_x,
+                                   double gap_y,
+                                   double gap_center)
     {
-        this->tracking_angle = this->tracking_limit_upper;
-        this->convert_global_to_reference(this->aim,
-                                          this->vector_upper_limit);
+        if (gap_x < 0.0 || gap_y < 0.0 || gap_center < 0.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_gaps: Invalid gap dimensions. "
+               << "gap_x (" << gap_x << "), gap_y (" << gap_y
+               << "), and gap_center (" << gap_center
+               << ") must be non-negative.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->gap_x = gap_x;
+        this->gap_y = gap_y;
+        this->gap_center = gap_center;
+
+        return;
     }
-    else
+
+    void ParabolicTrough::set_number_panels(int_fast64_t num_x,
+                                            int_fast64_t num_y)
     {
-        this->tracking_angle = theta;
-        this->convert_global_to_reference(this->aim, sun_proj);
+        if (num_x < 1 || num_y < 1)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_number_panels: Invalid panel count. "
+               << "num_x (" << num_x << ") and num_y (" << num_y
+               << ") must be at least 1.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (num_x != 1 && num_x % 2 != 0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_number_panels: Invalid panel count "
+               << "in x direction (" << num_x
+               << "). Must be either 1 or an even number.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->num_panels_x = num_x;
+        this->num_panels_y = num_y;
+
+        return;
     }
 
-    Vector3d rotation_axis_ref;
-    this->aim.make_unit();
-    double beta = asin(this->aim[1]);
-    this->convert_global_to_reference(rotation_axis_ref,
-                                      this->rotation_axis);
-    double gamma = acos(rotation_axis_ref[1] / cos(beta));
-
-    this->set_zrot_radians(gamma);
-    this->aim.scalar_mult(1000.0);
-    vector_add(1.0, this->origin, 1.0, this->aim);
-
-    this->compute_coordinate_rotations();
-
-    return;
-}
-
-double ParabolicTrough::calculate_receiver_power()
-{
-    // TODO: Implement...
-    return 0.0;
-}
-
-double ParabolicTrough::get_tracking_angle_degrees() const
-{
-    return this->tracking_angle;
-}
-
-double ParabolicTrough::get_tracking_angle_radians() const
-{
-    return D2R * this->get_tracking_angle_degrees();
-}
-
-void ParabolicTrough::set_angles(double azimuth, double tilt)
-{
-    if (azimuth < -180.0 || azimuth > 180.0)
+    void ParabolicTrough::set_optics(const OpticalProperties &mirror,
+                                     const OpticalProperties &absorber,
+                                     const OpticalProperties &envelope_inner,
+                                     const OpticalProperties &envelope_outer)
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_angles: Invalid azimuth angle ("
-           << azimuth << "). Must be between -180 and 180 degrees.";
-        throw std::invalid_argument(ss.str());
+        this->optics_mirror = mirror;
+        this->optics_absorber = absorber;
+        this->optics_envelope_inner = envelope_inner;
+        this->optics_envelope_outer = envelope_outer;
+        return;
     }
 
-    if (tilt < 0.0 || tilt > 90.0)
+    void ParabolicTrough::set_receiver_dimensions(double abs_diam,
+                                                  double env_diam,
+                                                  double env_thick)
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_angles: Invalid tilt angle ("
-           << tilt << "). Must be between 0 and 90 degrees.";
-        throw std::invalid_argument(ss.str());
+        if (abs_diam <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_receiver_dimensions: "
+               << "Invalid absorber diameter (" << abs_diam
+               << "). Must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (env_diam <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_receiver_dimensions: "
+               << "Invalid envelope diameter (" << env_diam
+               << "). Must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (env_thick <= 0.0)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_receiver_dimensions: "
+               << "Invalid envelope thickness (" << env_thick
+               << "). Must be positive.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        if (env_diam - 2 * env_thick < abs_diam)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_receiver_dimensions: "
+               << "Envelope inner diameter (" << (env_diam - 2 * env_thick)
+               << ") is smaller than absorber diameter (" << abs_diam
+               << "). Envelope is too small for the given absorber.";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->initialized = false;
+        this->absorber_diameter = abs_diam;
+        this->envelope_diameter = env_diam;
+        this->envelope_thickness = env_thick;
+
+        return;
     }
 
-    this->coordinates_initialized = false;
-    this->azimuth = azimuth;
-    this->tilt = tilt;
-
-    // Convert input angles to spherical coordinate angles
-    double az = azimuth * D2R;
-    double el = tilt * D2R;
-    double pol = 0.5 * PI - az;
-    double inc = 0.5 * PI - el;
-
-    // Convert spherical coordinates to cartesian coordinates
-    // y-axis
-    this->rotation_axis.set_values(sin(inc) * cos(pol),
-                                   sin(inc) * sin(pol),
-                                   cos(inc));
-
-    // z-axis
-    this->neutral_normal.set_values(sin(-el) * cos(pol),
-                                    sin(-el) * sin(pol),
-                                    cos(-el));
-
-    // x-axis
-    cross_product(this->rotation_axis,
-                  this->neutral_normal,
-                  this->tracking_origin);
-
-    return;
-}
-
-void ParabolicTrough::set_aperture_size(double size_x,
-                                        double size_y)
-{
-    if (size_x <= 0.0 || size_y <= 0.0)
+    void ParabolicTrough::set_tracking_limits(double lower, double upper)
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_aperture_size: Invalid aperture "
-           << "dimensions. size_x (" << size_x << ") and size_y ("
-           << size_y << ") must be positive.";
-        throw std::invalid_argument(ss.str());
+        if (lower > upper)
+        {
+            std::stringstream ss;
+            ss << "ParabolicTrough::set_tracking_limits: Invalid tracking "
+               << "limits. Lower limit (" << lower
+               << ") must be less than or equal to upper limit ("
+               << upper << ").";
+            throw std::invalid_argument(ss.str());
+        }
+
+        this->tracking_limit_lower = lower;
+        this->tracking_limit_upper = upper;
+
+        return;
     }
 
-    this->initialized = false;
-    this->aperture_size_x = size_x;
-    this->aperture_size_y = size_y;
-
-    return;
-}
-
-void ParabolicTrough::set_focal_length(double flen)
-{
-    if (flen <= 0.0)
+    double ParabolicTrough::determine_x_coordinate(double x0,
+                                                   double arc_length)
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_focal_length: Invalid focal length ("
-           << flen << "). Must be positive.";
-        throw std::invalid_argument(ss.str());
+        return parabolic_determine_x_coordinate(this->cx, x0, arc_length);
     }
 
-    this->initialized = false;
-    this->focal_length = flen;
-    this->cx = 0.5 / this->focal_length;
-
-    return;
-}
-
-void ParabolicTrough::set_gaps(double gap_x,
-                               double gap_y,
-                               double gap_center)
-{
-    if (gap_x < 0.0 || gap_y < 0.0 || gap_center < 0.0)
+    void ParabolicTrough::enforce_user_fields_set() const
     {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_gaps: Invalid gap dimensions. "
-           << "gap_x (" << gap_x << "), gap_y (" << gap_y
-           << "), and gap_center (" << gap_center
-           << ") must be non-negative.";
-        throw std::invalid_argument(ss.str());
+        if (this->initialized)
+        {
+            // If we have created subelements, do composite element checks
+            CompositeElement::enforce_user_fields_set();
+        }
+
+        // Validate that all required parameters have been set
+        if (this->aperture_size_x <= 0.0 || this->aperture_size_y <= 0.0)
+        {
+            throw std::invalid_argument(
+                "ParabolicTrough: Aperture size must be set "
+                "before creating geometry.");
+        }
+
+        if (this->focal_length <= 0.0)
+        {
+            throw std::invalid_argument(
+                "ParabolicTrough: Focal length must be set "
+                "before creating geometry.");
+        }
+
+        if (this->num_panels_x <= 0 || this->num_panels_y <= 0)
+        {
+            throw std::invalid_argument(
+                "ParabolicTrough: Number of panels must be set "
+                "before creating geometry.");
+        }
+
+        if (this->absorber_diameter <= 0.0 ||
+            this->envelope_diameter <= 0.0 ||
+            this->envelope_thickness <= 0.0)
+        {
+            throw std::invalid_argument(
+                "ParabolicTrough: Receiver dimensions must be set "
+                "before creating geometry.");
+        }
+
+        return;
     }
-
-    this->initialized = false;
-    this->gap_x = gap_x;
-    this->gap_y = gap_y;
-    this->gap_center = gap_center;
-
-    return;
-}
-
-void ParabolicTrough::set_number_panels(int_fast64_t num_x,
-                                        int_fast64_t num_y)
-{
-    if (num_x < 1 || num_y < 1)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_number_panels: Invalid panel count. "
-           << "num_x (" << num_x << ") and num_y (" << num_y
-           << ") must be at least 1.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (num_x != 1 && num_x % 2 != 0)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_number_panels: Invalid panel count "
-           << "in x direction (" << num_x
-           << "). Must be either 1 or an even number.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->num_panels_x = num_x;
-    this->num_panels_y = num_y;
-
-    return;
-}
-
-void ParabolicTrough::set_optics(const OpticalProperties &mirror,
-                                 const OpticalProperties &absorber,
-                                 const OpticalProperties &envelope_inner,
-                                 const OpticalProperties &envelope_outer)
-{
-    this->optics_mirror = mirror;
-    this->optics_absorber = absorber;
-    this->optics_envelope_inner = envelope_inner;
-    this->optics_envelope_outer = envelope_outer;
-    return;
-}
-
-void ParabolicTrough::set_receiver_dimensions(double abs_diam,
-                                              double env_diam,
-                                              double env_thick)
-{
-    if (abs_diam <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_receiver_dimensions: "
-           << "Invalid absorber diameter (" << abs_diam
-           << "). Must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (env_diam <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_receiver_dimensions: "
-           << "Invalid envelope diameter (" << env_diam
-           << "). Must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (env_thick <= 0.0)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_receiver_dimensions: "
-           << "Invalid envelope thickness (" << env_thick
-           << "). Must be positive.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    if (env_diam - 2 * env_thick < abs_diam)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_receiver_dimensions: "
-           << "Envelope inner diameter (" << (env_diam - 2 * env_thick)
-           << ") is smaller than absorber diameter (" << abs_diam
-           << "). Envelope is too small for the given absorber.";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->initialized = false;
-    this->absorber_diameter = abs_diam;
-    this->envelope_diameter = env_diam;
-    this->envelope_thickness = env_thick;
-
-    return;
-}
-
-void ParabolicTrough::set_tracking_limits(double lower, double upper)
-{
-    if (lower > upper)
-    {
-        std::stringstream ss;
-        ss << "ParabolicTrough::set_tracking_limits: Invalid tracking "
-           << "limits. Lower limit (" << lower
-           << ") must be less than or equal to upper limit ("
-           << upper << ").";
-        throw std::invalid_argument(ss.str());
-    }
-
-    this->tracking_limit_lower = lower;
-    this->tracking_limit_upper = upper;
-
-    return;
-}
-
-double ParabolicTrough::determine_x_coordinate(double x0,
-                                               double arc_length)
-{
-    return parabolic_determine_x_coordinate(this->cx, x0, arc_length);
-}
-
-void ParabolicTrough::enforce_user_fields_set() const
-{
-    if (this->initialized)
-    {
-        // If we have created subelements, do composite element checks
-        CompositeElement::enforce_user_fields_set();
-    }
-
-    // Validate that all required parameters have been set
-    if (this->aperture_size_x <= 0.0 || this->aperture_size_y <= 0.0)
-    {
-        throw std::invalid_argument(
-            "ParabolicTrough: Aperture size must be set "
-            "before creating geometry.");
-    }
-
-    if (this->focal_length <= 0.0)
-    {
-        throw std::invalid_argument(
-            "ParabolicTrough: Focal length must be set "
-            "before creating geometry.");
-    }
-
-    if (this->num_panels_x <= 0 || this->num_panels_y <= 0)
-    {
-        throw std::invalid_argument(
-            "ParabolicTrough: Number of panels must be set "
-            "before creating geometry.");
-    }
-
-    if (this->absorber_diameter <= 0.0 ||
-        this->envelope_diameter <= 0.0 ||
-        this->envelope_thickness <= 0.0)
-    {
-        throw std::invalid_argument(
-            "ParabolicTrough: Receiver dimensions must be set "
-            "before creating geometry.");
-    }
-
-    return;
-}
 
 } // namespace SolTrace::Data

--- a/coretrace/simulation_data/simulation_data_export.hpp
+++ b/coretrace/simulation_data/simulation_data_export.hpp
@@ -12,7 +12,7 @@ using SolTrace::Data::CompositeElement;
 using SolTrace::Data::Cone;
 using SolTrace::Data::Cylinder;
 using SolTrace::Data::DistributionType;
-using SolTrace::Data::EqualateralTriangle;
+using SolTrace::Data::EquilateralTriangle;
 using SolTrace::Data::Flat;
 using SolTrace::Data::Hexagon;
 using SolTrace::Data::InteractionType;

--- a/coretrace/simulation_data/surface.cpp
+++ b/coretrace/simulation_data/surface.cpp
@@ -126,8 +126,8 @@ namespace SolTrace::Data
         // See, e.g., native_runner/cylinder_calculator.cpp.
         assert(is_approx(x_minmax[0], -r, 1e-6));
         assert(is_approx(x_minmax[1], r, 1e-6));
-        z_min = 0.0;
-        z_max = 2.0 * r;
+        z_min = -r;
+        z_max = r;
         return;
     }
 

--- a/coretrace/simulation_data/surface.hpp
+++ b/coretrace/simulation_data/surface.hpp
@@ -71,6 +71,14 @@ namespace SolTrace::Data
                                   const double y_minmax[2],
                                   double &z_min,
                                   double &z_max) const = 0;
+      inline void bounding_box(double x_min, double x_max,
+			       double y_min, double y_max,
+			       double &z_min, double &z_max)
+      {
+	double x_minmax[2] = {x_min, x_max};
+	double y_minmax[2] = {y_min, y_max};
+	return bounding_box(x_minmax, y_minmax, z_min, z_max);
+      }
 
         virtual surface_ptr make_copy() const = 0;
 

--- a/coretrace/simulation_data/surface.hpp
+++ b/coretrace/simulation_data/surface.hpp
@@ -71,14 +71,15 @@ namespace SolTrace::Data
                                   const double y_minmax[2],
                                   double &z_min,
                                   double &z_max) const = 0;
-      inline void bounding_box(double x_min, double x_max,
-			       double y_min, double y_max,
-			       double &z_min, double &z_max)
-      {
-	double x_minmax[2] = {x_min, x_max};
-	double y_minmax[2] = {y_min, y_max};
-	return bounding_box(x_minmax, y_minmax, z_min, z_max);
-      }
+        inline void bounding_box(double x_min, double x_max,
+                                 double y_min, double y_max,
+                                 double &z_min, double &z_max) const
+        {
+            double x_minmax[2] = {x_min, x_max};
+            double y_minmax[2] = {y_min, y_max};
+            bounding_box(x_minmax, y_minmax, z_min, z_max);
+            return;
+        }
 
         virtual surface_ptr make_copy() const = 0;
 

--- a/coretrace/simulation_runner/native_runner/cylinder_calculator.cpp
+++ b/coretrace/simulation_runner/native_runner/cylinder_calculator.cpp
@@ -112,8 +112,12 @@ namespace SolTrace::NativeRunner
 
         Vector3d p1, p2;
 
-        c = x0 * x0 + z0 * z0 - 2.0 * z0 * r;
-        b = 2.0 * (x0 * mx + (z0 - r) * mz);
+        // c = x0 * x0 + z0 * z0 - 2.0 * z0 * r;
+        // b = 2.0 * (x0 * mx + (z0 - r) * mz);
+        // a = mx * mx + mz * mz;
+
+        c = x0 * x0 + z0 * z0 - r * r;
+        b = 2.0 * (x0 * mx + z0 * mz);
         a = mx * mx + mz * mz;
 
         ZeroVec3(PosXYZ);
@@ -198,13 +202,13 @@ namespace SolTrace::NativeRunner
         // (which is used currently) or the outside?
         DFXYZ[0] = 2.0 * PosXYZ[0];
         DFXYZ[1] = 0.0;
-        DFXYZ[2] = 2.0 * (PosXYZ[2] - this->radius);
+        DFXYZ[2] = 2.0 * PosXYZ[2];
         return;
     }
 
     double CylinderCalculator::compute_z_aperture(aperture_ptr ap)
     {
-        double zmax = 2.0 * this->radius;
+        double zmax = this->radius;
         return zmax;
     }
 

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/Aperture.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/Aperture.cpp
@@ -63,3 +63,13 @@ Vec3d ApertureTriangle::get_v1() const { return m_v1; }
 Vec3d ApertureTriangle::get_v2() const { return m_v2; }
 
 
+ApertureQuadrilateral::ApertureQuadrilateral(Vec3d p0, Vec3d p1, Vec3d p2, Vec3d p3) : m_p0(p0), m_p1(p1), m_p2(p2), m_p3(p3) {}
+ApertureQuadrilateral::ApertureQuadrilateral() : m_p0(0,0,0), m_p1(1,0,0), m_p2(1,1,0), m_p3(0,1,0) {}
+ApertureType ApertureQuadrilateral::get_aperture_type() const {
+  return ApertureType::QUADRILATERAL;
+}
+
+Vec3d ApertureQuadrilateral::get_p0() const { return m_p0; }
+Vec3d ApertureQuadrilateral::get_p1() const { return m_p1; }
+Vec3d ApertureQuadrilateral::get_p2() const { return m_p2; }
+Vec3d ApertureQuadrilateral::get_p3() const { return m_p3; }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/Aperture.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/Aperture.h
@@ -89,5 +89,24 @@ namespace OptixCSP {
 		Vec3d m_v2;
     };
 
+    class ApertureQuadrilateral : public Aperture {
+    public:
+        ApertureQuadrilateral();
+        // input four vertices in 3D space
+		// sequence matters, front side is determined by right-hand rule
+        ApertureQuadrilateral(Vec3d p0, Vec3d p1, Vec3d p2, Vec3d p3);
+        virtual ~ApertureQuadrilateral() = default;
+        virtual ApertureType get_aperture_type() const override;
+        Vec3d get_p0() const;
+        Vec3d get_p1() const;
+        Vec3d get_p2() const;
+        Vec3d get_p3() const;
+
+    private:
+        Vec3d m_p0;
+        Vec3d m_p1;
+        Vec3d m_p2;
+        Vec3d m_p3;
+    };
 
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
@@ -234,11 +234,11 @@ GeometryDataST CspElement::toDeviceGeometryData() const
         geometry_data.setTriangle_Flat(heliostat);
     }
 
-    if (aperture_type == ApertureType::ApertureQuadrilateral)
+    if (aperture_type == ApertureType::QUADRILATERAL)
     {
         ApertureQuadrilateral quad = static_cast<ApertureQuadrilateral &>(*m_aperture);
 
-        Vec3d p0, p1, p2, p3;
+        Vec3d p1, p2, p3, p4;
 
         p1 = quad.get_p0();
         p2 = quad.get_p1();

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
@@ -160,6 +160,68 @@ void CspElement::set_lower_bounding_box(const Vec3d &lower)
     return;
 }
 
+void CspElement::set_bounding_box_local(const Vec3d &lower_local,
+                                        const Vec3d &upper_local)
+{
+    // TODO: Functionality should be in simulation data. Perhaps with
+    // a tighter bounding box. This version simply finds the global
+    // bounding box for the local bounding box.
+
+    Matrix33d rotation_matrix = get_rotation_matrix(); // L2G rotation matrix
+
+    Vec3d c0 = lower_local;
+    Vec3d c7 = upper_local;
+    Vec3d c1(c0[0], c0[1], c7[2]);
+    Vec3d c2(c0[0], c7[1], c0[2]);
+    Vec3d c3(c7[0], c0[1], c0[2]);
+    Vec3d c4(c0[0], c7[1], c7[2]);
+    Vec3d c5(c7[0], c0[1], c7[2]);
+    Vec3d c6(c7[0], c7[1], c0[2]);
+
+    Vec3d g0 = rotation_matrix * c0 + m_origin;
+    Vec3d g1 = rotation_matrix * c1 + m_origin;
+    Vec3d g2 = rotation_matrix * c2 + m_origin;
+    Vec3d g3 = rotation_matrix * c3 + m_origin;
+    Vec3d g4 = rotation_matrix * c4 + m_origin;
+    Vec3d g5 = rotation_matrix * c5 + m_origin;
+    Vec3d g6 = rotation_matrix * c6 + m_origin;
+    Vec3d g7 = rotation_matrix * c7 + m_origin;
+
+    // go through the corners and find the min and max x, y, z
+    std::vector<Vec3d> corners = {g0, g1, g2, g3,
+                                  g4, g5, g6, g7};
+
+    double min_x = std::numeric_limits<double>::max();
+    double min_y = std::numeric_limits<double>::max();
+    double min_z = std::numeric_limits<double>::max();
+
+    double max_x = std::numeric_limits<double>::lowest();
+    double max_y = std::numeric_limits<double>::lowest();
+    double max_z = std::numeric_limits<double>::lowest();
+
+    for (auto &corner : corners)
+    {
+        min_x = fmin(min_x, corner[0]);
+        min_y = fmin(min_y, corner[1]);
+        min_z = fmin(min_z, corner[2]);
+
+        max_x = fmax(max_x, corner[0]);
+        max_y = fmax(max_y, corner[1]);
+        max_z = fmax(max_z, corner[2]);
+    }
+
+    // set the lower and upper bounds
+    m_lower_box_bound[0] = min_x;
+    m_lower_box_bound[1] = min_y;
+    m_lower_box_bound[2] = min_z;
+
+    m_upper_box_bound[0] = max_x;
+    m_upper_box_bound[1] = max_y;
+    m_upper_box_bound[2] = max_z;
+
+    return;
+}
+
 GeometryDataST CspElement::toDeviceGeometryData() const
 {
 

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <vector>
 

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.cpp
@@ -142,10 +142,22 @@ Vec3d CspElement::get_upper_bounding_box() const
     return m_upper_box_bound;
 }
 
+void CspElement::set_upper_bounding_box(const Vec3d &upper)
+{
+    m_upper_box_bound = upper;
+    return;
+}
+
 // return lower bounding box
 Vec3d CspElement::get_lower_bounding_box() const
 {
     return m_lower_box_bound;
+}
+
+void CspElement::set_lower_bounding_box(const Vec3d &lower)
+{
+    m_lower_box_bound = lower;
+    return;
 }
 
 GeometryDataST CspElement::toDeviceGeometryData() const
@@ -204,7 +216,6 @@ GeometryDataST CspElement::toDeviceGeometryData() const
 
     if (aperture_type == ApertureType::TRIANGLE)
     {
-
         Vec3d v1, v2, v3;
         // first cast to ApertureTriangle type
         ApertureTriangle tri = static_cast<ApertureTriangle &>(*m_aperture);
@@ -223,6 +234,31 @@ GeometryDataST CspElement::toDeviceGeometryData() const
         geometry_data.setTriangle_Flat(heliostat);
     }
 
+    if (aperture_type == ApertureType::ApertureQuadrilateral)
+    {
+        ApertureQuadrilateral quad = static_cast<ApertureQuadrilateral &>(*m_aperture);
+
+        Vec3d p0, p1, p2, p3;
+
+        p1 = quad.get_p0();
+        p2 = quad.get_p1();
+        p3 = quad.get_p2();
+        p4 = quad.get_p3();
+
+        // given the origin and rotation, compute global coordinates of the triangle vertices
+        Matrix33d rotation_matrix = get_rotation_matrix(); // L2G rotation matrix
+        Vec3d p1_global = rotation_matrix * p1 + m_origin;
+        Vec3d p2_global = rotation_matrix * p2 + m_origin;
+        Vec3d p3_global = rotation_matrix * p3 + m_origin;
+        Vec3d p4_global = rotation_matrix * p4 + m_origin;
+
+        GeometryDataST::Quadrilateral_Flat heliostat(OptixCSP::toFloat3(p1_global),
+                                                     OptixCSP::toFloat3(p2_global),
+                                                     OptixCSP::toFloat3(p3_global),
+                                                     OptixCSP::toFloat3(p4_global));
+        geometry_data.setQuadrilateral_Flat(heliostat);
+    }
+
     geometry_data.id = this->m_id;
 
     return geometry_data;
@@ -238,138 +274,138 @@ MaterialData CspElement::toDeviceMaterialDataBack() const
     return this->m_optics_back;
 }
 
-// we also need to implement the bounding box computation
-// for a case like a rectangle aperture,
-// once we have the origin, euler angles, rotatioin matrix
-// and the aperture size, we can compute the bounding box
-// this can be called when adding an element to the system
-void CspElement::compute_bounding_box()
-{
-    // this can also be called while "initializing" the element
-    // get the rotation matrix first
-    Matrix33d rotation_matrix = get_rotation_matrix(); // L2G rotation matrix
+// // we also need to implement the bounding box computation
+// // for a case like a rectangle aperture,
+// // once we have the origin, euler angles, rotation matrix
+// // and the aperture size, we can compute the bounding box
+// // this can be called when adding an element to the system
+// void CspElement::compute_bounding_box()
+// {
+//     // this can also be called while "initializing" the element
+//     // get the rotation matrix first
+//     Matrix33d rotation_matrix = get_rotation_matrix(); // L2G rotation matrix
 
-    // now check the type of the aperture
-    ApertureType aperture_type = m_aperture->get_aperture_type();
-    SurfaceType surface_type = m_surface->get_surface_type();
+//     // now check the type of the aperture
+//     ApertureType aperture_type = m_aperture->get_aperture_type();
+//     SurfaceType surface_type = m_surface->get_surface_type();
 
-    if (aperture_type == ApertureType::RECTANGLE && surface_type != SurfaceType::CYLINDER)
-    {
-        // get the width and height of the aperture
-        double width = m_aperture->get_width();
-        double height = m_aperture->get_height();
+//     if (aperture_type == ApertureType::RECTANGLE && surface_type != SurfaceType::CYLINDER)
+//     {
+//         // get the width and height of the aperture
+//         double width = m_aperture->get_width();
+//         double height = m_aperture->get_height();
 
-        // compute the four corners of the rectangle locally
-        Vec3d corner1 = Vec3d(-width / 2, -height / 2, 0.0);
-        Vec3d corner2 = Vec3d(width / 2, -height / 2, 0.0);
-        Vec3d corner3 = Vec3d(width / 2, height / 2, 0.0);
-        Vec3d corner4 = Vec3d(-width / 2, height / 2, 0.0);
+//         // compute the four corners of the rectangle locally
+//         Vec3d corner1 = Vec3d(-width / 2, -height / 2, 0.0);
+//         Vec3d corner2 = Vec3d(width / 2, -height / 2, 0.0);
+//         Vec3d corner3 = Vec3d(width / 2, height / 2, 0.0);
+//         Vec3d corner4 = Vec3d(-width / 2, height / 2, 0.0);
 
-        // transform the corners to the global frame
-        Vec3d corner1_global = rotation_matrix * corner1 + m_origin;
-        Vec3d corner2_global = rotation_matrix * corner2 + m_origin;
-        Vec3d corner3_global = rotation_matrix * corner3 + m_origin;
-        Vec3d corner4_global = rotation_matrix * corner4 + m_origin;
+//         // transform the corners to the global frame
+//         Vec3d corner1_global = rotation_matrix * corner1 + m_origin;
+//         Vec3d corner2_global = rotation_matrix * corner2 + m_origin;
+//         Vec3d corner3_global = rotation_matrix * corner3 + m_origin;
+//         Vec3d corner4_global = rotation_matrix * corner4 + m_origin;
 
-        // Extended z axis box slightly
-        double epsilon = 1e-1;
+//         // Extended z axis box slightly
+//         double epsilon = 1e-1;
 
-        // now update the bounding box, need to find the min and max x, y, z
-        m_lower_box_bound[0] = fmin(fmin(corner1_global[0], corner2_global[0]), fmin(corner3_global[0], corner4_global[0]));
-        m_lower_box_bound[1] = fmin(fmin(corner1_global[1], corner2_global[1]), fmin(corner3_global[1], corner4_global[1]));
-        m_lower_box_bound[2] = fmin(fmin(corner1_global[2], corner2_global[2]), fmin(corner3_global[2], corner4_global[2])) - epsilon;
+//         // now update the bounding box, need to find the min and max x, y, z
+//         m_lower_box_bound[0] = fmin(fmin(corner1_global[0], corner2_global[0]), fmin(corner3_global[0], corner4_global[0]));
+//         m_lower_box_bound[1] = fmin(fmin(corner1_global[1], corner2_global[1]), fmin(corner3_global[1], corner4_global[1]));
+//         m_lower_box_bound[2] = fmin(fmin(corner1_global[2], corner2_global[2]), fmin(corner3_global[2], corner4_global[2])) - epsilon;
 
-        m_upper_box_bound[0] = fmax(fmax(corner1_global[0], corner2_global[0]), fmax(corner3_global[0], corner4_global[0]));
-        m_upper_box_bound[1] = fmax(fmax(corner1_global[1], corner2_global[1]), fmax(corner3_global[1], corner4_global[1]));
-        m_upper_box_bound[2] = fmax(fmax(corner1_global[2], corner2_global[2]), fmax(corner3_global[2], corner4_global[2])) + epsilon;
-    }
+//         m_upper_box_bound[0] = fmax(fmax(corner1_global[0], corner2_global[0]), fmax(corner3_global[0], corner4_global[0]));
+//         m_upper_box_bound[1] = fmax(fmax(corner1_global[1], corner2_global[1]), fmax(corner3_global[1], corner4_global[1]));
+//         m_upper_box_bound[2] = fmax(fmax(corner1_global[2], corner2_global[2]), fmax(corner3_global[2], corner4_global[2])) + epsilon;
+//     }
 
-    // slightly different for the cylinder, we want to know the radius and half height
-    if (surface_type == SurfaceType::CYLINDER)
-    {
-        // get the radius and full height of the cylinder
-        double width = m_aperture->get_width();
-        double height = m_aperture->get_height();
+//     // slightly different for the cylinder, we want to know the radius and half height
+//     if (surface_type == SurfaceType::CYLINDER)
+//     {
+//         // get the radius and full height of the cylinder
+//         double width = m_aperture->get_width();
+//         double height = m_aperture->get_height();
 
-        // compute 8 corners of the cyliinder box locally
-        Vec3d corner1 = Vec3d(-width / 2, -height / 2, -width / 2);
-        Vec3d corner2 = Vec3d(width / 2, -height / 2, -width / 2);
-        Vec3d corner3 = Vec3d(-width / 2, height / 2, -width / 2);
-        Vec3d corner4 = Vec3d(width / 2, height / 2, -width / 2);
-        Vec3d corner5 = Vec3d(-width / 2, -height / 2, width / 2);
-        Vec3d corner6 = Vec3d(width / 2, -height / 2, width / 2);
-        Vec3d corner7 = Vec3d(-width / 2, height / 2, width / 2);
-        Vec3d corner8 = Vec3d(width / 2, height / 2, width / 2);
+//         // compute 8 corners of the cyliinder box locally
+//         Vec3d corner1 = Vec3d(-width / 2, -height / 2, -width / 2);
+//         Vec3d corner2 = Vec3d(width / 2, -height / 2, -width / 2);
+//         Vec3d corner3 = Vec3d(-width / 2, height / 2, -width / 2);
+//         Vec3d corner4 = Vec3d(width / 2, height / 2, -width / 2);
+//         Vec3d corner5 = Vec3d(-width / 2, -height / 2, width / 2);
+//         Vec3d corner6 = Vec3d(width / 2, -height / 2, width / 2);
+//         Vec3d corner7 = Vec3d(-width / 2, height / 2, width / 2);
+//         Vec3d corner8 = Vec3d(width / 2, height / 2, width / 2);
 
-        // get the rotation matrix
-        Matrix33d rotation_matrix = get_rotation_matrix(); // L2G rotation matrix
+//         // get the rotation matrix
+//         Matrix33d rotation_matrix = get_rotation_matrix(); // L2G rotation matrix
 
-        // transform the corners to the global frame
-        Vec3d corner1_global = rotation_matrix * corner1 + m_origin;
-        Vec3d corner2_global = rotation_matrix * corner2 + m_origin;
-        Vec3d corner3_global = rotation_matrix * corner3 + m_origin;
-        Vec3d corner4_global = rotation_matrix * corner4 + m_origin;
-        Vec3d corner5_global = rotation_matrix * corner5 + m_origin;
-        Vec3d corner6_global = rotation_matrix * corner6 + m_origin;
-        Vec3d corner7_global = rotation_matrix * corner7 + m_origin;
-        Vec3d corner8_global = rotation_matrix * corner8 + m_origin;
+//         // transform the corners to the global frame
+//         Vec3d corner1_global = rotation_matrix * corner1 + m_origin;
+//         Vec3d corner2_global = rotation_matrix * corner2 + m_origin;
+//         Vec3d corner3_global = rotation_matrix * corner3 + m_origin;
+//         Vec3d corner4_global = rotation_matrix * corner4 + m_origin;
+//         Vec3d corner5_global = rotation_matrix * corner5 + m_origin;
+//         Vec3d corner6_global = rotation_matrix * corner6 + m_origin;
+//         Vec3d corner7_global = rotation_matrix * corner7 + m_origin;
+//         Vec3d corner8_global = rotation_matrix * corner8 + m_origin;
 
-        // go through the corners and find the min and max x, y, z
-        std::vector<Vec3d> corners = {corner1_global, corner2_global, corner3_global, corner4_global,
-                                      corner5_global, corner6_global, corner7_global, corner8_global};
+//         // go through the corners and find the min and max x, y, z
+//         std::vector<Vec3d> corners = {corner1_global, corner2_global, corner3_global, corner4_global,
+//                                       corner5_global, corner6_global, corner7_global, corner8_global};
 
-        double min_x = std::numeric_limits<double>::max();
-        double min_y = std::numeric_limits<double>::max();
-        double min_z = std::numeric_limits<double>::max();
+//         double min_x = std::numeric_limits<double>::max();
+//         double min_y = std::numeric_limits<double>::max();
+//         double min_z = std::numeric_limits<double>::max();
 
-        double max_x = std::numeric_limits<double>::lowest();
-        double max_y = std::numeric_limits<double>::lowest();
-        double max_z = std::numeric_limits<double>::lowest();
+//         double max_x = std::numeric_limits<double>::lowest();
+//         double max_y = std::numeric_limits<double>::lowest();
+//         double max_z = std::numeric_limits<double>::lowest();
 
-        for (auto &corner : corners)
-        {
-            min_x = fmin(min_x, corner[0]);
-            min_y = fmin(min_y, corner[1]);
-            min_z = fmin(min_z, corner[2]);
+//         for (auto &corner : corners)
+//         {
+//             min_x = fmin(min_x, corner[0]);
+//             min_y = fmin(min_y, corner[1]);
+//             min_z = fmin(min_z, corner[2]);
 
-            max_x = fmax(max_x, corner[0]);
-            max_y = fmax(max_y, corner[1]);
-            max_z = fmax(max_z, corner[2]);
-        }
+//             max_x = fmax(max_x, corner[0]);
+//             max_y = fmax(max_y, corner[1]);
+//             max_z = fmax(max_z, corner[2]);
+//         }
 
-        // set the lower and upper bounds
-        m_lower_box_bound[0] = min_x;
-        m_lower_box_bound[1] = min_y;
-        m_lower_box_bound[2] = min_z;
+//         // set the lower and upper bounds
+//         m_lower_box_bound[0] = min_x;
+//         m_lower_box_bound[1] = min_y;
+//         m_lower_box_bound[2] = min_z;
 
-        m_upper_box_bound[0] = max_x;
-        m_upper_box_bound[1] = max_y;
-        m_upper_box_bound[2] = max_z;
-    }
+//         m_upper_box_bound[0] = max_x;
+//         m_upper_box_bound[1] = max_y;
+//         m_upper_box_bound[2] = max_z;
+//     }
 
-    // bounding box for triangle aperture
-    if (aperture_type == ApertureType::TRIANGLE)
-    {
-        // get the three vertices of the triangle aperture in local coordinates
-        // first cast to ApertureTriangle type
-        ApertureTriangle tri = static_cast<ApertureTriangle &>(*m_aperture);
+//     // bounding box for triangle aperture
+//     if (aperture_type == ApertureType::TRIANGLE)
+//     {
+//         // get the three vertices of the triangle aperture in local coordinates
+//         // first cast to ApertureTriangle type
+//         ApertureTriangle tri = static_cast<ApertureTriangle &>(*m_aperture);
 
-        Vec3d v1 = tri.get_v0();
-        Vec3d v2 = tri.get_v1();
-        Vec3d v3 = tri.get_v2();
-        // transform the vertices to the global frame
-        Vec3d v1_global = rotation_matrix * v1 + m_origin;
-        Vec3d v2_global = rotation_matrix * v2 + m_origin;
-        Vec3d v3_global = rotation_matrix * v3 + m_origin;
-        // now update the bounding box, need to find the min and max x, y, z
-        m_lower_box_bound[0] = fmin(fmin(v1_global[0], v2_global[0]), v3_global[0]);
-        m_lower_box_bound[1] = fmin(fmin(v1_global[1], v2_global[1]), v3_global[1]);
-        m_lower_box_bound[2] = fmin(fmin(v1_global[2], v2_global[2]), v3_global[2]);
-        m_upper_box_bound[0] = fmax(fmax(v1_global[0], v2_global[0]), v3_global[0]);
-        m_upper_box_bound[1] = fmax(fmax(v1_global[1], v2_global[1]), v3_global[1]);
-        m_upper_box_bound[2] = fmax(fmax(v1_global[2], v2_global[2]), v3_global[2]);
-    }
-}
+//         Vec3d v1 = tri.get_v0();
+//         Vec3d v2 = tri.get_v1();
+//         Vec3d v3 = tri.get_v2();
+//         // transform the vertices to the global frame
+//         Vec3d v1_global = rotation_matrix * v1 + m_origin;
+//         Vec3d v2_global = rotation_matrix * v2 + m_origin;
+//         Vec3d v3_global = rotation_matrix * v3 + m_origin;
+//         // now update the bounding box, need to find the min and max x, y, z
+//         m_lower_box_bound[0] = fmin(fmin(v1_global[0], v2_global[0]), v3_global[0]);
+//         m_lower_box_bound[1] = fmin(fmin(v1_global[1], v2_global[1]), v3_global[1]);
+//         m_lower_box_bound[2] = fmin(fmin(v1_global[2], v2_global[2]), v3_global[2]);
+//         m_upper_box_bound[0] = fmax(fmax(v1_global[0], v2_global[0]), v3_global[0]);
+//         m_upper_box_bound[1] = fmax(fmax(v1_global[1], v2_global[1]), v3_global[1]);
+//         m_upper_box_bound[2] = fmax(fmax(v1_global[2], v2_global[2]), v3_global[2]);
+//     }
+// }
 
 bool CspElement::in_plane(const Vec3d &point) const
 {

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.h
@@ -13,28 +13,29 @@
 #include "shaders/GeometryDataST.h"
 #include "shaders/MaterialDataST.h"
 
-namespace OptixCSP {
+namespace OptixCSP
+{
 
     class Aperture;
-    class CspElementBase {
+    class CspElementBase
+    {
     public:
         CspElementBase();
         virtual ~CspElementBase() = default;
 
         // Positioning and orientation.
-        virtual const Vec3d& get_origin() const = 0;
-        virtual void set_origin(const OptixCSP::Vec3d&) = 0;
-        virtual const Vec3d& get_aim_point() const = 0;
-        virtual void set_aim_point(const Vec3d&) = 0;
-        //virtual const Vec3d& get_euler_angles() const = 0;
-        //virtual void set_euler_angles(const Vec3d&) = 0;
+        virtual const Vec3d &get_origin() const = 0;
+        virtual void set_origin(const OptixCSP::Vec3d &) = 0;
+        virtual const Vec3d &get_aim_point() const = 0;
+        virtual void set_aim_point(const Vec3d &) = 0;
+        // virtual const Vec3d& get_euler_angles() const = 0;
+        // virtual void set_euler_angles(const Vec3d&) = 0;
 
         // Bounding box accessors.
-        //virtual const Vec3d& get_upper_bounding_box() const = 0;
-        //virtual const Vec3d& get_lower_bounding_box() const = 0;
+        // virtual const Vec3d& get_upper_bounding_box() const = 0;
+        // virtual const Vec3d& get_lower_bounding_box() const = 0;
 
-
-	    virtual GeometryDataST toDeviceGeometryData() const = 0;
+        virtual GeometryDataST toDeviceGeometryData() const = 0;
         virtual MaterialData toDeviceMaterialDataFront() const = 0;
         virtual MaterialData toDeviceMaterialDataBack() const = 0;
 
@@ -42,20 +43,21 @@ namespace OptixCSP {
 
     protected:
         // Derived classes must implement bounding box computation.
-        //virtual int set_bounding_box() = 0;
+        // virtual int set_bounding_box() = 0;
     };
 
     // A concrete implementation of Element that stores data in member variables.
-    class CspElement : public CspElementBase {
+    class CspElement : public CspElementBase
+    {
     public:
         CspElement();
         ~CspElement() = default;
 
-        // set and get origin 
-        const Vec3d& get_origin() const override;
-        void set_origin(const Vec3d& o) override;
-        void set_aim_point(const Vec3d& a) override;
-        const Vec3d& get_aim_point() const override;
+        // set and get origin
+        const Vec3d &get_origin() const override;
+        void set_origin(const Vec3d &o) override;
+        void set_aim_point(const Vec3d &a) override;
+        const Vec3d &get_aim_point() const override;
 
         // set zrot (in degrees)
         void set_zrot(double zrot);
@@ -66,36 +68,38 @@ namespace OptixCSP {
         SurfaceType get_surface_type() const;
 
         // Optical CspElements setters.
-        void set_aperture(const std::shared_ptr<Aperture>& aperture);
-        void set_surface(const std::shared_ptr<Surface>& surface);
+        void set_aperture(const std::shared_ptr<Aperture> &aperture);
+        void set_surface(const std::shared_ptr<Surface> &surface);
         void set_optics_front(const bool use_refraction, const float reflectivity,
-			      const float transmissivity, const float slope_error, const float specularity_error,
-			      const OpticalDistribution od);
+                              const float transmissivity, const float slope_error, const float specularity_error,
+                              const OpticalDistribution od);
         void set_optics_back(const bool use_refraction, const float reflectivity,
-			     const float transmissivity, const float slope_error, const float specularity_error,
-			     const OpticalDistribution od);
+                             const float transmissivity, const float slope_error, const float specularity_error,
+                             const OpticalDistribution od);
 
         // set orientation based on aimpoint and zrot
-        void update_euler_angles(const Vec3d& aim_point, const double zrot);
-	    // set orientation based on the CspElement's aim point and zrot
+        void update_euler_angles(const Vec3d &aim_point, const double zrot);
+        // set orientation based on the CspElement's aim point and zrot
         void update_euler_angles();
 
-        void update_element(const Vec3d& aim_point, const double zrot);
+        void update_element(const Vec3d &aim_point, const double zrot);
 
         // return L2G rotation matrix
         Matrix33d get_rotation_matrix() const;
-
 
         // return upper bounding box
         Vec3d get_upper_bounding_box() const;
         void set_upper_bounding_box(const Vec3d &upper);
 
-	    // return lower bounding box
+        // return lower bounding box
         Vec3d get_lower_bounding_box() const;
         void set_lower_bounding_box(const Vec3d &lower);
 
+        void set_bounding_box_local(const Vec3d &lower_local,
+                                    const Vec3d &upper_local);
+
         // convert to device data available to GPU
-        GeometryDataST toDeviceGeometryData() const override; 
+        GeometryDataST toDeviceGeometryData() const override;
         MaterialData toDeviceMaterialDataFront() const override;
         MaterialData toDeviceMaterialDataBack() const override;
 
@@ -105,26 +109,25 @@ namespace OptixCSP {
         // // and the aperture size, we can compute the bounding box
         // // this can be called when adding an element to the system
         // void compute_bounding_box();
-        
-		// check if a point is inside the surface aperture
-		bool in_plane(const Vec3d& point) const;
+
+        // check if a point is inside the surface aperture
+        bool in_plane(const Vec3d &point) const;
 
         // Set id
         void set_id(const int32_t id) override;
 
     private:
-
         void set_optics(const bool is_front, const bool use_refraction, const float reflectivity,
-			const float transmissivity, const float slope_error, const float specularity_error,
-			const OpticalDistribution od);
+                        const float transmissivity, const float slope_error, const float specularity_error,
+                        const OpticalDistribution od);
 
         Vec3d m_origin;
         Vec3d m_aim_point;
-        Vec3d m_euler_angles;  // euler angles, need to be computed from aim point and zrot
-        double m_zrot; // zrot from the stinput file, user provided value, in degrees
+        Vec3d m_euler_angles; // euler angles, need to be computed from aim point and zrot
+        double m_zrot;        // zrot from the stinput file, user provided value, in degrees
 
-        Vec3d m_upper_box_bound;
-        Vec3d m_lower_box_bound;
+        Vec3d m_upper_box_bound; // Global coordinates
+        Vec3d m_lower_box_bound; // Global coordinates
 
         std::shared_ptr<Surface> m_surface;
         std::shared_ptr<Aperture> m_aperture;

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/CspElement.h
@@ -88,21 +88,23 @@ namespace OptixCSP {
 
         // return upper bounding box
         Vec3d get_upper_bounding_box() const;
+        void set_upper_bounding_box(const Vec3d &upper);
 
 	    // return lower bounding box
         Vec3d get_lower_bounding_box() const;
+        void set_lower_bounding_box(const Vec3d &lower);
 
         // convert to device data available to GPU
         GeometryDataST toDeviceGeometryData() const override; 
         MaterialData toDeviceMaterialDataFront() const override;
         MaterialData toDeviceMaterialDataBack() const override;
 
-        // we also need to implement the bounding box computation
-        // for a case like a rectangle aperture,
-        // once we have the origin, euler angles, rotatioin matrix
-        // and the aperture size, we can compute the bounding box
-        // this can be called when adding an element to the system
-        void compute_bounding_box();
+        // // we also need to implement the bounding box computation
+        // // for a case like a rectangle aperture,
+        // // once we have the origin, euler angles, rotatioin matrix
+        // // and the aperture size, we can compute the bounding box
+        // // this can be called when adding an element to the system
+        // void compute_bounding_box();
         
 		// check if a point is inside the surface aperture
 		bool in_plane(const Vec3d& point) const;

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
@@ -11,31 +11,31 @@
 #include <sstream>
 #include <vector>
 
-
 using namespace OptixCSP;
 
-
 // Collect geometry and material information from the scene elements
-void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<CspElement>>& element_list,
-                                            LaunchParams& params) {    
-    m_aabb_list_H.clear(); // Clear the existing AABB list
-    m_sbt_index_H.clear(); // Clear the existing SBT index list
-	m_geometry_data_array_H.clear(); // Clear the existing geometry data array
+void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<CspElement>> &element_list,
+                                            LaunchParams &params)
+{
+    m_aabb_list_H.clear();           // Clear the existing AABB list
+    m_sbt_index_H.clear();           // Clear the existing SBT index list
+    m_geometry_data_array_H.clear(); // Clear the existing geometry data array
     m_material_data_array_front_H.clear();
     m_material_data_array_back_H.clear();
 
-	m_obj_counts = static_cast<uint32_t>(element_list.size()); // Number of objects in the scene
+    m_obj_counts = static_cast<uint32_t>(element_list.size()); // Number of objects in the scene
 
-	// Resize
-	m_aabb_list_H.resize(m_obj_counts);
-	m_geometry_data_array_H.resize(m_obj_counts);
+    // Resize
+    m_aabb_list_H.resize(m_obj_counts);
+    m_geometry_data_array_H.resize(m_obj_counts);
     m_sbt_index_H.resize(m_obj_counts);
-	m_material_data_array_front_H.resize(m_obj_counts);
+    m_material_data_array_front_H.resize(m_obj_counts);
     m_material_data_array_back_H.resize(m_obj_counts);
 
-    for (uint32_t i = 0; i < m_obj_counts; i++) {
+    for (uint32_t i = 0; i < m_obj_counts; i++)
+    {
 
-		std::shared_ptr<CspElement> element = element_list[i];
+        std::shared_ptr<CspElement> element = element_list[i];
 
         // Create an OptixAabb from the geometry data
         OptixAabb aabb;
@@ -43,54 +43,58 @@ void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<Cs
         float3 m_max;
         uint32_t sbt_offset = 0;
 
-        if (element->get_aperture_type() == ApertureType::CIRCLE) {
+        if (element->get_aperture_type() == ApertureType::CIRCLE)
+        {
             m_min = make_float3(0.0f, 0.0f, 0.0f); // Initialize min to a large value
             m_max = make_float3(0.0f, 0.0f, 0.0f); // Initialize max to a small value
         }
 
-
-        if (element->get_aperture_type() == ApertureType::RECTANGLE) {
+        if (element->get_aperture_type() == ApertureType::RECTANGLE)
+        {
             element->compute_bounding_box();
             m_min.x = (float)(element->get_lower_bounding_box()[0]);
             m_min.y = (float)(element->get_lower_bounding_box()[1]);
-			m_min.z = (float)(element->get_lower_bounding_box()[2]);
+            m_min.z = (float)(element->get_lower_bounding_box()[2]);
 
-			m_max.x = (float)(element->get_upper_bounding_box()[0]);
-			m_max.y = (float)(element->get_upper_bounding_box()[1]);
-			m_max.z = (float)(element->get_upper_bounding_box()[2]);
+            m_max.x = (float)(element->get_upper_bounding_box()[0]);
+            m_max.y = (float)(element->get_upper_bounding_box()[1]);
+            m_max.z = (float)(element->get_upper_bounding_box()[2]);
 
-            if (element->get_surface_type() == SurfaceType::PARABOLIC) {
+            if (element->get_surface_type() == SurfaceType::PARABOLIC)
+            {
                 sbt_offset = static_cast<uint32_t>(OpticalEntityType::RECTANGLE_PARABOLIC);
             }
-            else if (element->get_surface_type() == SurfaceType::FLAT) {
+            else if (element->get_surface_type() == SurfaceType::FLAT)
+            {
                 sbt_offset = static_cast<uint32_t>(OpticalEntityType::RECTANGLE_FLAT);
             }
-            else if (element->get_surface_type() == SurfaceType::CYLINDER){
+            else if (element->get_surface_type() == SurfaceType::CYLINDER)
+            {
                 sbt_offset = static_cast<uint32_t>(OpticalEntityType::CYLINDRICAL);
             }
-	    else {
-	      std::stringstream ss;
-	      ss << "Unimplemented surface type ("
-		 << static_cast<int>(element->get_surface_type())
-		 << ") for rectangle aperture ("
-		 << static_cast<int>(element->get_aperture_type());
-	      throw std::runtime_error(ss.str());
+            else
+            {
+                std::stringstream ss;
+                ss << "Unimplemented surface type ("
+                   << static_cast<int>(element->get_surface_type())
+                   << ") for rectangle aperture ("
+                   << static_cast<int>(element->get_aperture_type());
+                throw std::runtime_error(ss.str());
             }
         }
 
-        if (element->get_aperture_type() == ApertureType::TRIANGLE) {
+        if (element->get_aperture_type() == ApertureType::TRIANGLE)
+        {
             element->compute_bounding_box();
             m_min.x = (float)(element->get_lower_bounding_box()[0]);
             m_min.y = (float)(element->get_lower_bounding_box()[1]);
-			m_min.z = (float)(element->get_lower_bounding_box()[2]);
-			m_max.x = (float)(element->get_upper_bounding_box()[0]);
-			m_max.y = (float)(element->get_upper_bounding_box()[1]);
-			m_max.z = (float)(element->get_upper_bounding_box()[2]);
+            m_min.z = (float)(element->get_lower_bounding_box()[2]);
+            m_max.x = (float)(element->get_upper_bounding_box()[0]);
+            m_max.y = (float)(element->get_upper_bounding_box()[1]);
+            m_max.z = (float)(element->get_upper_bounding_box()[2]);
 
             sbt_offset = static_cast<uint32_t>(OpticalEntityType::TRIANGLE_FLAT);
-
         }
-
 
         aabb.minX = m_min.x;
         aabb.minY = m_min.y;
@@ -100,56 +104,54 @@ void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<Cs
         aabb.maxY = m_max.y;
         aabb.maxZ = m_max.z;
 
-
-		m_aabb_list_H[i] = aabb; // Store the AABB in the list
+        m_aabb_list_H[i] = aabb;       // Store the AABB in the list
         m_sbt_index_H[i] = sbt_offset; // Store the SBT index
         m_geometry_data_array_H[i] = element->toDeviceGeometryData();
 
-
-		// now we set the material data for each element, use placeholder values for now 
+        // now we set the material data for each element, use placeholder values for now
         m_material_data_array_front_H[i] = element->toDeviceMaterialDataFront();
         m_material_data_array_back_H[i] = element->toDeviceMaterialDataBack();
     }
 
-    // print out computed minimum distance 
-	std::cout << "Minimum distance to sun plane: " << m_sun_plane_distance << std::endl;
+    // print out computed minimum distance
+    std::cout << "Minimum distance to sun plane: " << m_sun_plane_distance << std::endl;
 }
 
-
-void GeometryManager::compute_sun_plane_H(LaunchParams& params) {
+void GeometryManager::compute_sun_plane_H(LaunchParams &params)
+{
 
     m_sun_plane_distance = -1;
     float3 sun_vector = params.sun_vector;
 
-    float* sun_plane_dist_D;
-    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&sun_plane_dist_D), sizeof(float)));
+    float *sun_plane_dist_D;
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void **>(&sun_plane_dist_D), sizeof(float)));
     CUDA_CHECK(cudaMemset(sun_plane_dist_D, 0, sizeof(float)));
 
-    compute_d_on_gpu(reinterpret_cast<const OptixAabb*>(m_aabb_list_D), m_obj_counts, sun_vector, sun_plane_dist_D);
+    compute_d_on_gpu(reinterpret_cast<const OptixAabb *>(m_aabb_list_D), m_obj_counts, sun_vector, sun_plane_dist_D);
 
-    CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(&m_sun_plane_distance),
-                         reinterpret_cast<void*>(sun_plane_dist_D),
-                         sizeof(float),
-                         cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(reinterpret_cast<void *>(&m_sun_plane_distance),
+                          reinterpret_cast<void *>(sun_plane_dist_D),
+                          sizeof(float),
+                          cudaMemcpyDeviceToHost));
 
     float3 sun_u, sun_v;
     float3 axis = (abs(sun_vector.x) < 0.9f) ? make_float3(1.0f, 0.0f, 0.0f) : make_float3(0.0f, 1.0f, 0.0f);
     sun_u = normalize(cross(axis, sun_vector));
     sun_v = normalize(cross(sun_vector, sun_u));
     // allocate uv bounds on device, float array of size four
-    float sun_uv_bounds[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    float sun_uv_bounds[4] = {0.0f, 0.0f, 0.0f, 0.0f};
     // allocate memory for the sun_u_bounds on device
-    float* sun_uv_bounds_D;
-    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&sun_uv_bounds_D), 4 * sizeof(float)));
+    float *sun_uv_bounds_D;
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void **>(&sun_uv_bounds_D), 4 * sizeof(float)));
 
-    compute_uv_bounds_on_gpu(reinterpret_cast<const OptixAabb*>(m_aabb_list_D),
-        m_obj_counts,
-        m_sun_plane_distance,
-        sun_vector,
-        sun_u,
-        sun_v,
-        tan(params.sun_max_angle * 1e-3),   // Convert from mrad to rad
-        sun_uv_bounds_D);
+    compute_uv_bounds_on_gpu(reinterpret_cast<const OptixAabb *>(m_aabb_list_D),
+                             m_obj_counts,
+                             m_sun_plane_distance,
+                             sun_vector,
+                             sun_u,
+                             sun_v,
+                             tan(params.sun_max_angle * 1e-3), // Convert from mrad to rad
+                             sun_uv_bounds_D);
 
     // Copy the computed bounds back to the host
     cudaMemcpy(sun_uv_bounds, sun_uv_bounds_D, 4 * sizeof(float), cudaMemcpyDeviceToHost);
@@ -164,34 +166,35 @@ void GeometryManager::compute_sun_plane_H(LaunchParams& params) {
     params.sun_v2 = u_max * sun_u + v_max * sun_v + m_sun_plane_distance * sun_vector;
     params.sun_v3 = u_min * sun_u + v_max * sun_v + m_sun_plane_distance * sun_vector;
 
-    CUDA_CHECK(cudaFree(reinterpret_cast<void*>(sun_plane_dist_D)));
-    CUDA_CHECK(cudaFree(reinterpret_cast<void*>(sun_uv_bounds_D)));
-
+    CUDA_CHECK(cudaFree(reinterpret_cast<void *>(sun_plane_dist_D)));
+    CUDA_CHECK(cudaFree(reinterpret_cast<void *>(sun_uv_bounds_D)));
 }
 
-void GeometryManager::create_geometries(LaunchParams& params) {
+void GeometryManager::create_geometries(LaunchParams &params)
+{
 
     // Allocate memory on the device for the AABB array.
-    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&m_aabb_list_D), m_obj_counts * sizeof(OptixAabb)));
-    CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(m_aabb_list_D),
-               m_aabb_list_H.data(), 
-		       m_obj_counts * sizeof(OptixAabb),
-               cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void **>(&m_aabb_list_D), m_obj_counts * sizeof(OptixAabb)));
+    CUDA_CHECK(cudaMemcpy(reinterpret_cast<void *>(m_aabb_list_D),
+                          m_aabb_list_H.data(),
+                          m_obj_counts * sizeof(OptixAabb),
+                          cudaMemcpyHostToDevice));
 
-	compute_sun_plane_H(params);
+    compute_sun_plane_H(params);
 
     // populate aabb_input_flags vector, size of types, no rebuild
     std::vector<uint32_t> aabb_input_flags(NUM_OPTICAL_ENTITY_TYPES);
-    for (int i = 0; i < NUM_OPTICAL_ENTITY_TYPES; i++) {
+    for (int i = 0; i < NUM_OPTICAL_ENTITY_TYPES; i++)
+    {
         aabb_input_flags[i] = OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT;
     }
 
-	// device vector for SBT index, no need to rebuild
+    // device vector for SBT index, no need to rebuild
     CUdeviceptr d_sbt_index;
-    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&d_sbt_index), m_obj_counts * sizeof(uint32_t)));
-    CUDA_CHECK(cudaMemcpy(reinterpret_cast<void*>(d_sbt_index),
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void **>(&d_sbt_index), m_obj_counts * sizeof(uint32_t)));
+    CUDA_CHECK(cudaMemcpy(reinterpret_cast<void *>(d_sbt_index),
                           m_sbt_index_H.data(),
-        m_obj_counts * sizeof(uint32_t),
+                          m_obj_counts * sizeof(uint32_t),
                           cudaMemcpyHostToDevice));
 
     // Configure the input for the GAS build process.
@@ -206,83 +209,81 @@ void GeometryManager::create_geometries(LaunchParams& params) {
 
     // Set up acceleration structure (AS) build options.
     m_accel_build_options = {
-        OPTIX_BUILD_FLAG_ALLOW_UPDATE,        // allow update
-        OPTIX_BUILD_OPERATION_BUILD           // operation type, build a new aceleration structure
+        OPTIX_BUILD_FLAG_ALLOW_UPDATE, // allow update
+        OPTIX_BUILD_OPERATION_BUILD    // operation type, build a new aceleration structure
     };
 
-    OptixAccelBufferSizes gas_buffer_sizes;     // sizes for temp and output buffers.
+    OptixAccelBufferSizes gas_buffer_sizes; // sizes for temp and output buffers.
 
     // Query the memory usage required for building the GAS.
-	OPTIX_CHECK(optixAccelComputeMemoryUsage(m_state.context, 
-                                             &m_accel_build_options, 
+    OPTIX_CHECK(optixAccelComputeMemoryUsage(m_state.context,
+                                             &m_accel_build_options,
                                              &m_aabb_input,
                                              1,
                                              &gas_buffer_sizes));
 
-    m_temp_buffer_size   = gas_buffer_sizes.tempSizeInBytes;
+    m_temp_buffer_size = gas_buffer_sizes.tempSizeInBytes;
     m_output_buffer_size = gas_buffer_sizes.outputSizeInBytes;
 
-    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&m_temp_buffer),   m_temp_buffer_size));
-    CUDA_CHECK(cudaMalloc(reinterpret_cast<void**>(&m_output_buffer), m_output_buffer_size));
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void **>(&m_temp_buffer), m_temp_buffer_size));
+    CUDA_CHECK(cudaMalloc(reinterpret_cast<void **>(&m_output_buffer), m_output_buffer_size));
 
     // Build the GAS.
-	OPTIX_CHECK(optixAccelBuild(m_state.context,								  // OptiX context
-		m_state.stream,                                  // CUDA stream (default is 0)
-        &m_accel_build_options,
-        &m_aabb_input,
-        1,
-        m_temp_buffer,
-        m_temp_buffer_size,
-        m_output_buffer,
-        m_output_buffer_size,
-		&m_state.gas_handle,                             // Output handle for the GAS
-		nullptr,                                        // Emitted properties (not used here)
-		0));                                           // Number of emitted properties
-    
+    OPTIX_CHECK(optixAccelBuild(m_state.context, // OptiX context
+                                m_state.stream,  // CUDA stream (default is 0)
+                                &m_accel_build_options,
+                                &m_aabb_input,
+                                1,
+                                m_temp_buffer,
+                                m_temp_buffer_size,
+                                m_output_buffer,
+                                m_output_buffer_size,
+                                &m_state.gas_handle, // Output handle for the GAS
+                                nullptr,             // Emitted properties (not used here)
+                                0));                 // Number of emitted properties
 }
 
-
-void GeometryManager::update_geometry_info(const std::vector<std::shared_ptr<CspElement>>& element_list,
-	LaunchParams& params) {
-	// Recollect geometry info
-	collect_geometry_info(element_list, params);
+void GeometryManager::update_geometry_info(const std::vector<std::shared_ptr<CspElement>> &element_list,
+                                           LaunchParams &params)
+{
+    // Recollect geometry info
+    collect_geometry_info(element_list, params);
 
     // update device aabb list
-	CUDA_CHECK(cudaMemcpyAsync(
-		reinterpret_cast<void*>(m_aabb_list_D),
-		m_aabb_list_H.data(),
-		m_aabb_list_H.size() * sizeof(OptixAabb),
-		cudaMemcpyHostToDevice, m_state.stream));
-
-    std::vector<uint32_t> aabb_input_flags(NUM_OPTICAL_ENTITY_TYPES);
-    for (int i = 0; i < NUM_OPTICAL_ENTITY_TYPES; i++) {
-        aabb_input_flags[i] = OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT;
-    }
-
-	m_aabb_input.customPrimitiveArray.flags = aabb_input_flags.data();
-
-
     CUDA_CHECK(cudaMemcpyAsync(
-        reinterpret_cast<void*>(m_aabb_input.customPrimitiveArray.aabbBuffers[0]),
+        reinterpret_cast<void *>(m_aabb_list_D),
         m_aabb_list_H.data(),
         m_aabb_list_H.size() * sizeof(OptixAabb),
         cudaMemcpyHostToDevice, m_state.stream));
 
-    m_accel_build_options.operation = OPTIX_BUILD_OPERATION_UPDATE; // set to update 
+    std::vector<uint32_t> aabb_input_flags(NUM_OPTICAL_ENTITY_TYPES);
+    for (int i = 0; i < NUM_OPTICAL_ENTITY_TYPES; i++)
+    {
+        aabb_input_flags[i] = OPTIX_GEOMETRY_FLAG_DISABLE_ANYHIT;
+    }
 
-    OPTIX_CHECK(optixAccelBuild(m_state.context,								  // OptiX context
-        m_state.stream,                                  // CUDA stream (default is 0)
-        &m_accel_build_options,
-        &m_aabb_input,
-        1,
-        m_temp_buffer,
-        m_temp_buffer_size,
-        m_output_buffer,
-        m_output_buffer_size,
-        &m_state.gas_handle,                             // Output handle for the GAS
-        nullptr,                                        // Emitted properties (not used here)
-        0));                                           // Number of emitted properties
+    m_aabb_input.customPrimitiveArray.flags = aabb_input_flags.data();
 
+    CUDA_CHECK(cudaMemcpyAsync(
+        reinterpret_cast<void *>(m_aabb_input.customPrimitiveArray.aabbBuffers[0]),
+        m_aabb_list_H.data(),
+        m_aabb_list_H.size() * sizeof(OptixAabb),
+        cudaMemcpyHostToDevice, m_state.stream));
 
-	compute_sun_plane_H(params);
+    m_accel_build_options.operation = OPTIX_BUILD_OPERATION_UPDATE; // set to update
+
+    OPTIX_CHECK(optixAccelBuild(m_state.context, // OptiX context
+                                m_state.stream,  // CUDA stream (default is 0)
+                                &m_accel_build_options,
+                                &m_aabb_input,
+                                1,
+                                m_temp_buffer,
+                                m_temp_buffer_size,
+                                m_output_buffer,
+                                m_output_buffer_size,
+                                &m_state.gas_handle, // Output handle for the GAS
+                                nullptr,             // Emitted properties (not used here)
+                                0));                 // Number of emitted properties
+
+    compute_sun_plane_H(params);
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
@@ -39,27 +39,14 @@ void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<Cs
 
         // Create an OptixAabb from the geometry data
         OptixAabb aabb;
-        float3 m_min;
-        float3 m_max;
         uint32_t sbt_offset = 0;
 
-        if (element->get_aperture_type() == ApertureType::CIRCLE)
-        {
-            m_min = make_float3(0.0f, 0.0f, 0.0f); // Initialize min to a large value
-            m_max = make_float3(0.0f, 0.0f, 0.0f); // Initialize max to a small value
-        }
+        // if (element->get_aperture_type() == ApertureType::CIRCLE)
+        // {
+        // }
 
         if (element->get_aperture_type() == ApertureType::RECTANGLE)
         {
-            element->compute_bounding_box();
-            m_min.x = (float)(element->get_lower_bounding_box()[0]);
-            m_min.y = (float)(element->get_lower_bounding_box()[1]);
-            m_min.z = (float)(element->get_lower_bounding_box()[2]);
-
-            m_max.x = (float)(element->get_upper_bounding_box()[0]);
-            m_max.y = (float)(element->get_upper_bounding_box()[1]);
-            m_max.z = (float)(element->get_upper_bounding_box()[2]);
-
             if (element->get_surface_type() == SurfaceType::PARABOLIC)
             {
                 sbt_offset = static_cast<uint32_t>(OpticalEntityType::RECTANGLE_PARABOLIC);
@@ -85,24 +72,21 @@ void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<Cs
 
         if (element->get_aperture_type() == ApertureType::TRIANGLE)
         {
-            element->compute_bounding_box();
-            m_min.x = (float)(element->get_lower_bounding_box()[0]);
-            m_min.y = (float)(element->get_lower_bounding_box()[1]);
-            m_min.z = (float)(element->get_lower_bounding_box()[2]);
-            m_max.x = (float)(element->get_upper_bounding_box()[0]);
-            m_max.y = (float)(element->get_upper_bounding_box()[1]);
-            m_max.z = (float)(element->get_upper_bounding_box()[2]);
-
             sbt_offset = static_cast<uint32_t>(OpticalEntityType::TRIANGLE_FLAT);
         }
 
-        aabb.minX = m_min.x;
-        aabb.minY = m_min.y;
-        aabb.minZ = m_min.z;
+        if (element->get_aperture_type() == ApertureType::QUADRILATERAL)
+        {
+            sbt_offset = static_cast<uint32_t>(OpticalEntityType::QUADRILATERAL_FLAT);
+        }
 
-        aabb.maxX = m_max.x;
-        aabb.maxY = m_max.y;
-        aabb.maxZ = m_max.z;
+        aabb.minX = (float)(element->get_lower_bounding_box()[0]);
+        aabb.minY = (float)(element->get_lower_bounding_box()[1]);
+        aabb.minZ = (float)(element->get_lower_bounding_box()[2]);
+
+        aabb.maxX = (float)(element->get_upper_bounding_box()[0]);
+        aabb.maxY = (float)(element->get_upper_bounding_box()[1]);
+        aabb.maxZ = (float)(element->get_upper_bounding_box()[2]);
 
         m_aabb_list_H[i] = aabb;       // Store the AABB in the list
         m_sbt_index_H[i] = sbt_offset; // Store the SBT index

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
@@ -72,12 +72,36 @@ void GeometryManager::collect_geometry_info(const std::vector<std::shared_ptr<Cs
 
         if (element->get_aperture_type() == ApertureType::TRIANGLE)
         {
-            sbt_offset = static_cast<uint32_t>(OpticalEntityType::TRIANGLE_FLAT);
+            if (element->get_surface_type() == SurfaceType::FLAT)
+            {
+                sbt_offset = static_cast<uint32_t>(OpticalEntityType::TRIANGLE_FLAT);
+            }
+            else
+            {
+                std::stringstream ss;
+                ss << "Unimplemented surface type ("
+                   << static_cast<int>(element->get_surface_type())
+                   << ") for triangle aperture ("
+                   << static_cast<int>(element->get_aperture_type());
+                throw std::runtime_error(ss.str());
+            }
         }
 
         if (element->get_aperture_type() == ApertureType::QUADRILATERAL)
         {
-            sbt_offset = static_cast<uint32_t>(OpticalEntityType::QUADRILATERAL_FLAT);
+            if (element->get_surface_type() == SurfaceType::FLAT)
+            {
+                sbt_offset = static_cast<uint32_t>(OpticalEntityType::QUADRILATERAL_FLAT);
+            }
+            else
+            {
+                std::stringstream ss;
+                ss << "Unimplemented surface type ("
+                   << static_cast<int>(element->get_surface_type())
+                   << ") for quadrilateral aperture ("
+                   << static_cast<int>(element->get_aperture_type());
+                throw std::runtime_error(ss.str());
+            }
         }
 
         aabb.minX = (float)(element->get_lower_bounding_box()[0]);

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
@@ -118,6 +118,8 @@ void GeometryManager::compute_sun_plane_H(LaunchParams &params)
                           sizeof(float),
                           cudaMemcpyDeviceToHost));
 
+    m_sun_plane_distance = fmaxf(m_sun_plane_distance * 2.0f, 10.0f);
+
     float3 sun_u, sun_v;
     float3 axis = (abs(sun_vector.x) < 0.9f) ? make_float3(1.0f, 0.0f, 0.0f) : make_float3(0.0f, 1.0f, 0.0f);
     sun_u = normalize(cross(axis, sun_vector));

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/geometry_manager.cpp
@@ -118,7 +118,10 @@ void GeometryManager::compute_sun_plane_H(LaunchParams &params)
                           sizeof(float),
                           cudaMemcpyDeviceToHost));
 
-    m_sun_plane_distance = fmaxf(m_sun_plane_distance * 2.0f, 10.0f);
+    // Place the sun plane just above the scene (1 world-unit margin) so that
+    // rays always travel at least tmin before reaching any element, without
+    // amplifying angular errors from sun shape perturbations.
+    m_sun_plane_distance = m_sun_plane_distance + 1.0f;
 
     float3 sun_u, sun_v;
     float3 axis = (abs(sun_vector.x) < 0.9f) ? make_float3(1.0f, 0.0f, 0.0f) : make_float3(0.0f, 1.0f, 0.0f);

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
@@ -1,19 +1,21 @@
+#include "pipeline_manager.h"
+
+#include <fstream>
+#include <map>
 #include <string>
 #include <vector>
+
 #include <cuda_runtime.h>
 #include <optix.h>
 #include <sampleConfig.h>
 #include <optix_stack_size.h>
 #include <optix_stubs.h>
+
 #include "utils/util_check.hpp"
 #include "shaders/Soltrace.h"
 
 #include "data_manager.h"
 #include "soltrace_state.h"
-#include "pipeline_manager.h"
-#include <fstream>
-#include <optix_stubs.h>
-
 
 using namespace OptixCSP;
 
@@ -21,11 +23,20 @@ char LOG[2048] = {};   // A mutable log buffer.
 size_t LOG_SIZE = sizeof(LOG);
 
 
-const char* intersectionFuncs[] = {
-    "__intersection__rectangle_parabolic",
-    "__intersection__rectangle_flat",
-    "__intersection__triangle_flat",
-    "__intersection__cylinder_y_capped"
+// const char* intersectionFuncs[] = {
+//     "__intersection__rectangle_parabolic",
+//     "__intersection__rectangle_flat",
+//     "__intersection__triangle_flat",
+//     // "__intersection__cylinder_y_capped"
+//     "__intersection_cylinder_y",
+// };
+
+const std::map<SurfaceApertureMap,std::string> IntersectionKernelMap = 
+{
+    {SurfaceApertureMap(ApertureType::RECTANGLE, SurfaceType::PARABOLIC), "__intersection__rectangle_parabolic"},
+    {SurfaceApertureMap(ApertureType::RECTANGLE, SurfaceType::FLAT), "__intersection__rectangle_flat"},
+    {SurfaceApertureMap(ApertureType::TRIANGLE, SurfaceType::FLAT), "__intersection__triangle_flat"},
+    {SurfaceApertureMap(ApertureType::RECTANGLE, SurfaceType::CYLINDER), "__intersection_cylinder_y"}
 };
 
 pipelineManager::pipelineManager(SoltraceState& state) : m_state(state) {}
@@ -228,19 +239,42 @@ void pipelineManager::createElementPrograms()
 {   
 
     // number of element programs
-	size_t numElementPrograms = sizeof(intersectionFuncs) / sizeof(intersectionFuncs[0]);
+	// size_t numElementPrograms = sizeof(intersectionFuncs) / sizeof(intersectionFuncs[0]);
 
-	for (size_t i = 0; i < numElementPrograms; i++) {
-		OptixProgramGroup group; 
+	// for (size_t i = 0; i < numElementPrograms; i++) {
+	// 	OptixProgramGroup group; 
+
+	// 	createHitGroupProgram(group,
+    //         			      m_state.geometry_module, 
+	// 			              intersectionFuncs[i],
+    //         			      m_state.shading_module,
+	// 			              "__closesthit__element");
+
+	// 	m_program_groups.push_back(group);
+	// }
+
+    size_t idx;
+    for (const auto& [surf_ap_key, kernel_name] : IntersectionKernelMap)
+    {
+        OptixProgramGroup group; 
 
 		createHitGroupProgram(group,
             			      m_state.geometry_module, 
-				              intersectionFuncs[i],
+				              kernel_name,
             			      m_state.shading_module,
 				              "__closesthit__element");
 
-		m_program_groups.push_back(group);
-	}   
+        idx = m_program_groups.size();
+        
+        auto sts = m_intersection_program_group_map.insert_or_assign(surf_ap_key, idx);
+        if (!sts.second)
+        {
+            // This should be impossible since we are iterating over a map
+            throw std::runtime_error("Duplicate surface aperture combination!");
+        }
+		
+        m_program_groups.push_back(group);
+    }
 
 }
 
@@ -285,25 +319,31 @@ OptixProgramGroup pipelineManager::getElementProgram(SurfaceApertureMap map) con
     // need to figure out a better way to arrange the table
 	// should be depenedent on intersection func array .... 
 
-    if (map.apertureType == ApertureType::RECTANGLE) {
-        if (map.surfaceType == SurfaceType::FLAT) {
-            //std::cout << "returning element program group 3, easy rectangle flat" << std::endl;
-            return m_program_groups[2];
-        }
+    // if (map.apertureType == ApertureType::RECTANGLE) {
+    //     if (map.surfaceType == SurfaceType::FLAT) {
+    //         //std::cout << "returning element program group 3, easy rectangle flat" << std::endl;
+    //         return m_program_groups[2];
+    //     }
 
-        else if (map.surfaceType == SurfaceType::PARABOLIC) {
-            //std::cout << "returning element program group 2, rectangle parabolic" << std::endl;
-            return m_program_groups[1];
-		}
-	else if (map.surfaceType == SurfaceType::CYLINDER) {
-	  return m_program_groups[4];
-	}
+    //     else if (map.surfaceType == SurfaceType::PARABOLIC) {
+    //         //std::cout << "returning element program group 2, rectangle parabolic" << std::endl;
+    //         return m_program_groups[1];
+	// 	}
+	// else if (map.surfaceType == SurfaceType::CYLINDER) {
+	//   return m_program_groups[4];
+	// }
 
-    }
-    else if (map.apertureType == ApertureType::TRIANGLE) {
-      if (map.surfaceType == SurfaceType::FLAT) {
-	return m_program_groups[3];
-      }
+    // }
+    // else if (map.apertureType == ApertureType::TRIANGLE) {
+    //   if (map.surfaceType == SurfaceType::FLAT) {
+	// return m_program_groups[3];
+    //   }
+    // }
+
+    auto iter = m_intersection_program_group_map.find(map);
+    if (iter != m_intersection_program_group_map.cend())
+    {
+        return m_program_groups[iter->second];
     }
     throw std::runtime_error("Unsupported surface or aperture type in getElementProgram");
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
@@ -33,10 +33,10 @@ size_t LOG_SIZE = sizeof(LOG);
 
 const std::map<SurfaceApertureMap,std::string> IntersectionKernelMap = 
 {
-    {SurfaceApertureMap(ApertureType::RECTANGLE, SurfaceType::PARABOLIC), "__intersection__rectangle_parabolic"},
-    {SurfaceApertureMap(ApertureType::RECTANGLE, SurfaceType::FLAT), "__intersection__rectangle_flat"},
-    {SurfaceApertureMap(ApertureType::TRIANGLE, SurfaceType::FLAT), "__intersection__triangle_flat"},
-    {SurfaceApertureMap(ApertureType::RECTANGLE, SurfaceType::CYLINDER), "__intersection_cylinder_y"}
+  {SurfaceApertureMap(SurfaceType::PARABOLIC, ApertureType::RECTANGLE), "__intersection__rectangle_parabolic"},
+  {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::RECTANGLE), "__intersection__rectangle_flat"},
+  {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::TRIANGLE), "__intersection__triangle_flat"},
+  {SurfaceApertureMap(SurfaceType::CYLINDER, ApertureType::RECTANGLE), "__intersection__cylinder_y"}
 };
 
 pipelineManager::pipelineManager(SoltraceState& state) : m_state(state) {}
@@ -260,11 +260,16 @@ void pipelineManager::createElementPrograms()
 
 		createHitGroupProgram(group,
             			      m_state.geometry_module, 
-				              kernel_name,
+				      kernel_name.c_str(),
             			      m_state.shading_module,
 				              "__closesthit__element");
 
         idx = m_program_groups.size();
+
+	// std::cout << "Key: " << surf_ap_key
+	// 	  << " Kernel: " << kernel_name
+	// 	  << " Program Group Index: " << idx
+	// 	  << std::endl;
         
         auto sts = m_intersection_program_group_map.insert_or_assign(surf_ap_key, idx);
         if (!sts.second)

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
@@ -19,9 +19,8 @@
 
 using namespace OptixCSP;
 
-char LOG[2048] = {};   // A mutable log buffer.
+char LOG[2048] = {}; // A mutable log buffer.
 size_t LOG_SIZE = sizeof(LOG);
-
 
 // const char* intersectionFuncs[] = {
 //     "__intersection__rectangle_parabolic",
@@ -31,37 +30,37 @@ size_t LOG_SIZE = sizeof(LOG);
 //     "__intersection_cylinder_y",
 // };
 
-const std::map<SurfaceApertureMap,std::string> IntersectionKernelMap = 
+const std::map<SurfaceApertureMap, std::string> IntersectionKernelMap = {
+    {SurfaceApertureMap(SurfaceType::PARABOLIC, ApertureType::RECTANGLE), "__intersection__rectangle_parabolic"},
+    {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::RECTANGLE), "__intersection__rectangle_flat"},
+    {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::TRIANGLE), "__intersection__triangle_flat"},
+    {SurfaceApertureMap(SurfaceType::CYLINDER, ApertureType::RECTANGLE), "__intersection__cylinder_y"}};
+
+pipelineManager::pipelineManager(SoltraceState &state) : m_state(state) {}
+
+pipelineManager::~pipelineManager()
 {
-  {SurfaceApertureMap(SurfaceType::PARABOLIC, ApertureType::RECTANGLE), "__intersection__rectangle_parabolic"},
-  {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::RECTANGLE), "__intersection__rectangle_flat"},
-  {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::TRIANGLE), "__intersection__triangle_flat"},
-  {SurfaceApertureMap(SurfaceType::CYLINDER, ApertureType::RECTANGLE), "__intersection__cylinder_y"}
-};
-
-pipelineManager::pipelineManager(SoltraceState& state) : m_state(state) {}
-
-
-pipelineManager::~pipelineManager() {
-	//cleanup();
+    // cleanup();
 }
 
-void pipelineManager::cleanup() {
+void pipelineManager::cleanup()
+{
 
     OPTIX_CHECK(optixPipelineDestroy(m_state.pipeline));
 
-    // destroy all program groups 
-    for (auto& prog_group : m_program_groups) {
+    // destroy all program groups
+    for (auto &prog_group : m_program_groups)
+    {
         OPTIX_CHECK(optixProgramGroupDestroy(prog_group));
     }
 
     OPTIX_CHECK(optixModuleDestroy(m_state.geometry_module));
     OPTIX_CHECK(optixModuleDestroy(m_state.shading_module));
     OPTIX_CHECK(optixModuleDestroy(m_state.sun_module));
-
 }
 
-std::string pipelineManager::loadPtxFromFile(const std::string& kernelName) {
+std::string pipelineManager::loadPtxFromFile(const std::string &kernelName)
+{
     std::string ptxFile = std::string(SAMPLES_PTX_DIR) + "/" + kernelName + ".ptx";
     std::ifstream file(ptxFile);
     if (!file.good())
@@ -71,7 +70,8 @@ std::string pipelineManager::loadPtxFromFile(const std::string& kernelName) {
     return buffer.str();
 }
 
-void pipelineManager::loadModules() {
+void pipelineManager::loadModules()
+{
     OptixModuleCompileOptions moduleCompileOptions = {};
 #if !defined(NDEBUG)
     moduleCompileOptions.optLevel = OPTIX_COMPILE_OPTIMIZATION_LEVEL_0;
@@ -119,12 +119,12 @@ void pipelineManager::loadModules() {
 void pipelineManager::createPipeline()
 {
     m_state.pipeline_compile_options = {
-        false,                                                  // usesMotionBlur: Disable motion blur.
-        OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS,          // traversableGraphFlags: Allow only a single GAS.
-        2,    /* RadiancePRD uses 5 payloads */                 // numPayloadValues
-        5,    /* Parallelogram intersection uses 5 attrs */     // numAttributeValues 
-        OPTIX_EXCEPTION_FLAG_NONE,                              // exceptionFlags
-        "params"                                                // pipelineLaunchParamsVariableName
+        false,                                           // usesMotionBlur: Disable motion blur.
+        OPTIX_TRAVERSABLE_GRAPH_FLAG_ALLOW_SINGLE_GAS,   // traversableGraphFlags: Allow only a single GAS.
+        2, /* RadiancePRD uses 5 payloads */             // numPayloadValues
+        5, /* Parallelogram intersection uses 5 attrs */ // numAttributeValues
+        OPTIX_EXCEPTION_FLAG_NONE,                       // exceptionFlags
+        "params"                                         // pipelineLaunchParamsVariableName
     };
 
     // Prepare modules and program groups
@@ -135,23 +135,23 @@ void pipelineManager::createPipeline()
 
     // Link program groups to pipeline
     OptixPipelineLinkOptions pipeline_link_options = {};
-    // TODO max trace belong to who? 
+    // TODO max trace belong to who?
     pipeline_link_options.maxTraceDepth = MAX_TRACE_DEPTH; // Maximum recursion depth for ray tracing.
 
     // Create the OptiX pipeline by linking the program groups.
     OPTIX_CHECK(optixPipelineCreate(
-        m_state.context,                        // OptiX context.
-        &m_state.pipeline_compile_options,      // Compile options for the pipeline.
-        &pipeline_link_options,               // Link options for the pipeline.
-        m_program_groups.data(),                // Array of program groups.
+        m_state.context,                                    // OptiX context.
+        &m_state.pipeline_compile_options,                  // Compile options for the pipeline.
+        &pipeline_link_options,                             // Link options for the pipeline.
+        m_program_groups.data(),                            // Array of program groups.
         static_cast<unsigned int>(m_program_groups.size()), // Number of program groups.
-        LOG, &LOG_SIZE,                       // Logs for diagnostics.
-        &m_state.pipeline                       // Output: Handle for the created pipeline.
-    ));
+        LOG, &LOG_SIZE,                                     // Logs for diagnostics.
+        &m_state.pipeline                                   // Output: Handle for the created pipeline.
+        ));
 
     // Compute and configure the stack sizes for the pipeline.
     OptixStackSizes stack_sizes = {};
-    for (auto& prog_group : m_program_groups)
+    for (auto &prog_group : m_program_groups)
     {
         OPTIX_CHECK(optixUtilAccumulateStackSizes(prog_group, &stack_sizes, m_state.pipeline));
     }
@@ -162,31 +162,33 @@ void pipelineManager::createPipeline()
 
     // Compute stack sizes based on the maximum trace depth and other settings.
     OPTIX_CHECK(optixUtilComputeStackSizes(
-        &stack_sizes,                      // Input stack sizes.
-        MAX_TRACE_DEPTH,                         // Maximum trace depth.
-        0,                                 // maxCCDepth: Maximum depth of continuation callables (none in this case).
-        0,                                 // maxDCDepth: Maximum depth of direct callables (none in this case).
+        &stack_sizes,                               // Input stack sizes.
+        MAX_TRACE_DEPTH,                            // Maximum trace depth.
+        0,                                          // maxCCDepth: Maximum depth of continuation callables (none in this case).
+        0,                                          // maxDCDepth: Maximum depth of direct callables (none in this case).
         &direct_callable_stack_size_from_traversal, // Output: Stack size for callable traversal.
         &direct_callable_stack_size_from_state,     // Output: Stack size for callable state.
         &continuation_stack_size                    // Output: Stack size for continuation stack.
-    ));
+        ));
     // Set the computed stack sizes for the pipeline.
     OPTIX_CHECK(optixPipelineSetStackSize(
-        m_state.pipeline,                               // Pipeline to configure.
-        direct_callable_stack_size_from_traversal,    // Stack size for direct callable traversal.
-        direct_callable_stack_size_from_state,        // Stack size for direct callable state.
-        continuation_stack_size,                      // Stack size for continuation stack.
-        1                                            // maxTraversableDepth: Maximum depth of traversable hierarchy.
-    ));
+        m_state.pipeline,                          // Pipeline to configure.
+        direct_callable_stack_size_from_traversal, // Stack size for direct callable traversal.
+        direct_callable_stack_size_from_state,     // Stack size for direct callable state.
+        continuation_stack_size,                   // Stack size for continuation stack.
+        1                                          // maxTraversableDepth: Maximum depth of traversable hierarchy.
+        ));
 }
 
-OptixPipeline pipelineManager::getPipeline() const {
-	return m_state.pipeline;
+OptixPipeline pipelineManager::getPipeline() const
+{
+    return m_state.pipeline;
 }
 
-void pipelineManager::createHitGroupProgram(OptixProgramGroup& group,
-    OptixModule intersectionModule, const char* intersectionFunc,
-    OptixModule closestHitModule, const char* closestHitFunc) {
+void pipelineManager::createHitGroupProgram(OptixProgramGroup &group,
+                                            OptixModule intersectionModule, const char *intersectionFunc,
+                                            OptixModule closestHitModule, const char *closestHitFunc)
+{
     OptixProgramGroupOptions options = {};
     OptixProgramGroupDesc desc = {};
     desc.kind = OPTIX_PROGRAM_GROUP_KIND_HITGROUP;
@@ -203,16 +205,15 @@ void pipelineManager::createHitGroupProgram(OptixProgramGroup& group,
         1,
         &options,
         LOG, &LOG_SIZE,
-        &group
-    ));
+        &group));
 }
 
-// TODO: simplify 
+// TODO: simplify
 void pipelineManager::createSunProgram()
 {
-    OptixProgramGroup           group;           // Handle for the sun program group.
-    OptixProgramGroupOptions    options = {};    // Options for the program group
-    OptixProgramGroupDesc       desc = {};       // Descriptor to define the program group.
+    OptixProgramGroup group;               // Handle for the sun program group.
+    OptixProgramGroupOptions options = {}; // Options for the program group
+    OptixProgramGroupDesc desc = {};       // Descriptor to define the program group.
 
     // Specify the kind of program group (Ray Generation).
     desc.kind = OPTIX_PROGRAM_GROUP_KIND_RAYGEN;
@@ -222,13 +223,13 @@ void pipelineManager::createSunProgram()
 
     // Create the program group
     OPTIX_CHECK_LOG(optixProgramGroupCreate(
-        m_state.context,                 // OptiX context.
-        &desc,          // Descriptor defining the program group.
-        1,                             // Number of program groups to create (1 in this case).
-        &options,       // Options for the program group.
-        LOG, &LOG_SIZE,                // Logs to capture diagnostic information.
-        &group                // Output: Handle for the created program group.
-    ));
+        m_state.context, // OptiX context.
+        &desc,           // Descriptor defining the program group.
+        1,               // Number of program groups to create (1 in this case).
+        &options,        // Options for the program group.
+        LOG, &LOG_SIZE,  // Logs to capture diagnostic information.
+        &group           // Output: Handle for the created program group.
+        ));
 
     m_program_groups.push_back(group);
     m_state.raygen_prog_group = group;
@@ -236,59 +237,60 @@ void pipelineManager::createSunProgram()
 
 // Create program group for handling rays interacting with elements.
 void pipelineManager::createElementPrograms()
-{   
+{
 
     // number of element programs
-	// size_t numElementPrograms = sizeof(intersectionFuncs) / sizeof(intersectionFuncs[0]);
+    // size_t numElementPrograms = sizeof(intersectionFuncs) / sizeof(intersectionFuncs[0]);
 
-	// for (size_t i = 0; i < numElementPrograms; i++) {
-	// 	OptixProgramGroup group; 
+    // for (size_t i = 0; i < numElementPrograms; i++) {
+    // 	OptixProgramGroup group;
 
-	// 	createHitGroupProgram(group,
-    //         			      m_state.geometry_module, 
-	// 			              intersectionFuncs[i],
+    // 	createHitGroupProgram(group,
+    //         			      m_state.geometry_module,
+    // 			              intersectionFuncs[i],
     //         			      m_state.shading_module,
-	// 			              "__closesthit__element");
+    // 			              "__closesthit__element");
 
-	// 	m_program_groups.push_back(group);
-	// }
+    // 	m_program_groups.push_back(group);
+    // }
 
+    m_intersection_program_group_map.clear();
     size_t idx;
-    for (const auto& [surf_ap_key, kernel_name] : IntersectionKernelMap)
+    for (const auto &[surf_ap_key, kernel_name] : IntersectionKernelMap)
     {
-        OptixProgramGroup group; 
+        OptixProgramGroup group;
 
-		createHitGroupProgram(group,
-            			      m_state.geometry_module, 
-				      kernel_name.c_str(),
-            			      m_state.shading_module,
-				              "__closesthit__element");
+        createHitGroupProgram(group,
+                              m_state.geometry_module,
+                              kernel_name.c_str(),
+                              m_state.shading_module,
+                              "__closesthit__element");
 
         idx = m_program_groups.size();
 
-	// std::cout << "Key: " << surf_ap_key
-	// 	  << " Kernel: " << kernel_name
-	// 	  << " Program Group Index: " << idx
-	// 	  << std::endl;
-        
+        // std::cout << "Key: " << surf_ap_key
+        // 	  << " Kernel: " << kernel_name
+        // 	  << " Program Group Index: " << idx
+        // 	  << std::endl;
+
         auto sts = m_intersection_program_group_map.insert_or_assign(surf_ap_key, idx);
         if (!sts.second)
         {
-            // This should be impossible since we are iterating over a map
-            throw std::runtime_error("Duplicate surface aperture combination!");
+            // This should be impossible since we are iterating over a map with the same
+            // key as we are inserting here.
+            throw std::runtime_error("Duplicate surface-aperture combination!");
         }
-		
+
         m_program_groups.push_back(group);
     }
-
 }
 
 // Create program group for handling rays that miss all geometry.
 void pipelineManager::createMissProgram()
 {
-    OptixProgramGroup           group;       // Handle for the miss program group.
-    OptixProgramGroupOptions    options = {};   // Options for the program group (none needed).
-    OptixProgramGroupDesc       desc = {};      // Descriptor for the program group.
+    OptixProgramGroup group;               // Handle for the miss program group.
+    OptixProgramGroupOptions options = {}; // Options for the program group (none needed).
+    OptixProgramGroupDesc desc = {};       // Descriptor for the program group.
 
     // Specify the kind of program group (Miss Program for handling missed rays).
     desc.kind = OPTIX_PROGRAM_GROUP_KIND_MISS;
@@ -308,43 +310,16 @@ void pipelineManager::createMissProgram()
     m_program_groups.push_back(group);
     m_state.radiance_miss_prog_group = group;
 
-// now let's print out program groups address 
-	for (int i = 0; i < m_program_groups.size(); i++) {
-		OptixProgramGroup group = m_program_groups[i];
-		std::cout << "Program group " << i << " address: " << group << ", kind: " << desc.kind << std::endl;
-	}   
-
-
+    // now let's print out program groups address
+    for (int i = 0; i < m_program_groups.size(); i++)
+    {
+        OptixProgramGroup group = m_program_groups[i];
+        std::cout << "Program group " << i << " address: " << group << ", kind: " << desc.kind << std::endl;
+    }
 }
 
-
-OptixProgramGroup pipelineManager::getElementProgram(SurfaceApertureMap map) const {
-    // TODO this part is still hard coded ... 
-	// squence are raygen, then heliostat, then receiver, then miss
-    // need to figure out a better way to arrange the table
-	// should be depenedent on intersection func array .... 
-
-    // if (map.apertureType == ApertureType::RECTANGLE) {
-    //     if (map.surfaceType == SurfaceType::FLAT) {
-    //         //std::cout << "returning element program group 3, easy rectangle flat" << std::endl;
-    //         return m_program_groups[2];
-    //     }
-
-    //     else if (map.surfaceType == SurfaceType::PARABOLIC) {
-    //         //std::cout << "returning element program group 2, rectangle parabolic" << std::endl;
-    //         return m_program_groups[1];
-	// 	}
-	// else if (map.surfaceType == SurfaceType::CYLINDER) {
-	//   return m_program_groups[4];
-	// }
-
-    // }
-    // else if (map.apertureType == ApertureType::TRIANGLE) {
-    //   if (map.surfaceType == SurfaceType::FLAT) {
-	// return m_program_groups[3];
-    //   }
-    // }
-
+OptixProgramGroup pipelineManager::getElementProgram(SurfaceApertureMap map) const
+{
     auto iter = m_intersection_program_group_map.find(map);
     if (iter != m_intersection_program_group_map.cend())
     {

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
@@ -30,11 +30,19 @@ size_t LOG_SIZE = sizeof(LOG);
 //     "__intersection_cylinder_y",
 // };
 
-const std::map<SurfaceApertureMap, std::string> IntersectionKernelMap = {
-    {SurfaceApertureMap(SurfaceType::PARABOLIC, ApertureType::RECTANGLE), "__intersection__rectangle_parabolic"},
-    {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::RECTANGLE), "__intersection__rectangle_flat"},
-    {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::TRIANGLE), "__intersection__triangle_flat"},
-    {SurfaceApertureMap(SurfaceType::CYLINDER, ApertureType::RECTANGLE), "__intersection__cylinder_y"}};
+// const std::map<SurfaceApertureMap, std::string> IntersectionKernelMap = {
+//     {SurfaceApertureMap(SurfaceType::PARABOLIC, ApertureType::RECTANGLE), "__intersection__rectangle_parabolic"},
+//     {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::RECTANGLE), "__intersection__rectangle_flat"},
+//     {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::TRIANGLE), "__intersection__triangle_flat"},
+//     {SurfaceApertureMap(SurfaceType::CYLINDER, ApertureType::RECTANGLE), "__intersection__cylinder_y"},
+//     {SurfaceApertureMap(SurfaceType::FLAT, ApertureType::QUADRILATERAL), "__intersection__flat_quadrilateral"}};
+
+const std::map<OpticalEntityType, std::string> IntersectionKernelMap = {
+    {OpticalEntityType::RECTANGLE_PARABOLIC, "__intersection__rectangle_parabolic"},
+    {OpticalEntityType::RECTANGLE_FLAT, "__intersection__rectangle_flat"},
+    {OpticalEntityType::TRIANGLE_FLAT, "__intersection__triangle_flat"},
+    {OpticalEntityType::CYLINDRICAL, "__intersection__cylinder_y"},
+    {OpticalEntityType::QUADRILATERAL_FLAT, "__intersection__flat_quadrilateral"}};
 
 pipelineManager::pipelineManager(SoltraceState &state) : m_state(state) {}
 
@@ -318,7 +326,7 @@ void pipelineManager::createMissProgram()
     }
 }
 
-OptixProgramGroup pipelineManager::getElementProgram(SurfaceApertureMap map) const
+OptixProgramGroup pipelineManager::getElementProgram(OpticalEntityType map) const
 {
     auto iter = m_intersection_program_group_map.find(map);
     if (iter != m_intersection_program_group_map.cend())

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.cpp
@@ -42,7 +42,7 @@ const std::map<OpticalEntityType, std::string> IntersectionKernelMap = {
     {OpticalEntityType::RECTANGLE_FLAT, "__intersection__rectangle_flat"},
     {OpticalEntityType::TRIANGLE_FLAT, "__intersection__triangle_flat"},
     {OpticalEntityType::CYLINDRICAL, "__intersection__cylinder_y"},
-    {OpticalEntityType::QUADRILATERAL_FLAT, "__intersection__flat_quadrilateral"}};
+    {OpticalEntityType::QUADRILATERAL_FLAT, "__intersection__quadrilateral_flat"}};
 
 pipelineManager::pipelineManager(SoltraceState &state) : m_state(state) {}
 
@@ -264,7 +264,7 @@ void pipelineManager::createElementPrograms()
 
     m_intersection_program_group_map.clear();
     size_t idx;
-    for (const auto &[surf_ap_key, kernel_name] : IntersectionKernelMap)
+    for (const auto &[optype, kernel_name] : IntersectionKernelMap)
     {
         OptixProgramGroup group;
 
@@ -276,17 +276,17 @@ void pipelineManager::createElementPrograms()
 
         idx = m_program_groups.size();
 
-        // std::cout << "Key: " << surf_ap_key
+        // std::cout << "Key: " << optype
         // 	  << " Kernel: " << kernel_name
         // 	  << " Program Group Index: " << idx
         // 	  << std::endl;
 
-        auto sts = m_intersection_program_group_map.insert_or_assign(surf_ap_key, idx);
+        auto sts = m_intersection_program_group_map.insert_or_assign(optype, idx);
         if (!sts.second)
         {
             // This should be impossible since we are iterating over a map with the same
             // key as we are inserting here.
-            throw std::runtime_error("Duplicate surface-aperture combination!");
+            throw std::runtime_error("Duplicate optical entity!");
         }
 
         m_program_groups.push_back(group);

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
@@ -86,24 +86,24 @@ namespace OptixCSP {
             OptixModule closestHitModule,
             const char* closestHitFunc);
 
-        /**
-         * @brief Retrieves the ray generation program group.
-         * @return The OptixProgramGroup for ray generation.
-         */
-        OptixProgramGroup getRaygenProgram() const;
+        // /**
+        //  * @brief Retrieves the ray generation program group.
+        //  * @return The OptixProgramGroup for ray generation.
+        //  */
+        // OptixProgramGroup getRaygenProgram() const;
 
-        /**
-         * @brief Retrieves the miss program group.
-         * @return The OptixProgramGroup for the miss shader.
-         */
-        OptixProgramGroup getMissProgram() const;
+        // /**
+        //  * @brief Retrieves the miss program group.
+        //  * @return The OptixProgramGroup for the miss shader.
+        //  */
+        // OptixProgramGroup getMissProgram() const;
 
         /**
          * @brief Retrieves the appropriate element program group based on surface and aperture type.
          * @param map SurfaceApertureMap specifying the surface and aperture combination.
          * @return The corresponding OptixProgramGroup.
          */
-        OptixProgramGroup getElementProgram(SurfaceApertureMap map) const;
+        OptixProgramGroup getElementProgram(OpticalEntityType map) const;
 
     private:
         SoltraceState& m_state;  ///< Reference to the simulation's OptiX state.

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
@@ -7,20 +7,20 @@
 #include "soltrace_type.h"
 #include "soltrace_state.h"
 
-
-
-namespace OptixCSP {
+namespace OptixCSP
+{
     /**
      * @class pipelineManager
      * @brief Manages the OptiX pipeline, including loading modules, creating programs, and handling cleanup.
      */
-    class pipelineManager {
+    class pipelineManager
+    {
     public:
         /**
          * @brief Constructs a pipelineManager instance.
          * @param state Reference to SoltraceState for managing OptiX state.
          */
-        pipelineManager(SoltraceState& state);
+        pipelineManager(SoltraceState &state);
 
         /**
          * @brief Destroys the pipelineManager and cleans up resources.
@@ -37,7 +37,7 @@ namespace OptixCSP {
          * @param kernelName The name of the PTX kernel file to load.
          * @return The loaded PTX code as a string.
          */
-        std::string loadPtxFromFile(const std::string& kernelName);
+        std::string loadPtxFromFile(const std::string &kernelName);
 
         /**
          * @brief Loads all required OptiX modules.
@@ -80,11 +80,11 @@ namespace OptixCSP {
          * @param closestHitModule OptiX module containing the closest hit function.
          * @param closestHitFunc Name of the closest hit function.
          */
-        void createHitGroupProgram(OptixProgramGroup& group,
-            OptixModule intersectionModule,
-            const char* intersectionFunc,
-            OptixModule closestHitModule,
-            const char* closestHitFunc);
+        void createHitGroupProgram(OptixProgramGroup &group,
+                                   OptixModule intersectionModule,
+                                   const char *intersectionFunc,
+                                   OptixModule closestHitModule,
+                                   const char *closestHitFunc);
 
         // /**
         //  * @brief Retrieves the ray generation program group.
@@ -100,14 +100,14 @@ namespace OptixCSP {
 
         /**
          * @brief Retrieves the appropriate element program group based on surface and aperture type.
-         * @param map SurfaceApertureMap specifying the surface and aperture combination.
+         * @param map OpticalEntityType specifying the surface and aperture combination.
          * @return The corresponding OptixProgramGroup.
          */
         OptixProgramGroup getElementProgram(OpticalEntityType map) const;
 
     private:
-        SoltraceState& m_state;  ///< Reference to the simulation's OptiX state.
-        std::vector<OptixProgramGroup> m_program_groups; ///< Stores all created OptiX program groups.
+        SoltraceState &m_state;                                               ///< Reference to the simulation's OptiX state.
+        std::vector<OptixProgramGroup> m_program_groups;                      ///< Stores all created OptiX program groups.
         std::map<OpticalEntityType, size_t> m_intersection_program_group_map; ///< Map surface-aperture combinations to index in m_program_groups
 
         // // Number of program groups categorized by type.

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
@@ -108,7 +108,7 @@ namespace OptixCSP {
     private:
         SoltraceState& m_state;  ///< Reference to the simulation's OptiX state.
         std::vector<OptixProgramGroup> m_program_groups; ///< Stores all created OptiX program groups.
-        std::map<SurfaceApertureMap, size_t> m_intersection_program_group_map; ///< Map surface-aperture combinations to index in m_program_groups
+        std::map<OpticalEntityType, size_t> m_intersection_program_group_map; ///< Map surface-aperture combinations to index in m_program_groups
 
         // // Number of program groups categorized by type.
         // int num_raygen_programs = 1; ///< Number of ray generation programs.

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/pipeline_manager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <map>
 #include <string>
 #include <vector>
 #include "optix.h"
@@ -107,10 +108,11 @@ namespace OptixCSP {
     private:
         SoltraceState& m_state;  ///< Reference to the simulation's OptiX state.
         std::vector<OptixProgramGroup> m_program_groups; ///< Stores all created OptiX program groups.
+        std::map<SurfaceApertureMap, size_t> m_intersection_program_group_map; ///< Map surface-aperture combinations to index in m_program_groups
 
-        // Number of program groups categorized by type.
-        int num_raygen_programs = 1; ///< Number of ray generation programs.
-        int num_heliostat_programs = 4; ///< Number of heliostat-related programs.
-        int num_miss_programs = 1; ///< Number of miss programs.
+        // // Number of program groups categorized by type.
+        // int num_raygen_programs = 1; ///< Number of ray generation programs.
+        // int num_heliostat_programs = 4; ///< Number of heliostat-related programs.
+        // int num_miss_programs = 1; ///< Number of miss programs.
     };
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_system.cpp
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_system.cpp
@@ -616,46 +616,56 @@ void SolTraceSystem::create_shader_binding_table()
 
             OptixCSP::OpticalEntityType my_type = static_cast<OptixCSP::OpticalEntityType>(i);
             // initialize program handle and data
-            OptixProgramGroup program_group_handle = nullptr;
-            SurfaceApertureMap map = {};
+            OptixProgramGroup program_group_handle = pipeline_manager->getElementProgram(my_type);
+            hitgroup_records_list[i].data.material_data = {0.875425, 0, 0, 0};
+            // OptixProgramGroup program_group_handle = nullptr;
+            // SurfaceApertureMap map = {};
 
-            switch (my_type)
-            {
-            case OptixCSP::OpticalEntityType::RECTANGLE_FLAT:
-                map = {SurfaceType::FLAT, ApertureType::RECTANGLE};
-                program_group_handle = pipeline_manager->getElementProgram(map);
-                hitgroup_records_list[i].data.material_data = {0.875425, 0, 0, 0};
-                printf("RECTANGLE_FLAT, program group address: %p \n", program_group_handle);
+            // switch (my_type)
+            // {
+            // case OptixCSP::OpticalEntityType::RECTANGLE_FLAT:
+            //     map = {SurfaceType::FLAT, ApertureType::RECTANGLE};
+            //     program_group_handle = pipeline_manager->getElementProgram(map);
+            //     hitgroup_records_list[i].data.material_data = {0.875425, 0, 0, 0};
+            //     printf("RECTANGLE_FLAT, program group address: %p \n", program_group_handle);
 
-                break;
+            //     break;
 
-            case OptixCSP::OpticalEntityType::RECTANGLE_PARABOLIC:
-                map = {SurfaceType::PARABOLIC, ApertureType::RECTANGLE};
-                program_group_handle = pipeline_manager->getElementProgram(map);
-                hitgroup_records_list[i].data.material_data = {0.875425, 0, 0, 0};
-                printf("RECTANGLE_PARABOLIC, program group address: %p \n", program_group_handle);
+            // case OptixCSP::OpticalEntityType::RECTANGLE_PARABOLIC:
+            //     map = {SurfaceType::PARABOLIC, ApertureType::RECTANGLE};
+            //     program_group_handle = pipeline_manager->getElementProgram(map);
+            //     hitgroup_records_list[i].data.material_data = {0.875425, 0, 0, 0};
+            //     printf("RECTANGLE_PARABOLIC, program group address: %p \n", program_group_handle);
 
-                break;
+            //     break;
 
-            case OptixCSP::OpticalEntityType::CYLINDRICAL:
-                map = {SurfaceType::CYLINDER, ApertureType::RECTANGLE};
-                program_group_handle = pipeline_manager->getElementProgram(map);
-                hitgroup_records_list[i].data.material_data = {0.95, 0, 0, 0};
-                printf("CYLINDRICAL, program group address: %p \n", program_group_handle);
+            // case OptixCSP::OpticalEntityType::CYLINDRICAL:
+            //     map = {SurfaceType::CYLINDER, ApertureType::RECTANGLE};
+            //     program_group_handle = pipeline_manager->getElementProgram(map);
+            //     hitgroup_records_list[i].data.material_data = {0.95, 0, 0, 0};
+            //     printf("CYLINDRICAL, program group address: %p \n", program_group_handle);
 
-                break;
+            //     break;
 
-            case OptixCSP::OpticalEntityType::TRIANGLE_FLAT:
-                map = {SurfaceType::FLAT, ApertureType::TRIANGLE};
-                program_group_handle = pipeline_manager->getElementProgram(map);
-                hitgroup_records_list[i].data.material_data = {0.95, 0, 0, 0};
-                printf("FLAT_TRIANGLE, program group address: %p \n", program_group_handle);
+            // case OptixCSP::OpticalEntityType::TRIANGLE_FLAT:
+            //     map = {SurfaceType::FLAT, ApertureType::TRIANGLE};
+            //     program_group_handle = pipeline_manager->getElementProgram(map);
+            //     hitgroup_records_list[i].data.material_data = {0.95, 0, 0, 0};
+            //     printf("FLAT_TRIANGLE, program group address: %p \n", program_group_handle);
 
-                break;
+            //     break;
 
-            default:
-                std::cerr << "Unknown OpticalEntityType: " << my_type << std::endl;
-            }
+            // case OptixCSP::OpticalEntityType::QUADRILATERAL_FLAT:
+            //     ma = {SurfaceType::FLAT, ApertureType::QUADRILATERAL};
+            //     program_group_handle = pipeline_manager->getElementProgram(map);
+            //     hitgroup_records_list[i].data.material_data = {0.875425, 0, 0, 0};
+            //     printf("FLAT_QUADRILATERAL, program group address: %p \n", program_group_handle);
+
+            //     break;
+
+            // default:
+            //     std::cerr << "Unknown OpticalEntityType: " << my_type << std::endl;
+            // }
 
             OPTIX_CHECK(optixSbtRecordPackHeader(program_group_handle, &hitgroup_records_list[i].header));
         }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
@@ -1,16 +1,18 @@
 #pragma once
 
-namespace OptixCSP {
+namespace OptixCSP
+{
 
-	enum class ApertureType {
+	enum class ApertureType
+	{
 		RECTANGLE,
 		CIRCLE,
 		TRIANGLE
 	};
 
-
 	// types for both scene building and pipeline assembly
-	enum class SurfaceType {
+	enum class SurfaceType
+	{
 		FLAT,
 		PARABOLIC,
 		MESH,
@@ -19,15 +21,21 @@ namespace OptixCSP {
 
 	// mapping of the surface type combined with the aperture type
 	// for lookup in the sbt mapping
-	struct SurfaceApertureMap {
+	struct SurfaceApertureMap
+	{
 		SurfaceType surfaceType;
 		ApertureType apertureType;
 
-		// TODO: might not need this, since i always compare 
-		// surface and aperture types separately .... 
-		bool operator==(SurfaceApertureMap& map) {
-			return (surfaceType == map.surfaceType) && (apertureType == map.apertureType);
+		SurfaceApertureMap(ApertureType ap, SurfaceType surf) : surfaceType(surf),
+																apertureType(ap)
+		{
 		}
 
+		// TODO: might not need this, since i always compare
+		// surface and aperture types separately ....
+		bool operator==(SurfaceApertureMap &map)
+		{
+			return (surfaceType == map.surfaceType) && (apertureType == map.apertureType);
+		}
 	};
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
@@ -41,7 +41,7 @@ namespace OptixCSP
 
 		// TODO: might not need this, since i always compare
 		// surface and aperture types separately ....
-		bool operator==(SurfaceApertureMap &map)
+		bool operator==(const SurfaceApertureMap &map) const
 		{
 			return (surfaceType == map.surfaceType) && (apertureType == map.apertureType);
 		}

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
@@ -9,7 +9,8 @@ namespace OptixCSP
 	{
 		RECTANGLE,
 		CIRCLE,
-		TRIANGLE
+		TRIANGLE,
+		QUADRILATERAL
 	};
 
 	// types for both scene building and pipeline assembly

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/core/soltrace_type.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <ostream>
+
 namespace OptixCSP
 {
 
@@ -26,7 +28,12 @@ namespace OptixCSP
 		SurfaceType surfaceType;
 		ApertureType apertureType;
 
-		SurfaceApertureMap(ApertureType ap, SurfaceType surf) : surfaceType(surf),
+	  SurfaceApertureMap() : surfaceType(SurfaceType::FLAT),
+		                 apertureType(ApertureType::RECTANGLE)
+	  {
+	  }
+
+          SurfaceApertureMap(SurfaceType surf, ApertureType ap) : surfaceType(surf),
 																apertureType(ap)
 		{
 		}
@@ -37,5 +44,20 @@ namespace OptixCSP
 		{
 			return (surfaceType == map.surfaceType) && (apertureType == map.apertureType);
 		}
+
+	  bool operator<(const SurfaceApertureMap &b) const
+	  {
+	    return surfaceType < b.surfaceType ||
+	      (surfaceType == b.surfaceType && apertureType < b.apertureType);
+	  }
+
+	  friend std::ostream& operator<<(std::ostream &os, const SurfaceApertureMap &sam);
 	};
+
+	inline std::ostream& operator<<(std::ostream &os, const SurfaceApertureMap &sam)
+	{
+	  os << "SurfApMap -- Surface: " << static_cast<int>(sam.surfaceType)
+	     << " Aperture: " << static_cast<int>(sam.apertureType);
+	  return os;
+	}
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/GeometryDataST.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/GeometryDataST.h
@@ -20,7 +20,8 @@ namespace OptixCSP {
             RECTANGLE_PARABOLIC = 2,
             UNKNOWN_TYPE = 3,
             RECTANGLE_FLAT = 4,
-			TRIANGLE_FLAT = 5
+			TRIANGLE_FLAT = 5,
+            QUADRILATERAL_FLAT = 6
         };
 
         struct Parallelogram
@@ -122,6 +123,20 @@ namespace OptixCSP {
             float  d;      // plane distance
         };
 
+        struct Quadrilateral_Flat{
+            Quadrilateral_Flat() = default;
+            Quadrilateral_Flat(const float3 &a, const float3 &b,
+                               const float3 &c, const float3 &d)
+                : p0(a), p1(b), p2(c), p3(d)
+            {
+                float3 e1 = p1 - p0;
+                float3 e2 = p3 - p0;
+                normal = normalize(cross(e1, e2));
+            }
+            float3 p0, p1, p2, p3; // Vertices in counterclockwise order
+            float3 normal; // Positive direction follows right-hand rule
+        };
+
         GeometryDataST() = default;
 
         void setParallelogram(const Parallelogram& p)
@@ -189,6 +204,19 @@ namespace OptixCSP {
             return triangle_flat;
 		}
 
+        void setQuadrilateral_Flat(const Quadrilateral_Flat &q)
+        {
+            assert(type == UNKNOWN_TYPE);
+            type = QUADRILATERAL_FLAT;
+            quadrilateral_flat = q;
+        }
+
+        __host__ __device__ const Quadrilateral_Flat& getQuadrilaterl_Flat() const
+        {
+            assert(type == QUADRILATERAL_FLAT);
+            return quadrilateral_flat;
+        }
+
 
         Type type = UNKNOWN_TYPE;
 
@@ -202,6 +230,7 @@ namespace OptixCSP {
             Rectangle_Parabolic rectangle_parabolic;
             Rectangle_Flat rectangle_flat;
 			Triangle_Flat triangle_flat;
+            Quadrilateral_Flat quadrilateral_flat;
         };
     };
 }

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/GeometryDataST.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/GeometryDataST.h
@@ -211,7 +211,7 @@ namespace OptixCSP {
             quadrilateral_flat = q;
         }
 
-        __host__ __device__ const Quadrilateral_Flat& getQuadrilaterl_Flat() const
+        __host__ __device__ const Quadrilateral_Flat& getQuadrilateral_Flat() const
         {
             assert(type == QUADRILATERAL_FLAT);
             return quadrilateral_flat;

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/Soltrace.h
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/Soltrace.h
@@ -30,6 +30,7 @@ namespace OptixCSP{
         RECTANGLE_PARABOLIC  = 1,
         CYLINDRICAL          = 2,
         TRIANGLE_FLAT        = 3,
+        QUADRILATERAL_FLAT   = 4,
 	    NUM_OPTICAL_ENTITY_TYPES
     };
 

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/intersection.cu
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/intersection.cu
@@ -462,7 +462,7 @@ extern "C" __device__ __inline__ float _triangle_intersect(
     // Backface culling + parallel rejection
     // (det must be strictly positive and not tiny)
     const float eps = 1e-8f;
-    if (det <= eps) return;
+    if (det <= eps) return -1.0f;
 
     const float inv_det = 1.0f / det;
 
@@ -550,7 +550,7 @@ extern "C" __global__ void __intersection__triangle_flat()
 
 extern "C" __global__ void __intersection__quadrilateral_flat()
 {
-    const OptixCSP::GeometryDataST::Quadrilateral_Flat& quad = params.geometry_data_array[optixGetPrimitiveIndex()].getQudrilateral_Flat();
+    const OptixCSP::GeometryDataST::Quadrilateral_Flat& quad = params.geometry_data_array[optixGetPrimitiveIndex()].getQuadrilateral_Flat();
 
     const float3 ro = optixGetObjectRayOrigin();
     const float3 rd = optixGetObjectRayDirection();

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/intersection.cu
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/intersection.cu
@@ -459,10 +459,16 @@ extern "C" __device__ __inline__ float _triangle_intersect(
     const float3 pvec = cross(rd, edge2);
     const float  det = dot(edge1, pvec);
 
-    // Backface culling + parallel rejection
-    // (det must be strictly positive and not tiny)
+    // // Backface culling + parallel rejection
+    // // (det must be strictly positive and not tiny)
+    // const float eps = 1e-8f;
+    // if (det <= eps) return -1.0f;
+
+    // Parallel rejection
+    // (det must be not tiny)
     const float eps = 1e-8f;
-    if (det <= eps) return -1.0f;
+    if (fabs(det) <= eps) return -1.0f;
+
 
     const float inv_det = 1.0f / det;
 

--- a/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/intersection.cu
+++ b/coretrace/simulation_runner/optix_runner/OptixCSP/src/shaders/intersection.cu
@@ -450,22 +450,12 @@ extern "C" __global__ void __intersection__rectangle_parabolic()
         __float_as_uint(world_normal.z));    
 }
 
-
-// intersection algorithm for a flat triangle based on "Fast, Minimum Storage Ray/Triangle Intersection" by Möller and Trumbore (1997)
+// intersection algorithm for a flat triangle based on "Fast, Minimum Storage Ray/Triangle Intersection" by Mï¿½ller and Trumbore (1997)
 // code from here: https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm 
-extern "C" __global__ void __intersection__triangle_flat()
+extern "C" __device__ __inline__ float _triangle_intersect(
+    float3 p0, float3 edge1, float3 edge2,
+    float3 ro, float3 rd)
 {
-	const OptixCSP::GeometryDataST::Triangle_Flat& tri = params.geometry_data_array[optixGetPrimitiveIndex()].getTriangle_Flat();
-
-    const float3 ro = optixGetObjectRayOrigin();
-    const float3 rd = optixGetObjectRayDirection();
-
-	//printf("Ray origin: (%f,%f,%f), direction: (%f,%f,%f)\n", ro.x, ro.y, ro.z, rd.x, rd.y, rd.z);
-
-    const float3 edge1 = tri.e1;
-    const float3 edge2 = tri.e2;
-
-
     const float3 pvec = cross(rd, edge2);
     const float  det = dot(edge1, pvec);
 
@@ -476,16 +466,76 @@ extern "C" __global__ void __intersection__triangle_flat()
 
     const float inv_det = 1.0f / det;
 
-    const float3 tvec = ro - tri.v0;
+    const float3 tvec = ro - p0;
     const float  u = dot(tvec, pvec) * inv_det;
-    if (u < 0.0f || u > 1.0f) return;
+    if (u < 0.0f || u > 1.0f) return -1.0f;
 
     const float3 qvec = cross(tvec, edge1);
     const float  v = dot(rd, qvec) * inv_det;
-    if (v < 0.0f || (u + v) > 1.0f) 
-        return;
+    if (v < 0.0f || (u + v) > 1.0f) return -1.0f;
 
     const float  t = dot(edge2, qvec) * inv_det;
+
+    return t;
+}
+
+// // intersection algorithm for a flat triangle based on "Fast, Minimum Storage Ray/Triangle Intersection" by Mï¿½ller and Trumbore (1997)
+// // code from here: https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm 
+// extern "C" __global__ void __intersection__triangle_flat()
+// {
+// 	const OptixCSP::GeometryDataST::Triangle_Flat& tri = params.geometry_data_array[optixGetPrimitiveIndex()].getTriangle_Flat();
+
+//     const float3 ro = optixGetObjectRayOrigin();
+//     const float3 rd = optixGetObjectRayDirection();
+
+// 	//printf("Ray origin: (%f,%f,%f), direction: (%f,%f,%f)\n", ro.x, ro.y, ro.z, rd.x, rd.y, rd.z);
+
+//     const float3 edge1 = tri.e1;
+//     const float3 edge2 = tri.e2;
+
+
+//     const float3 pvec = cross(rd, edge2);
+//     const float  det = dot(edge1, pvec);
+
+//     // Backface culling + parallel rejection
+//     // (det must be strictly positive and not tiny)
+//     const float eps = 1e-8f;
+//     if (det <= eps) return;
+
+//     const float inv_det = 1.0f / det;
+
+//     const float3 tvec = ro - tri.v0;
+//     const float  u = dot(tvec, pvec) * inv_det;
+//     if (u < 0.0f || u > 1.0f) return;
+
+//     const float3 qvec = cross(tvec, edge1);
+//     const float  v = dot(rd, qvec) * inv_det;
+//     if (v < 0.0f || (u + v) > 1.0f) 
+//         return;
+
+//     const float  t = dot(edge2, qvec) * inv_det;
+//     if (t < optixGetRayTmin() || t > optixGetRayTmax()) return;
+
+//     float3 world_normal = tri.normal;
+
+//     optixReportIntersection(t, 0,
+//         __float_as_uint(world_normal.x),
+//         __float_as_uint(world_normal.y),
+//         __float_as_uint(world_normal.z));
+
+// }
+
+// intersection algorithm for a flat triangle based on "Fast, Minimum Storage Ray/Triangle Intersection" by Mï¿½ller and Trumbore (1997)
+// code from here: https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm 
+extern "C" __global__ void __intersection__triangle_flat()
+{
+	const OptixCSP::GeometryDataST::Triangle_Flat& tri = params.geometry_data_array[optixGetPrimitiveIndex()].getTriangle_Flat();
+
+    const float3 ro = optixGetObjectRayOrigin();
+    const float3 rd = optixGetObjectRayDirection();
+
+    const float t = _triangle_intersect(tri.v0, tri.e1, tri.e2, ro, rd);
+
     if (t < optixGetRayTmin() || t > optixGetRayTmax()) return;
 
     float3 world_normal = tri.normal;
@@ -495,4 +545,36 @@ extern "C" __global__ void __intersection__triangle_flat()
         __float_as_uint(world_normal.y),
         __float_as_uint(world_normal.z));
 
+}
+
+
+extern "C" __global__ void __intersection__quadrilateral_flat()
+{
+    const OptixCSP::GeometryDataST::Quadrilateral_Flat& quad = params.geometry_data_array[optixGetPrimitiveIndex()].getQudrilateral_Flat();
+
+    const float3 ro = optixGetObjectRayOrigin();
+    const float3 rd = optixGetObjectRayDirection();
+
+    const float3 p0 = quad.p0;
+    const float3 p2 = quad.p2;
+    float3 e1 = quad.p1 - p0;
+    float3 e2 = quad.p3 - p0;
+
+    float t = _triangle_intersect(p0, e1, e2, ro, rd);
+
+    if (t < optixGetRayTmin() || t > optixGetRayTmax())
+    {
+        e1 = quad.p1 - p2;
+        e2 = quad.p3 - p2;
+        t = _triangle_intersect(p2, e1, e2, ro, rd);
+    }
+
+    if (t < optixGetRayTmin() || t > optixGetRayTmax()) return;
+
+    float3 world_normal = quad.normal;
+
+    optixReportIntersection(t, 0,
+        __float_as_uint(world_normal.x),
+        __float_as_uint(world_normal.y),
+        __float_as_uint(world_normal.z));
 }

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -163,7 +163,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 case SurfaceType::FLAT:
                 {
                     auto surface = std::make_shared<OptixCSP::SurfaceFlat>();
-                    assert(el_surface != nullptr);
+                    assert(surface != nullptr);
                     optix_el->set_surface(surface);
 
                     break;
@@ -243,6 +243,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                     OptixCSP::Vec3d p2 = ToVec3d(p_glob);
 
                     auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
+		    optix_el->set_aperture(aperture);
 
                     break;
                 }
@@ -267,6 +268,8 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                     OptixCSP::Vec3d p2 = ToVec3d(p_glob);
 
                     auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
+		    optix_el->set_aperture(aperture);
+
                     break;
                 }
 

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -225,7 +225,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 {
                     // Triangles in OptixRunner uses global coordinates of the 3 corner points
                     // so we convert everything to global coordinates here
-                    auto el_aperture = std::dynamic_pointer_cast<EqualateralTriangle>(el->get_aperture());
+                    auto el_aperture = std::dynamic_pointer_cast<EquilateralTriangle>(el->get_aperture());
                     assert(el_aperture != nullptr);
                     double r = 0.5 * el_aperture->circumscribe_diameter;
 

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -281,7 +281,8 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
 
             default:
                 // std::cerr << "Unsupported aperture type in OptixCSP" << std::endl;
-                throw std::runtime_error("Unsupported aperture type in OptixRunner") break;
+	      throw std::runtime_error("Unsupported aperture type in OptixRunner");
+	      break;
             }
 
             optix_el->update_euler_angles();

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -287,10 +287,9 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
             double xmin, xmax, ymin, ymax, zmin, zmax;
             el->get_aperture()->bounding_box(xmin, xmax, ymin, ymax);
             el->get_surface()->bounding_box(xmin, xmax, ymin, ymax, zmin, zmax);
-	    OptixCSP::Vec3d upper(xmax, ymax, zmax);
-	    OptixCSP::Vec3d lower(xmin, ymin, zmin);
-            optix_el->set_upper_bounding_box(upper);
-            optix_el->set_lower_bounding_box(lower);
+            OptixCSP::Vec3d upper(xmax, ymax, zmax);
+            OptixCSP::Vec3d lower(xmin, ymin, zmin);
+            optix_el->set_bounding_box_local(lower, upper);
 
             m_sys.add_element(optix_el);
 

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -121,7 +121,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 continue;
 
             auto optix_el = std::make_shared<OptixCSP::CspElement>();
-            optix_el->set_origin(ToVec3d(origin));
+            optix_el->set_origin(ToVec3d(el->get_origin_global()));
             optix_el->set_aim_point(ToVec3d(el->get_aim_vector_global()));
 
             // Safely narrow element id to int32_t
@@ -146,7 +146,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                                       opt_back->transmitivity, opt_back->slope_error, opt_back->specularity_error, od);
 
             std::cout << "adding elements " << el->get_name() << std::endl;
-            std::cout << "Origin: " << origin[0] << ", " << origin[1] << ", " << origin[2] << std::endl;
+            std::cout << "Origin: " << el->get_origin_global() << std::endl;
 
             if (el->get_surface() == nullptr)
             {
@@ -286,9 +286,9 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
 
             double xmin, xmax, ymin, ymax, zmin, zmax;
             el->get_aperture()->bounding_box(xmin, xmax, ymin, ymax);
-            el->get_surface()->bounding_box({xmin, xmax}, {ymin, ymax}, zmin, zmax);
-            Vec3d upper(xmax, ymax, zmax);
-            Vec3d lower(xmin, ymin, zmin);
+            el->get_surface()->bounding_box(xmin, xmax, ymin, ymax, zmin, zmax);
+	    OptixCSP::Vec3d upper(xmax, ymax, zmax);
+	    OptixCSP::Vec3d lower(xmin, ymin, zmin);
             optix_el->set_upper_bounding_box(upper);
             optix_el->set_lower_bounding_box(lower);
 

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -211,7 +211,8 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 break;
             }
             default:
-                std::cerr << "Unsupported surface type in OptixCSP" << std::endl;
+                // std::cerr << "Unsupported surface type in OptixCSP" << std::endl;
+                throw std::runtime_error("Unsupported surface type in OptixCSP");
                 break;
             }
 
@@ -224,10 +225,9 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
             {
 
                 auto el_aperture = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
-
+                assert(el_aperture != nullptr);
                 // TODO: account for x and y coord?
                 auto aperture = std::make_shared<OptixCSP::ApertureRectangle>(el_aperture->x_length, el_aperture->y_length);
-                assert(el_aperture != nullptr);
                 optix_el->set_aperture(aperture);
                 break;
             }
@@ -280,11 +280,11 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
             }
 
             default:
-                std::cerr << "Unsupported aperture type in OptixCSP" << std::endl;
-                break;
+                // std::cerr << "Unsupported aperture type in OptixCSP" << std::endl;
+                throw std::runtime_error("Unsupported aperture type in OptixRunner") break;
             }
 
-	    optix_el->update_euler_angles();
+            optix_el->update_euler_angles();
 
             double xmin, xmax, ymin, ymax, zmin, zmax;
             el->get_aperture()->bounding_box(xmin, xmax, ymin, ymax);
@@ -293,8 +293,8 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
             OptixCSP::Vec3d lower(xmin, ymin, zmin);
             optix_el->set_bounding_box_local(lower, upper);
 
-	    std::cout << "Bounding Box Upper: " << optix_el->get_upper_bounding_box() << std::endl;
-	    std::cout << "Bounding Box Lower: " << optix_el->get_lower_bounding_box() << std::endl;
+            std::cout << "Bounding Box Upper: " << optix_el->get_upper_bounding_box() << std::endl;
+            std::cout << "Bounding Box Lower: " << optix_el->get_lower_bounding_box() << std::endl;
 
             m_sys.add_element(optix_el);
 

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -64,13 +64,9 @@ RunnerStatus OptixRunner::setup_parameters(const SimulationData *data)
     m_sys.set_number_of_rays(sim_params.number_of_rays, sim_params.max_number_of_rays);
     m_sys.set_seed(static_cast<uint64_t>(sim_params.seed));
 
-    m_sys.set_optical_errors(sim_params.include_optical_errors);   
+    m_sys.set_optical_errors(sim_params.include_optical_errors);
     m_sys.set_sun_shape_errors(sim_params.include_sun_shape_errors);
 
-    //this->tsys.sim_errors_optical = sim_params.include_optical_errors;
-    //this->tsys.sim_raycount = sim_params.number_of_rays;
-    //this->tsys.sim_raymax = sim_params.max_number_of_rays;
-    //this->tsys.seed = sim_params.seed;
     return RunnerStatus::SUCCESS;
 }
 
@@ -125,8 +121,6 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 continue;
 
             auto optix_el = std::make_shared<OptixCSP::CspElement>();
-            Vector3d origin = el->get_origin_global();
-            OptixCSP::Vec3d origin_vec(origin[0], origin[1], origin[2]);
             optix_el->set_origin(ToVec3d(origin));
             optix_el->set_aim_point(ToVec3d(el->get_aim_vector_global()));
 
@@ -154,132 +148,152 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
             std::cout << "adding elements " << el->get_name() << std::endl;
             std::cout << "Origin: " << origin[0] << ", " << origin[1] << ", " << origin[2] << std::endl;
 
-            if (el->get_surface() != nullptr)
+            if (el->get_surface() == nullptr)
             {
-                std::cout << "surface type: " << el->get_surface()->get_type() << std::endl;
-
-                switch (el->get_surface()->get_type())
-                {
-                case SurfaceType::FLAT:
-                {
-                    auto surface = std::make_shared<OptixCSP::SurfaceFlat>();
-                    assert(surface != nullptr);
-                    optix_el->set_surface(surface);
-
-                    break;
-                }
-                case SurfaceType::PARABOLA:
-                {
-                    auto el_surface = std::dynamic_pointer_cast<Parabola>(el->get_surface());
-                    assert(el_surface != nullptr);
-                    double fx = el_surface->focal_length_x;
-                    double fy = el_surface->focal_length_y;
-
-                    double cx = 1. / (2. * fx);
-                    double cy = 1. / (2. * fy);
-
-                    auto optix_surface = std::make_shared<OptixCSP::SurfaceParabolic>();
-                    optix_surface->set_curvature(cx, cy);
-                    optix_el->set_surface(optix_surface);
-
-                    break;
-                }
-                case SurfaceType::CYLINDER:
-                {
-                    auto el_surface = std::dynamic_pointer_cast<Cylinder>(el->get_surface());
-                    assert(el_surface != nullptr);
-                    auto el_aperture = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
-                    assert(el_aperture != nullptr);
-
-                    auto surface = std::make_shared<OptixCSP::SurfaceCylinder>();
-                    // surface->set_half_height(2.); // TODO this needs to come from the aperture
-                    surface->set_half_height(0.5 * el_aperture->y_length);
-                    surface->set_radius(el_surface->radius);
-                    optix_el->set_surface(surface);
-
-                    break;
-                }
-                default:
-                    std::cerr << "Unsupported surface type in OptixCSP" << std::endl;
-                    break;
-                }
-
-                auto soltrace_aperture_type = el->get_aperture()->get_type();
-
-                switch (soltrace_aperture_type)
-                {
-
-                case ApertureType::RECTANGLE:
-                {
-
-                    auto el_aperture = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
-
-                    // TODO: account for x and y coord?
-                    auto aperture = std::make_shared<OptixCSP::ApertureRectangle>(el_aperture->x_length, el_aperture->y_length);
-                    assert(el_aperture != nullptr);
-                    optix_el->set_aperture(aperture);
-                    break;
-                }
-
-                case ApertureType::EQUILATERAL_TRIANGLE:
-                {
-                    // Triangles in OptixRunner uses global coordinates of the 3 corner points
-                    // so we convert everything to global coordinates here
-                    auto el_aperture = std::dynamic_pointer_cast<EquilateralTriangle>(el->get_aperture());
-                    assert(el_aperture != nullptr);
-                    double r = 0.5 * el_aperture->circumscribe_diameter;
-
-                    Vector3d p_loc(-sqrt(0.75) * r, 0.5 * r, 0.0);
-                    Vector3d p_glob;
-                    el->convert_local_to_global(p_glob, p_loc);
-                    OptixCSP::Vec3d p0 = ToVec3d(p_glob);
-                    
-                    p_loc.set_values(sqrt(0.75) * r, 0.5 * r, 0.0);
-                    el->convert_local_to_global(p_glob, p_loc);
-                    OptixCSP::Vec3d p1 = ToVec3d(p_glob);
-
-                    p_loc.set_values(0.0, r, 0.0);
-                    el->convert_local_to_global(p_glob, p_loc);
-                    OptixCSP::Vec3d p2 = ToVec3d(p_glob);
-
-                    auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
-		    optix_el->set_aperture(aperture);
-
-                    break;
-                }
-                case ApertureType::IRREGULAR_TRIANGLE:
-                {
-                    // Triangles in OptixRunner uses global coordinates of the 3 corner points
-                    // so we convert everything to global coordinates here
-                    auto el_aperture = std::dynamic_pointer_cast<IrregularTriangle>(el->get_aperture());
-                    assert(el_aperture != nullptr);
-                    
-                    Vector3d p_loc(el_aperture->x1, el_aperture->y1, 0.0);
-                    Vector3d p_glob;
-                    el->convert_local_to_global(p_glob, p_loc);
-                    OptixCSP::Vec3d p0 = ToVec3d(p_glob);
-                    
-                    p_loc.set_values(el_aperture->x2, el_aperture->y2, 0.0);
-                    el->convert_local_to_global(p_glob, p_loc);
-                    OptixCSP::Vec3d p1 = ToVec3d(p_glob);
-
-                    p_loc.set_values(el_aperture->x3, el_aperture->y3, 0.0);
-                    el->convert_local_to_global(p_glob, p_loc);
-                    OptixCSP::Vec3d p2 = ToVec3d(p_glob);
-
-                    auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
-		    optix_el->set_aperture(aperture);
-
-                    break;
-                }
-
-                default:
-                    std::cerr << "Unsupported aperture type in OptixCSP" << std::endl;
-                    break;
-                }
-
-                m_sys.add_element(optix_el);
+                throw std::runtime_error("Element must be assigned a surface.");
             }
+
+            if (el->get_aperture() == nullptr)
+            {
+                throw std::runtime_error("Element must be assigned an aperture.");
+            }
+
+            std::cout << "surface type: " << el->get_surface()->get_type() << std::endl;
+
+            switch (el->get_surface()->get_type())
+            {
+            case SurfaceType::FLAT:
+            {
+                auto surface = std::make_shared<OptixCSP::SurfaceFlat>();
+                assert(surface != nullptr);
+                optix_el->set_surface(surface);
+
+                break;
+            }
+            case SurfaceType::PARABOLA:
+            {
+                auto el_surface = std::dynamic_pointer_cast<Parabola>(el->get_surface());
+                assert(el_surface != nullptr);
+                double fx = el_surface->focal_length_x;
+                double fy = el_surface->focal_length_y;
+
+                double cx = 1. / (2. * fx);
+                double cy = 1. / (2. * fy);
+
+                auto optix_surface = std::make_shared<OptixCSP::SurfaceParabolic>();
+                optix_surface->set_curvature(cx, cy);
+                optix_el->set_surface(optix_surface);
+
+                break;
+            }
+            case SurfaceType::CYLINDER:
+            {
+                auto el_surface = std::dynamic_pointer_cast<Cylinder>(el->get_surface());
+                assert(el_surface != nullptr);
+                auto el_aperture = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
+                // assert(el_aperture != nullptr);
+                if (el_aperture == nullptr)
+                {
+                    throw std::runtime_error("Cylinder surface type must have rectangular aperture.");
+                }
+
+                if (fabs(0.5 * el_aperture->x_length - el_surface->radius) > 1e-6)
+                {
+                    throw std::runtime_error("Rectangle aperture has incorrect dimension for cylinder surface.");
+                }
+
+                auto surface = std::make_shared<OptixCSP::SurfaceCylinder>();
+                // surface->set_half_height(2.); // TODO this needs to come from the aperture
+                surface->set_half_height(0.5 * el_aperture->y_length);
+                surface->set_radius(el_surface->radius);
+                optix_el->set_surface(surface);
+
+                break;
+            }
+            default:
+                std::cerr << "Unsupported surface type in OptixCSP" << std::endl;
+                break;
+            }
+
+            auto soltrace_aperture_type = el->get_aperture()->get_type();
+
+            switch (soltrace_aperture_type)
+            {
+
+            case ApertureType::RECTANGLE:
+            {
+
+                auto el_aperture = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
+
+                // TODO: account for x and y coord?
+                auto aperture = std::make_shared<OptixCSP::ApertureRectangle>(el_aperture->x_length, el_aperture->y_length);
+                assert(el_aperture != nullptr);
+                optix_el->set_aperture(aperture);
+                break;
+            }
+
+            case ApertureType::EQUILATERAL_TRIANGLE:
+            {
+                auto el_aperture = std::dynamic_pointer_cast<EquilateralTriangle>(el->get_aperture());
+                assert(el_aperture != nullptr);
+                double r = 0.5 * el_aperture->circumscribe_diameter;
+
+                OptixCSP::Vec3d p0(-sqrt(0.75) * r, -0.5 * r, 0.0);
+                OptixCSP::Vec3d p1(sqrt(0.75) * r, -0.5 * r, 0.0);
+                OptixCSP::Vec3d p2(0.0, r, 0.0);
+
+                auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
+                optix_el->set_aperture(aperture);
+
+                break;
+            }
+
+            case ApertureType::IRREGULAR_TRIANGLE:
+            {
+                auto el_aperture = std::dynamic_pointer_cast<IrregularTriangle>(el->get_aperture());
+                assert(el_aperture != nullptr);
+
+                OptixCSP::Vec3d p0(el_aperture->x1, el_aperture->y1, 0.0);
+                OptixCSP::Vec3d p1(el_aperture->x2, el_aperture->y2, 0.0);
+                OptixCSP::Vec3d p2(el_aperture->x3, el_aperture->y3, 0.0);
+
+                auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
+                optix_el->set_aperture(aperture);
+
+                break;
+            }
+
+            case ApertureType::IRREGULAR_QUADRILATERAL:
+            {
+                auto el_aperture = std::dynamic_pointer_cast<IrregularQuadrilateral>(el->get_aperture());
+                assert(el_aperture != nullptr);
+
+                OptixCSP::Vec3d p0(el_aperture->x1, el_aperture->y1, 0.0);
+                OptixCSP::Vec3d p1(el_aperture->x2, el_aperture->y2, 0.0);
+                OptixCSP::Vec3d p2(el_aperture->x3, el_aperture->y3, 0.0);
+                OptixCSP::Vec3d p3(el_aperture->x4, el_aperture->y4, 0.0);
+
+                auto aperture = std::make_shared<OptixCSP::ApertureQuadrilateral>(p0, p1, p2, p3);
+                optix_el->set_aperture(aperture);
+
+                break;
+            }
+
+            default:
+                std::cerr << "Unsupported aperture type in OptixCSP" << std::endl;
+                break;
+            }
+
+            double xmin, xmax, ymin, ymax, zmin, zmax;
+            el->get_aperture()->bounding_box(xmin, xmax, ymin, ymax);
+            el->get_surface()->bounding_box({xmin, xmax}, {ymin, ymax}, zmin, zmax);
+            Vec3d upper(xmax, ymax, zmax);
+            Vec3d lower(xmin, ymin, zmin);
+            optix_el->set_upper_bounding_box(upper);
+            optix_el->set_lower_bounding_box(lower);
+
+            m_sys.add_element(optix_el);
+
             std::cout << "=====================================================" << std::endl;
         }
     }

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -163,6 +163,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 case SurfaceType::FLAT:
                 {
                     auto surface = std::make_shared<OptixCSP::SurfaceFlat>();
+                    assert(el_surface != nullptr);
                     optix_el->set_surface(surface);
 
                     break;
@@ -170,6 +171,7 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 case SurfaceType::PARABOLA:
                 {
                     auto el_surface = std::dynamic_pointer_cast<Parabola>(el->get_surface());
+                    assert(el_surface != nullptr);
                     double fx = el_surface->focal_length_x;
                     double fy = el_surface->focal_length_y;
 
@@ -185,9 +187,13 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 case SurfaceType::CYLINDER:
                 {
                     auto el_surface = std::dynamic_pointer_cast<Cylinder>(el->get_surface());
+                    assert(el_surface != nullptr);
+                    auto el_aperture = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
+                    assert(el_aperture != nullptr);
 
                     auto surface = std::make_shared<OptixCSP::SurfaceCylinder>();
-                    surface->set_half_height(2.); // TODO this needs to come from the aperture
+                    // surface->set_half_height(2.); // TODO this needs to come from the aperture
+                    surface->set_half_height(0.5 * el_aperture->y_length);
                     surface->set_radius(el_surface->radius);
                     optix_el->set_surface(surface);
 
@@ -210,7 +216,57 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
 
                     // TODO: account for x and y coord?
                     auto aperture = std::make_shared<OptixCSP::ApertureRectangle>(el_aperture->x_length, el_aperture->y_length);
+                    assert(el_aperture != nullptr);
                     optix_el->set_aperture(aperture);
+                    break;
+                }
+
+                case ApertureType::EQUILATERAL_TRIANGLE:
+                {
+                    // Triangles in OptixRunner uses global coordinates of the 3 corner points
+                    // so we convert everything to global coordinates here
+                    auto el_aperture = std::dynamic_pointer_cast<EqualateralTriangle>(el->get_aperture());
+                    assert(el_aperture != nullptr);
+                    double r = 0.5 * el_aperture->circumscribe_diameter;
+
+                    Vector3d p_loc(-sqrt(0.75) * r, 0.5 * r, 0.0);
+                    Vector3d p_glob;
+                    el->convert_local_to_global(p_glob, p_loc);
+                    OptixCSP::Vec3d p0 = ToVec3d(p_glob);
+                    
+                    p_loc.set_values(sqrt(0.75) * r, 0.5 * r, 0.0);
+                    el->convert_local_to_global(p_glob, p_loc);
+                    OptixCSP::Vec3d p1 = ToVec3d(p_glob);
+
+                    p_loc.set_values(0.0, r, 0.0);
+                    el->convert_local_to_global(p_glob, p_loc);
+                    OptixCSP::Vec3d p2 = ToVec3d(p_glob);
+
+                    auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
+
+                    break;
+                }
+                case ApertureType::IRREGULAR_TRIANGLE:
+                {
+                    // Triangles in OptixRunner uses global coordinates of the 3 corner points
+                    // so we convert everything to global coordinates here
+                    auto el_aperture = std::dynamic_pointer_cast<IrregularTriangle>(el->get_aperture());
+                    assert(el_aperture != nullptr);
+                    
+                    Vector3d p_loc(el_aperture->x1, el_aperture->y1, 0.0);
+                    Vector3d p_glob;
+                    el->convert_local_to_global(p_glob, p_loc);
+                    OptixCSP::Vec3d p0 = ToVec3d(p_glob);
+                    
+                    p_loc.set_values(el_aperture->x2, el_aperture->y2, 0.0);
+                    el->convert_local_to_global(p_glob, p_loc);
+                    OptixCSP::Vec3d p1 = ToVec3d(p_glob);
+
+                    p_loc.set_values(el_aperture->x3, el_aperture->y3, 0.0);
+                    el->convert_local_to_global(p_glob, p_loc);
+                    OptixCSP::Vec3d p2 = ToVec3d(p_glob);
+
+                    auto aperture = std::make_shared<OptixCSP::ApertureTriangle>(p0, p1, p2);
                     break;
                 }
 

--- a/coretrace/simulation_runner/optix_runner/optix_runner.cpp
+++ b/coretrace/simulation_runner/optix_runner/optix_runner.cpp
@@ -284,12 +284,17 @@ RunnerStatus OptixRunner::setup_elements(const SimulationData *data)
                 break;
             }
 
+	    optix_el->update_euler_angles();
+
             double xmin, xmax, ymin, ymax, zmin, zmax;
             el->get_aperture()->bounding_box(xmin, xmax, ymin, ymax);
             el->get_surface()->bounding_box(xmin, xmax, ymin, ymax, zmin, zmax);
             OptixCSP::Vec3d upper(xmax, ymax, zmax);
             OptixCSP::Vec3d lower(xmin, ymin, zmin);
             optix_el->set_bounding_box_local(lower, upper);
+
+	    std::cout << "Bounding Box Upper: " << optix_el->get_upper_bounding_box() << std::endl;
+	    std::cout << "Bounding Box Lower: " << optix_el->get_lower_bounding_box() << std::endl;
 
             m_sys.add_element(optix_el);
 

--- a/google-tests/regression-tests/embree_runner_validation_test.cpp
+++ b/google-tests/regression-tests/embree_runner_validation_test.cpp
@@ -345,6 +345,7 @@ TEST(EmbreeRunner, ValidationTest2)
     // Constants
     const uint_fast64_t NRAYS = 50000;
     const double TOL = 1e-4;
+    element_id absorber_id = 6285;
 
     // Read Input File
     bool success = sd.import_from_file(sample_path);
@@ -353,6 +354,22 @@ TEST(EmbreeRunner, ValidationTest2)
     EXPECT_TRUE(sd.get_number_of_ray_sources() > 0);
 
     std::cout << "Num Elements: " << sd.get_number_of_elements() << std::endl;
+
+    // Change the location of the absorber to account for difference in origin
+    // of cylinder in new and legacy. Local z-axis of the absorber is aligned
+    // with the global y-axis so the offset to add the radius of the cylinder
+    // in the positive y-axis direction.
+    auto absorb = sd.get_element(absorber_id);
+    ASSERT_TRUE(absorb->get_surface()->get_type() == SurfaceType::CYLINDER);
+    auto surf = std::dynamic_pointer_cast<Cylinder>(absorb->get_surface());
+    ASSERT_TRUE(surf != nullptr);
+    double r = surf->radius;
+    Vector3d offset(0.0, r, 0.0);
+    Vector3d oref = absorb->get_origin_ref();
+    vector_add(1.0, offset, 1.0, oref);
+    Vector3d aref = absorb->get_aim_vector_ref();
+    vector_add(1.0, offset, 1.0, aref);
+    absorb->set_reference_frame_geometry(oref, aref, 0.0);
 
     // Parameters
     SimulationParameters &params = sd.get_simulation_parameters();
@@ -454,7 +471,6 @@ TEST(EmbreeRunner, ValidationTest2)
     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
     EXPECT_EQ(result.get_number_of_records(), NRAYS);
 
-    element_id absorber_id = 6285;
     int_fast64_t nabsorbed = count_element_event(result, absorber_id, RayEvent::ABSORB);
     int_fast64_t nreflect = count_element_event(result, absorber_id, RayEvent::REFLECT);
     int_fast64_t nevents = nabsorbed + nreflect;

--- a/google-tests/regression-tests/native_runner_validation_test.cpp
+++ b/google-tests/regression-tests/native_runner_validation_test.cpp
@@ -351,14 +351,31 @@ TEST(NativeRunner, ValidationTest2)
     // Constants
     const uint_fast64_t NRAYS = 50000;
     const double TOL = 1e-4;
+    element_id absorber_id = 6285;
 
     // Read Input File
     bool success = sd.import_from_file(sample_path);
-    EXPECT_TRUE(success);
-    EXPECT_TRUE(sd.get_number_of_elements() > 0);
-    EXPECT_TRUE(sd.get_number_of_ray_sources() > 0);
+    ASSERT_TRUE(success);
+    ASSERT_TRUE(sd.get_number_of_elements() > 0);
+    ASSERT_TRUE(sd.get_number_of_ray_sources() > 0);
 
     std::cout << "Num Elements: " << sd.get_number_of_elements() << std::endl;
+
+    // Change the location of the absorber to account for difference in origin
+    // of cylinder in new and legacy. Local z-axis of the absorber is aligned
+    // with the global y-axis so the offset to add the radius of the cylinder
+    // in the positive y-axis direction.
+    auto absorb = sd.get_element(absorber_id);
+    ASSERT_TRUE(absorb->get_surface()->get_type() == SurfaceType::CYLINDER);
+    auto surf = std::dynamic_pointer_cast<Cylinder>(absorb->get_surface());
+    ASSERT_TRUE(surf != nullptr);
+    double r = surf->radius;
+    Vector3d offset(0.0, r, 0.0);
+    Vector3d oref = absorb->get_origin_ref();
+    vector_add(1.0, offset, 1.0, oref);
+    Vector3d aref = absorb->get_aim_vector_ref();
+    vector_add(1.0, offset, 1.0, aref);
+    absorb->set_reference_frame_geometry(oref, aref, 0.0);
 
     // Parameters
     SimulationParameters &params = sd.get_simulation_parameters();
@@ -375,7 +392,7 @@ TEST(NativeRunner, ValidationTest2)
     //     auto elem = cit->second;
     //     if (elem->is_stage())
     //     {
-    //         stage_ptr st = dynamic_pointer_cast<StageElement>(elem);
+    //         stage_ptr st = std::dynamic_pointer_cast<StageElement>(elem);
     //         assert(st != nullptr);
     //         std::cout << "Stage: " << st->get_stage()
     //                   << "\nNumber of elements: "
@@ -385,9 +402,9 @@ TEST(NativeRunner, ValidationTest2)
     //         {
     //             auto el = st->get_const_iterator()->second;
 
-    //             auto surf = dynamic_pointer_cast<Cylinder>(el->get_surface());
+    //             auto surf = std::dynamic_pointer_cast<Cylinder>(el->get_surface());
     //             assert(surf != nullptr);
-    //             auto ap = dynamic_pointer_cast<Rectangle>(el->get_aperture());
+    //             auto ap = std::dynamic_pointer_cast<Rectangle>(el->get_aperture());
     //             assert(ap != nullptr);
 
     //             std::cout << "------------\n"
@@ -461,7 +478,6 @@ TEST(NativeRunner, ValidationTest2)
     EXPECT_EQ(sts, RunnerStatus::SUCCESS);
     EXPECT_EQ(result.get_number_of_records(), NRAYS);
 
-    element_id absorber_id = 6285;
     int_fast64_t nabsorbed = count_element_event(result, absorber_id, RayEvent::ABSORB);
     int_fast64_t nreflect = count_element_event(result, absorber_id, RayEvent::REFLECT);
     int_fast64_t nevents = nabsorbed + nreflect;

--- a/google-tests/unit-tests/simulation_data/aperture_test.cpp
+++ b/google-tests/unit-tests/simulation_data/aperture_test.cpp
@@ -261,7 +261,7 @@ TEST(Aperture, Circle)
     std::cout << "Expected fraction of hits: " << frac << std::endl;
 }
 
-TEST(Aperture, EqualateralTriangle)
+TEST(Aperture, EquilateralTriangle)
 {
     const double TOL = 1e-12;
     constexpr double D = 2.0;
@@ -285,7 +285,7 @@ TEST(Aperture, EqualateralTriangle)
     const double X5 = 0.375 * S;
     const double Y5 = -0.375 * R;
 
-    auto et = make_aperture<EqualateralTriangle>(D);
+    auto et = make_aperture<EquilateralTriangle>(D);
 
     EXPECT_EQ(et->diameter_circumscribed_circle(), D);
     EXPECT_EQ(et->radius_circumscribed_circle(), 0.5 * D);

--- a/google-tests/unit-tests/simulation_data/cst-templates/heliostat_field_test.cpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/heliostat_field_test.cpp
@@ -125,7 +125,8 @@ protected:
         receiver->get_back_optical_properties()->set_ideal_reflection();
         receiver->set_aperture(SolTrace::Data::make_aperture<SolTrace::Data::Rectangle>(rec_radius * 2.0, rec_height));
         receiver->set_surface(SolTrace::Data::make_surface<SolTrace::Data::Cylinder>(rec_radius));
-        Vector3d offset = { 0.0, rec_radius, 0.0 };    // Cylinder origin is on the edge
+        // Vector3d offset = { 0.0, rec_radius, 0.0 };    // Cylinder origin is on the edge
+        Vector3d offset = { 0.0, 0.0, 0.0 };
         Vector3d rec_origin_offset;
         vector_add(1.0, rec_origin, 1.0, offset, rec_origin_offset);
         Vector3d v1 = { 0.0, -1.0, 0.0 };
@@ -140,7 +141,8 @@ protected:
         top_heat_shield->get_back_optical_properties()->set_ideal_reflection();
         top_heat_shield->set_aperture(SolTrace::Data::make_aperture<SolTrace::Data::Rectangle>(rec_radius * 2.0, rec_heat_shield_height));
         top_heat_shield->set_surface(SolTrace::Data::make_surface<SolTrace::Data::Cylinder>(rec_radius));
-        offset = { 0.0, rec_radius, (rec_height + rec_heat_shield_height)/2.};    // Cylinder origin is on the edge
+        // offset = { 0.0, rec_radius, (rec_height + rec_heat_shield_height)/2.};    // Cylinder origin is on the edge
+        offset = { 0.0, 0.0, (rec_height + rec_heat_shield_height)/2.};
         vector_add(1.0, rec_origin, 1.0, offset, rec_origin_offset);
         vector_add(1.0, rec_origin_offset, 1.0, v1, aim_point);
         top_heat_shield->set_reference_frame_geometry(rec_origin_offset, aim_point, 0.0);
@@ -152,7 +154,8 @@ protected:
         bottom_heat_shield->get_back_optical_properties()->set_ideal_reflection();
         bottom_heat_shield->set_aperture(SolTrace::Data::make_aperture<SolTrace::Data::Rectangle>(rec_radius * 2.0, rec_heat_shield_height));
         bottom_heat_shield->set_surface(SolTrace::Data::make_surface<SolTrace::Data::Cylinder>(rec_radius));
-        offset = { 0.0, rec_radius, -(rec_height + rec_heat_shield_height) / 2. };    // Cylinder origin is on the edge
+        // offset = { 0.0, rec_radius, -(rec_height + rec_heat_shield_height) / 2. };    // Cylinder origin is on the edge
+        offset = { 0.0, 0.0, -(rec_height + rec_heat_shield_height) / 2. };
         vector_add(1.0, rec_origin, 1.0, offset, rec_origin_offset);
         vector_add(1.0, rec_origin_offset, 1.0, v1, aim_point);
         bottom_heat_shield->set_reference_frame_geometry(rec_origin_offset, aim_point, 0.0);
@@ -683,9 +686,9 @@ protected:
                         npoints++;
 
                         if (is_cylinder) {
-                            if (z <= rec_radius)
+                            if (z <= 0.0)
                                 x = rec_radius * asin(x / rec_radius);
-                            else if (z > rec_radius) {
+                            else if (z > 0.0) {
                                 if (x < 0) x = -(PI * rec_radius / 2.0 + rec_radius * acos(fabs(x) / rec_radius));
                                 if (x >= 0) x = PI * rec_radius / 2.0 + rec_radius * acos(x / rec_radius);
                             }

--- a/google-tests/unit-tests/simulation_data/cst-templates/single_heliostat_test_template.hpp
+++ b/google-tests/unit-tests/simulation_data/cst-templates/single_heliostat_test_template.hpp
@@ -509,9 +509,9 @@ public:
                         npoints++;
 
                         if (is_cylinder) {
-                            if (z <= rec_radius)
+                            if (z <= 0.0)
                                 x = rec_radius * asin(x / rec_radius);
-                            else if (z > rec_radius) {
+                            else if (z > 0.0) {
                                 if (x < 0) x = -(PI * rec_radius / 2.0 + rec_radius * acos(fabs(x) / rec_radius));
                                 if (x >= 0) x = PI * rec_radius / 2.0 + rec_radius * acos(x / rec_radius);
                             }

--- a/google-tests/unit-tests/simulation_data/file_io_test.cpp
+++ b/google-tests/unit-tests/simulation_data/file_io_test.cpp
@@ -542,7 +542,7 @@ TEST(io_json, apertures_read)
     jtriangle_eq["circumscribe_diameter"] = 6;
     EXPECT_NO_THROW(Aperture::make_aperture_from_json(jtriangle_eq));
     auto eq_ptr = Aperture::make_aperture_from_json(jtriangle_eq);
-    auto eq_cast = dynamic_cast<EqualateralTriangle*>(eq_ptr.get());
+    auto eq_cast = dynamic_cast<EquilateralTriangle*>(eq_ptr.get());
     ASSERT_TRUE(eq_cast != nullptr);
     EXPECT_DOUBLE_EQ(6, eq_cast->circumscribe_diameter);
 
@@ -645,7 +645,7 @@ TEST(io_json, apertures_write)
     // EQUILATERAL_TRIANGLE
     json jtriangle_eq;
     double eqdiam = 6;
-    auto triangle_eq = make_aperture<EqualateralTriangle>(eqdiam);
+    auto triangle_eq = make_aperture<EquilateralTriangle>(eqdiam);
     ASSERT_NO_THROW(triangle_eq->write_json(jtriangle_eq));
     EXPECT_DOUBLE_EQ(eqdiam, jtriangle_eq["circumscribe_diameter"]);
     EXPECT_TRUE(jtriangle_eq["aperture_type"] == SolTrace::Data::ApertureTypeMap.at(ApertureType::EQUILATERAL_TRIANGLE));

--- a/google-tests/unit-tests/simulation_data/surface_test.cpp
+++ b/google-tests/unit-tests/simulation_data/surface_test.cpp
@@ -226,8 +226,8 @@ TEST(Cylinder, BoundingBox)
     auto copy = cylin->make_copy();
 
     cylin->bounding_box(xbox, ybox, z0, z1);
-    EXPECT_NEAR(z0, 0.0, TOL);
-    EXPECT_NEAR(z1, 2.0 * R, TOL);
+    EXPECT_NEAR(z0, -R, TOL);
+    EXPECT_NEAR(z1, R, TOL);
 }
 
 TEST(Flat, MakeCopy)

--- a/google-tests/unit-tests/simulation_runner/native_runner/cylinder_calculator_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/native_runner/cylinder_calculator_test.cpp
@@ -36,7 +36,7 @@ TEST(CylinderCalculator, Case1)
     CylinderCalculator calc(surface, aperture);
 
     // Ray position and direction
-    Vector3d x0(-1.0, -1.0, -1.0);
+    Vector3d x0(-1.0, -1.0, -2.0);
     Vector3d m(0.0, 1.0, 0.0);
 
     // Solution values
@@ -61,7 +61,7 @@ TEST(CylinderCalculator, Case2)
     CylinderCalculator calc(surface, aperture);
 
     // Ray position and direction
-    Vector3d x0(5.0, 0.0, 1.0);
+    Vector3d x0(5.0, 0.0, 0.0);
     Vector3d m(-1.0, 1.0, 1.0);
 
     // Solution values
@@ -87,7 +87,7 @@ TEST(CylinderCalculator, Case3)
     CylinderCalculator calc(surface, aperture);
 
     // Ray position and direction
-    Vector3d x0(5.0, -3.0, 1.0);
+    Vector3d x0(5.0, -3.0, 0.0);
     Vector3d m(-1.0, 1.0, 0.0);
 
     // Solution values
@@ -102,7 +102,7 @@ TEST(CylinderCalculator, Case3)
     EXPECT_NEAR(t, 4.0, TOL);
     EXPECT_NEAR(xt[0], 1.0, TOL);
     EXPECT_NEAR(xt[1], 1.0, TOL);
-    EXPECT_NEAR(xt[2], 1.0, TOL);
+    EXPECT_NEAR(xt[2], 0.0, TOL);
     EXPECT_NEAR(mt[0], m[0], TOL);
     EXPECT_NEAR(mt[1], m[1], TOL);
     EXPECT_NEAR(mt[2], m[2], TOL);
@@ -119,7 +119,7 @@ TEST(CylinderCalculator, Case4)
     CylinderCalculator calc(surface, aperture);
 
     // Ray position and direction
-    Vector3d x0(0.0, -1.0, 1.0);
+    Vector3d x0(0.0, -1.0, 0.0);
     Vector3d m(-1.0, 1.0, 0.0);
 
     // Solution values
@@ -134,7 +134,7 @@ TEST(CylinderCalculator, Case4)
     EXPECT_NEAR(t, 1.0, TOL);
     EXPECT_NEAR(xt[0], -1.0, TOL);
     EXPECT_NEAR(xt[1], 0.0, TOL);
-    EXPECT_NEAR(xt[2], 1.0, TOL);
+    EXPECT_NEAR(xt[2], 0.0, TOL);
     EXPECT_NEAR(mt[0], m[0], TOL);
     EXPECT_NEAR(mt[1], m[1], TOL);
     EXPECT_NEAR(mt[2], m[2], TOL);
@@ -150,7 +150,7 @@ TEST(CylinderCalculator, Case5)
     CylinderCalculator calc(surface, aperture);
 
     // Ray position and direction
-    Vector3d x0(5.0, ymax, 1.0);
+    Vector3d x0(5.0, ymax, 0.0);
     Vector3d m(-1.0, 1.0, 0.0);
 
     // Solution values
@@ -175,7 +175,7 @@ TEST(CylinderCalculator, Case6)
     CylinderCalculator calc(surface, aperture);
 
     // Ray position and direction
-    Vector3d x0(5.0, ymax, 1.0);
+    Vector3d x0(5.0, ymax, 0.0);
     Vector3d m(-1.0, 1.0, 0.0);
 
     // Solution values

--- a/google-tests/unit-tests/simulation_runner/optix_runner/CMakeLists.txt
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
 set(OPTIX_RUNNER_TEST_SRC
     ../../common/common.cpp
     vector_error_test.cpp
+    geometry_intersection_test.cpp
     gpu_tower_demo.cpp
     flat_optical_test.cpp
     two_plate_test.cpp

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -71,7 +71,7 @@ TEST(OptixRunner, FlatEquilateralTriangle)
 {
     const double d = 4.0;
     auto surf = make_surface<Flat>();
-    auto aper = make_aperture<EqualateralTriangle>(d);
+    auto aper = make_aperture<EquilateralTriangle>(d);
 
     SimulationData sd;
     set_default_sd(sd, surf, aper);

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -8,6 +8,7 @@
 using SolTrace::Runner::RunnerStatus;
 
 const double Z_ELEM = 50.0;
+const double TOL = 1e-6;
 
 void set_default_sd(SimulationData &sd,
                     surface_ptr surf,
@@ -74,9 +75,9 @@ TEST(OptixRunner, FlatRectangle)
     Vector3d p0, p1;
     rr->get_position(0, p0);
     rr->get_position(1, p1);
-    EXPECT_EQ(p0[0], p1[0]);
-    EXPECT_EQ(p0[1], p1[1]);
-    EXPECT_EQ(p1[2], Z_ELEM);
+    EXPECT_NEAR(p0[0], p1[0], TOL);
+    EXPECT_NEAR(p0[1], p1[1], TOL);
+    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
 }
 
 TEST(OptixRunner, FlatEquilateralTriangle)
@@ -107,9 +108,9 @@ TEST(OptixRunner, FlatEquilateralTriangle)
     Vector3d p0, p1;
     rr->get_position(0, p0);
     rr->get_position(1, p1);
-    EXPECT_EQ(p0[0], p1[0]);
-    EXPECT_EQ(p0[1], p1[1]);
-    EXPECT_EQ(p1[2], Z_ELEM);
+    EXPECT_NEAR(p0[0], p1[0], TOL);
+    EXPECT_NEAR(p0[1], p1[1], TOL);
+    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
 }
 
 TEST(OptixRunner, FlatTriangle)
@@ -141,9 +142,9 @@ TEST(OptixRunner, FlatTriangle)
     Vector3d p0, p1;
     rr->get_position(0, p0);
     rr->get_position(1, p1);
-    EXPECT_EQ(p0[0], p1[0]);
-    EXPECT_EQ(p0[1], p1[1]);
-    EXPECT_EQ(p1[2], Z_ELEM);
+    EXPECT_NEAR(p0[0], p1[0], TOL);
+    EXPECT_NEAR(p0[1], p1[1], TOL);
+    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
 }
 
 TEST(OptixRunner, FlatQuadrilateral)
@@ -177,9 +178,9 @@ TEST(OptixRunner, FlatQuadrilateral)
     Vector3d p0, p1;
     rr->get_position(0, p0);
     rr->get_position(1, p1);
-    EXPECT_EQ(p0[0], p1[0]);
-    EXPECT_EQ(p0[1], p1[1]);
-    EXPECT_EQ(p1[2], Z_ELEM);
+    EXPECT_NEAR(p0[0], p1[0], TOL);
+    EXPECT_NEAR(p0[1], p1[1], TOL);
+    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
 }
 
 TEST(OptixRunner, ParabolaRectangle)

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -7,6 +7,8 @@
 
 using SolTrace::Runner::RunnerStatus;
 
+const double Z_ELEM = 50.0;
+
 void set_default_sd(SimulationData &sd,
                     surface_ptr surf,
                     aperture_ptr ap)
@@ -20,7 +22,7 @@ void set_default_sd(SimulationData &sd,
 
     // Make reflective flat el
     element_ptr el = make_element<SingleElement>();
-    el->set_origin(0, 0, 50);
+    el->set_origin(0, 0, Z_ELEM);
     el->set_aim_vector(0, 0, 100); // Face up towards sun
     el->set_surface(surf);
     el->set_aperture(ap);
@@ -64,7 +66,17 @@ TEST(OptixRunner, FlatRectangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // TODO: Add some tests for the results here
+    // Check a single intersection happens where expected
+    ASSERT_EQ(result.get_number_of_records(),
+              sd.get_simulation_parameters().number_of_rays);
+    auto rr = result[0];
+    ASSERT_GE(rr->get_number_of_interactions(), 2);
+    Vector3d p0, p1;
+    rr->get_position(0, p0);
+    rr->get_position(1, p1);
+    EXPECT_EQ(p0[0], p1[0]);
+    EXPECT_EQ(p0[1], p1[1]);
+    EXPECT_EQ(p1[2], Z_ELEM);
 }
 
 TEST(OptixRunner, FlatEquilateralTriangle)
@@ -87,7 +99,17 @@ TEST(OptixRunner, FlatEquilateralTriangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // TODO: Add some tests for the results here
+    // Check a single intersection happens where expected
+    ASSERT_EQ(result.get_number_of_records(),
+              sd.get_simulation_parameters().number_of_rays);
+    auto rr = result[0];
+    ASSERT_GE(rr->get_number_of_interactions(), 2);
+    Vector3d p0, p1;
+    rr->get_position(0, p0);
+    rr->get_position(1, p1);
+    EXPECT_EQ(p0[0], p1[0]);
+    EXPECT_EQ(p0[1], p1[1]);
+    EXPECT_EQ(p1[2], Z_ELEM);
 }
 
 TEST(OptixRunner, FlatTriangle)
@@ -111,7 +133,53 @@ TEST(OptixRunner, FlatTriangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // TODO: Add some tests for the results here
+    // Check a single intersection happens where expected
+    ASSERT_EQ(result.get_number_of_records(),
+              sd.get_simulation_parameters().number_of_rays);
+    auto rr = result[0];
+    ASSERT_GE(rr->get_number_of_interactions(), 2);
+    Vector3d p0, p1;
+    rr->get_position(0, p0);
+    rr->get_position(1, p1);
+    EXPECT_EQ(p0[0], p1[0]);
+    EXPECT_EQ(p0[1], p1[1]);
+    EXPECT_EQ(p1[2], Z_ELEM);
+}
+
+TEST(OptixRunner, FlatQuadrilateral)
+{
+    // Parallelogram
+    const double x1 = 0.0, x2 = 3.0, x3 = (x2 - x1) + 1.0, x4 = x3 - x2 + x1;
+    const double y1 = 0.0, y2 = y1, y3 = 2.0, y4 = y3;
+    auto surf = make_surface<Flat>();
+    auto aper = make_aperture<IrregularQuadrilateral>(
+        x1, y1, x2, y2, x3, y3, x4, y4);
+
+    SimulationData sd;
+    set_default_sd(sd, surf, aper);
+    SimulationResult result;
+
+    OptixRunner runner;
+    RunnerStatus sts = runner.initialize();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(&sd);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.run_simulation();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.report_simulation(&result, 0);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // Check a single intersection happens where expected
+    ASSERT_EQ(result.get_number_of_records(),
+              sd.get_simulation_parameters().number_of_rays);
+    auto rr = result[0];
+    ASSERT_GE(rr->get_number_of_interactions(), 2);
+    Vector3d p0, p1;
+    rr->get_position(0, p0);
+    rr->get_position(1, p1);
+    EXPECT_EQ(p0[0], p1[0]);
+    EXPECT_EQ(p0[1], p1[1]);
+    EXPECT_EQ(p1[2], Z_ELEM);
 }
 
 TEST(OptixRunner, ParabolaRectangle)
@@ -146,7 +214,7 @@ TEST(OptixRunner, Cylinder)
     const double R = 5.0;
     const double YL = 3.0; // Total cylinder length
     auto surf = make_surface<Cylinder>(R);
-    auto aper = make_aperture<Rectangle>(2*R, YL);
+    auto aper = make_aperture<Rectangle>(2 * R, YL);
 
     SimulationData sd;
     set_default_sd(sd, surf, aper);

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -9,6 +9,7 @@ using SolTrace::Runner::RunnerStatus;
 
 const double Z_ELEM = 50.0;
 const double TOL = 5e-6;
+const uint_fast64_t NRAYS = 10000;
 
 void set_default_sd(SimulationData &sd,
                     surface_ptr surf,
@@ -39,7 +40,7 @@ void set_default_sd(SimulationData &sd,
 
     // Set parameters
     SimulationParameters &params = sd.get_simulation_parameters();
-    params.number_of_rays = 10000;
+    params.number_of_rays = NRAYS;
     params.max_number_of_rays = params.number_of_rays * 100;
     params.include_optical_errors = false;
     params.include_sun_shape_errors = false;
@@ -67,17 +68,19 @@ TEST(OptixRunner, FlatRectangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // Check a single intersection happens where expected
     ASSERT_EQ(result.get_number_of_records(),
               sd.get_simulation_parameters().number_of_rays);
-    auto rr = result[0];
-    ASSERT_GE(rr->get_number_of_interactions(), 2);
-    Vector3d p0, p1;
-    rr->get_position(0, p0);
-    rr->get_position(1, p1);
-    EXPECT_NEAR(p0[0], p1[0], TOL);
-    EXPECT_NEAR(p0[1], p1[1], TOL);
-    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
+    for (int i = 0; i < (int)result.get_number_of_records(); ++i)
+    {
+        auto rr = result[i];
+        ASSERT_GE(rr->get_number_of_interactions(), 2);
+        Vector3d p0, p1;
+        rr->get_position(0, p0);
+        rr->get_position(1, p1);
+        EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
+        EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+    }
 }
 
 TEST(OptixRunner, FlatEquilateralTriangle)
@@ -100,17 +103,19 @@ TEST(OptixRunner, FlatEquilateralTriangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // Check a single intersection happens where expected
     ASSERT_EQ(result.get_number_of_records(),
               sd.get_simulation_parameters().number_of_rays);
-    auto rr = result[0];
-    ASSERT_GE(rr->get_number_of_interactions(), 2);
-    Vector3d p0, p1;
-    rr->get_position(0, p0);
-    rr->get_position(1, p1);
-    EXPECT_NEAR(p0[0], p1[0], TOL);
-    EXPECT_NEAR(p0[1], p1[1], TOL);
-    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
+    for (int i = 0; i < (int)result.get_number_of_records(); ++i)
+    {
+        auto rr = result[i];
+        ASSERT_GE(rr->get_number_of_interactions(), 2);
+        Vector3d p0, p1;
+        rr->get_position(0, p0);
+        rr->get_position(1, p1);
+        EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
+        EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+    }
 }
 
 TEST(OptixRunner, FlatTriangle)
@@ -134,17 +139,19 @@ TEST(OptixRunner, FlatTriangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // Check a single intersection happens where expected
     ASSERT_EQ(result.get_number_of_records(),
               sd.get_simulation_parameters().number_of_rays);
-    auto rr = result[0];
-    ASSERT_GE(rr->get_number_of_interactions(), 2);
-    Vector3d p0, p1;
-    rr->get_position(0, p0);
-    rr->get_position(1, p1);
-    EXPECT_NEAR(p0[0], p1[0], TOL);
-    EXPECT_NEAR(p0[1], p1[1], TOL);
-    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
+    for (int i = 0; i < (int)result.get_number_of_records(); ++i)
+    {
+        auto rr = result[i];
+        ASSERT_GE(rr->get_number_of_interactions(), 2);
+        Vector3d p0, p1;
+        rr->get_position(0, p0);
+        rr->get_position(1, p1);
+        EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
+        EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+    }
 }
 
 TEST(OptixRunner, FlatQuadrilateral)
@@ -170,17 +177,19 @@ TEST(OptixRunner, FlatQuadrilateral)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // Check a single intersection happens where expected
     ASSERT_EQ(result.get_number_of_records(),
               sd.get_simulation_parameters().number_of_rays);
-    auto rr = result[0];
-    ASSERT_GE(rr->get_number_of_interactions(), 2);
-    Vector3d p0, p1;
-    rr->get_position(0, p0);
-    rr->get_position(1, p1);
-    EXPECT_NEAR(p0[0], p1[0], TOL);
-    EXPECT_NEAR(p0[1], p1[1], TOL);
-    EXPECT_NEAR(p1[2], Z_ELEM, TOL);
+    for (int i = 0; i < (int)result.get_number_of_records(); ++i)
+    {
+        auto rr = result[i];
+        ASSERT_GE(rr->get_number_of_interactions(), 2);
+        Vector3d p0, p1;
+        rr->get_position(0, p0);
+        rr->get_position(1, p1);
+        EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
+        EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+    }
 }
 
 TEST(OptixRunner, ParabolaRectangle)
@@ -207,7 +216,20 @@ TEST(OptixRunner, ParabolaRectangle)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // TODO: Add some tests for the results here
+    ASSERT_EQ(result.get_number_of_records(),
+              sd.get_simulation_parameters().number_of_rays);
+    for (int i = 0; i < (int)result.get_number_of_records(); ++i)
+    {
+        auto rr = result[i];
+        ASSERT_GE(rr->get_number_of_interactions(), 2);
+        Vector3d p0, p1;
+        rr->get_position(0, p0);
+        rr->get_position(1, p1);
+        EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
+        EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
+        const double z1 = Z_ELEM + CX * p1[0] * p1[0] + CY * p1[1] * p1[1];
+        EXPECT_NEAR(p1[2], z1, TOL) << "ray " << i;
+    }
 }
 
 TEST(OptixRunner, Cylinder)
@@ -231,5 +253,18 @@ TEST(OptixRunner, Cylinder)
     sts = runner.report_simulation(&result, 0);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
 
-    // TODO: Add some tests for the results here
+    ASSERT_EQ(result.get_number_of_records(),
+              sd.get_simulation_parameters().number_of_rays);
+    for (int i = 0; i < (int)result.get_number_of_records(); ++i)
+    {
+        auto rr = result[i];
+        ASSERT_GE(rr->get_number_of_interactions(), 2);
+        Vector3d p0, p1;
+        rr->get_position(0, p0);
+        rr->get_position(1, p1);
+        EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
+        EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
+        const double z1 = Z_ELEM + R + sqrt(R * R - p1[0] * p1[0]);
+        EXPECT_NEAR(p1[2], z1, TOL) << "ray " << i;
+    }
 }

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -8,7 +8,7 @@
 using SolTrace::Runner::RunnerStatus;
 
 const double Z_ELEM = 50.0;
-const double TOL = 5e-6;
+const double TOL = 1e-6;
 const uint_fast64_t NRAYS = 10000;
 
 void set_default_sd(SimulationData &sd,
@@ -79,7 +79,7 @@ TEST(OptixRunner, FlatRectangle)
         rr->get_position(1, p1);
         EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
         EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
-        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL * Z_ELEM) << "ray " << i;
     }
 }
 
@@ -114,7 +114,7 @@ TEST(OptixRunner, FlatEquilateralTriangle)
         rr->get_position(1, p1);
         EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
         EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
-        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL * Z_ELEM) << "ray " << i;
     }
 }
 
@@ -150,7 +150,7 @@ TEST(OptixRunner, FlatTriangle)
         rr->get_position(1, p1);
         EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
         EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
-        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL * Z_ELEM) << "ray " << i;
     }
 }
 
@@ -188,7 +188,7 @@ TEST(OptixRunner, FlatQuadrilateral)
         rr->get_position(1, p1);
         EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
         EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
-        EXPECT_NEAR(p1[2], Z_ELEM, TOL) << "ray " << i;
+        EXPECT_NEAR(p1[2], Z_ELEM, TOL * Z_ELEM) << "ray " << i;
     }
 }
 
@@ -227,8 +227,8 @@ TEST(OptixRunner, ParabolaRectangle)
         rr->get_position(1, p1);
         EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
         EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
-        const double z1 = Z_ELEM + CX * p1[0] * p1[0] + CY * p1[1] * p1[1];
-        EXPECT_NEAR(p1[2], z1, TOL) << "ray " << i;
+        const double z1 = Z_ELEM + 0.5 * CX * p1[0] * p1[0] + 0.5 * CY * p1[1] * p1[1];
+        EXPECT_NEAR(p1[2], z1, TOL * Z_ELEM) << "ray " << i;
     }
 }
 
@@ -264,7 +264,7 @@ TEST(OptixRunner, Cylinder)
         rr->get_position(1, p1);
         EXPECT_NEAR(p0[0], p1[0], TOL) << "ray " << i;
         EXPECT_NEAR(p0[1], p1[1], TOL) << "ray " << i;
-        const double z1 = Z_ELEM + R + sqrt(R * R - p1[0] * p1[0]);
-        EXPECT_NEAR(p1[2], z1, TOL) << "ray " << i;
+        const double z1 = Z_ELEM + sqrt(R * R - p1[0] * p1[0]);
+        EXPECT_NEAR(p1[2], z1, TOL * Z_ELEM) << "ray " << i;
     }
 }

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -8,7 +8,7 @@
 using SolTrace::Runner::RunnerStatus;
 
 const double Z_ELEM = 50.0;
-const double TOL = 1e-6;
+const double TOL = 5e-6;
 
 void set_default_sd(SimulationData &sd,
                     surface_ptr surf,

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -57,7 +57,7 @@ TEST(OptixRunner, FlatRectangle)
     OptixRunner runner;
     RunnerStatus sts = runner.initialize();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
-    sts = runner.setup_simulation(sd);
+    sts = runner.setup_simulation(&sd);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
     sts = runner.run_simulation();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
@@ -80,7 +80,7 @@ TEST(OptixRunner, FlatEquilateralTriangle)
     OptixRunner runner;
     RunnerStatus sts = runner.initialize();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
-    sts = runner.setup_simulation(sd);
+    sts = runner.setup_simulation(&sd);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
     sts = runner.run_simulation();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
@@ -104,7 +104,7 @@ TEST(OptixRunner, FlatTriangle)
     OptixRunner runner;
     RunnerStatus sts = runner.initialize();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
-    sts = runner.setup_simulation(sd);
+    sts = runner.setup_simulation(&sd);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
     sts = runner.run_simulation();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
@@ -120,6 +120,7 @@ TEST(OptixRunner, ParabolaRectangle)
     constexpr double CY = 1.0;
     constexpr double FX = 0.5 / CX;
     constexpr double FY = 0.5 / CY;
+    const double XL = 10.0, YL = 5.0;
     auto surf = make_surface<Parabola>(FX, FY);
     auto aper = make_aperture<Rectangle>(XL, YL);
 
@@ -130,7 +131,7 @@ TEST(OptixRunner, ParabolaRectangle)
     OptixRunner runner;
     RunnerStatus sts = runner.initialize();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
-    sts = runner.setup_simulation(sd);
+    sts = runner.setup_simulation(&sd);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
     sts = runner.run_simulation();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
@@ -154,7 +155,7 @@ TEST(OptixRunner, Cylinder)
     OptixRunner runner;
     RunnerStatus sts = runner.initialize();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
-    sts = runner.setup_simulation(sd);
+    sts = runner.setup_simulation(&sd);
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);
     sts = runner.run_simulation();
     ASSERT_EQ(sts, RunnerStatus::SUCCESS);

--- a/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
+++ b/google-tests/unit-tests/simulation_runner/optix_runner/geometry_intersection_test.cpp
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+
+#include <optix_runner.hpp>
+#include <simulation_data_export.hpp>
+#include <simulation_result_export.hpp>
+#include <simulation_runner.hpp>
+
+using SolTrace::Runner::RunnerStatus;
+
+void set_default_sd(SimulationData &sd,
+                    surface_ptr surf,
+                    aperture_ptr ap)
+{
+    sd.clear();
+
+    // Sun
+    auto sun = make_ray_source<Sun>();
+    sun->set_position(0, 0, 100);
+    sd.add_ray_source(sun);
+
+    // Make reflective flat el
+    element_ptr el = make_element<SingleElement>();
+    el->set_origin(0, 0, 50);
+    el->set_aim_vector(0, 0, 100); // Face up towards sun
+    el->set_surface(surf);
+    el->set_aperture(ap);
+
+    OpticalProperties el_optics;
+    el_optics.set_ideal_absorption();
+    el->set_front_optical_properties(el_optics);
+    el->set_back_optical_properties(el_optics);
+    el->set_name("el");
+
+    // Add element to stage
+    sd.add_element(el);
+
+    // Set parameters
+    SimulationParameters &params = sd.get_simulation_parameters();
+    params.number_of_rays = 10000;
+    params.max_number_of_rays = params.number_of_rays * 100;
+    params.include_optical_errors = false;
+    params.include_sun_shape_errors = false;
+    params.seed = 123;
+}
+
+TEST(OptixRunner, FlatRectangle)
+{
+    const double XL = 10.0;
+    const double YL = 5.0;
+    auto surf = make_surface<Flat>();
+    auto aper = make_aperture<Rectangle>(XL, YL);
+
+    SimulationData sd;
+    set_default_sd(sd, surf, aper);
+    SimulationResult result;
+
+    OptixRunner runner;
+    RunnerStatus sts = runner.initialize();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(sd);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.run_simulation();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.report_simulation(&result, 0);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Add some tests for the results here
+}
+
+TEST(OptixRunner, FlatEquilateralTriangle)
+{
+    const double d = 4.0;
+    auto surf = make_surface<Flat>();
+    auto aper = make_aperture<EqualateralTriangle>(d);
+
+    SimulationData sd;
+    set_default_sd(sd, surf, aper);
+    SimulationResult result;
+
+    OptixRunner runner;
+    RunnerStatus sts = runner.initialize();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(sd);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.run_simulation();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.report_simulation(&result, 0);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Add some tests for the results here
+}
+
+TEST(OptixRunner, FlatTriangle)
+{
+    const double x1 = 0.0, x2 = 1.0, x3 = 2.0 * x2;
+    const double y1 = 0.0, y2 = 2.0, y3 = y1;
+    auto surf = make_surface<Flat>();
+    auto aper = make_aperture<IrregularTriangle>(x1, y1, x2, y2, x3, y3);
+
+    SimulationData sd;
+    set_default_sd(sd, surf, aper);
+    SimulationResult result;
+
+    OptixRunner runner;
+    RunnerStatus sts = runner.initialize();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(sd);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.run_simulation();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.report_simulation(&result, 0);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Add some tests for the results here
+}
+
+TEST(OptixRunner, ParabolaRectangle)
+{
+    constexpr double CX = 0.5;
+    constexpr double CY = 1.0;
+    constexpr double FX = 0.5 / CX;
+    constexpr double FY = 0.5 / CY;
+    auto surf = make_surface<Parabola>(FX, FY);
+    auto aper = make_aperture<Rectangle>(XL, YL);
+
+    SimulationData sd;
+    set_default_sd(sd, surf, aper);
+    SimulationResult result;
+
+    OptixRunner runner;
+    RunnerStatus sts = runner.initialize();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(sd);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.run_simulation();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.report_simulation(&result, 0);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Add some tests for the results here
+}
+
+TEST(OptixRunner, Cylinder)
+{
+    const double R = 5.0;
+    const double YL = 3.0; // Total cylinder length
+    auto surf = make_surface<Cylinder>(R);
+    auto aper = make_aperture<Rectangle>(2*R, YL);
+
+    SimulationData sd;
+    set_default_sd(sd, surf, aper);
+    SimulationResult result;
+
+    OptixRunner runner;
+    RunnerStatus sts = runner.initialize();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.setup_simulation(sd);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.run_simulation();
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+    sts = runner.report_simulation(&result, 0);
+    ASSERT_EQ(sts, RunnerStatus::SUCCESS);
+
+    // TODO: Add some tests for the results here
+}

--- a/simdriver/CMakeLists.txt
+++ b/simdriver/CMakeLists.txt
@@ -1,0 +1,37 @@
+project(simdriver)
+
+cmake_minimum_required(VERSION 3.19)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+include_directories(
+    .
+    ../coretrace/simulation_data
+    ../coretrace/simulation_results
+    ../coretrace/simulation_runner/native_runner
+)
+
+add_executable(simdriver main.cpp)
+
+if(SOLTRACE_BUILD_EMBREE_SUPPORT)
+    target_include_directories(simdriver PRIVATE
+        ../coretrace/simulation_runner/embree_runner
+    )
+    target_compile_definitions(simdriver PRIVATE SOLTRACE_EMBREE_SUPPORT)
+    target_link_libraries(simdriver PRIVATE embree_runner)
+endif()
+
+target_link_libraries(simdriver PRIVATE
+    simdata
+    simresult
+    native_runner
+)
+
+if(UNIX)
+    target_link_libraries(simdriver PRIVATE pthread)
+endif()
+
+install(TARGETS simdriver
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)


### PR DESCRIPTION
Enable the following geometries within OptixRunner:

- [x] Flat (general) Triangle
- [ ] Flat Circle
- [ ] Flat Hexagon
- [ ] Flat Annulus
- [x] Flat Quadrilateral
- [ ] Parabola Circle
- [ ] Parabola Hexagon
- [ ] Parabola (general) Triangle
- [ ] Parabola Annulus
- [ ] Parabola Quadrilateral

If there is time, adding these would also be good

- [ ] Cone Circle
- [ ] Cone Hexagon
- [ ] Cone (general) Triangle
- [ ] Cone Rectangle
- [ ] Cone Annulus
- [ ] Cone Quadrilateral
- [ ] Sphere Circle
- [ ] Sphere Hexagon
- [ ] Sphere (general) Triangle
- [ ] Sphere Rectangle
- [ ] Sphere Annulus
- [ ] Sphere Quadrilateral

The following checklist for adding Surface/Aperture combination to the OptixRunner may be of use in the future (while it is numbered, the order is not important):

1. Add needed OptixCSP Aperture and Surface types
2. Add needed conversion code in `OptixRunner::setup_elements`
3. Add needed types to GeometryDataST
4. Add needed conversion code in `CspElement::toDeviceGeometryData`
5. Add needed OpticalEntityType (in OptixCSP/src/core/Soltrace.h)
6. Add needed mapping to OpticalEntityType in `GeometryManager::collect_geometry_info`
7. Add needed mapping to program group in `SolTraceSystem::create_shader_binding_table`
8. Write intersection program (kernel) in `intersection.cu`. Function name must start with `__intersection__` (note double underscores on both sides!!!)
9. Add intersection function to `IntersectionKernelMap` in `pipeline_manager.cpp`