### PR TITLE
Change cmake pathing to use CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/google-tests/CMakeLists.txt
+++ b/google-tests/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_Declare(
 add_definitions(-DPROJECT_DIR="${CMAKE_CURRENT_BINARY_DIR}")
 # file(GLOB CSV_TOOL test_tools/*.cpp test_tools/*.h)
 
-set(SAMPLE_DIR "${CMAKE_SOURCE_DIR}/gui/assets/examples")
+set(SAMPLE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../gui/assets/examples")
 set(TEST_INPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/input-files")
 
 add_subdirectory(test_tools)

--- a/google-tests/unit-tests/gui/CMakeLists.txt
+++ b/google-tests/unit-tests/gui/CMakeLists.txt
@@ -42,7 +42,7 @@ target_link_libraries(GUIUnitTests
 
 target_compile_definitions(GUIUnitTests
     PRIVATE
-        SOLTRACE_REPO_ROOT="${CMAKE_SOURCE_DIR}"
+        SOLTRACE_REPO_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/../../.."
 )
 
 set_target_properties(GUIUnitTests PROPERTIES


### PR DESCRIPTION
This pull request modifies the google-tests cmakelists to use the CMAKE_CURRENT_SOURCE_DIR keyword for pathing rather than CMAKE_SOURCE_DIR. 

CMAKE_SOURCE_DIR is the location of the top-level cmakelists, which can be an issue if your repo is structured around the legacy SolTrace code, which had one higher Cmakelist that built LK and Wex along with SolTrace. 

This is a niche issue that only affects repos with an extra level of cmakelists, and does not affect CI testing. 